### PR TITLE
Add SQL stored procedure stub for RUN_DQ_CONFIG

### DIFF
--- a/sql/run_dq_config.sql
+++ b/sql/run_dq_config.sql
@@ -1,0 +1,12 @@
+-- RUN_DQ_CONFIG Stored Procedure
+-- To execute in Snowsight: open a worksheet, set your context, and run:
+--   CALL RUN_DQ_CONFIG('<CONFIG_ID>');
+create or replace procedure RUN_DQ_CONFIG(CONFIG_ID STRING)
+returns STRING
+language SQL
+as
+$$
+begin
+  return 'OK: ' || :CONFIG_ID;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add a minimal RUN_DQ_CONFIG stored procedure stub that returns the input configuration ID
- document how to execute the stored procedure from Snowsight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e388b17dec83249fdd9dfb6a9020f7