### PR TITLE
Add configurable scheduling support for data quality configs

### DIFF
--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -37,7 +37,11 @@ def build_rule_for_column_check(fqn: str, col: str, ctype: str, params: dict):
         allowed_csv = params.get("allowed_values_csv", "")
         values = [v.strip() for v in allowed_csv.split(",") if v.strip() != ""]
         if not values: return "(TRUE)", False
-        quoted = ", ".join([f"'{v.replace(\"'\",\"''\")}'" for v in values])
+        quoted_values = []
+        for raw in values:
+            sanitized = raw.replace("'", "''")
+            quoted_values.append("'" + sanitized + "'")
+        quoted = ", ".join(quoted_values)
         return f"({colq} IN ({quoted}))", False
     return "(TRUE)", False
 


### PR DESCRIPTION
## Summary
- add schedule controls to the Streamlit configuration editor and persist the values on save
- extend the metadata layer with schedule fields and use them when creating Snowflake tasks
- validate schedule strings before task creation and allow disabling automatic task setup

## Testing
- python -m compileall streamlit_app.py utils services

------
https://chatgpt.com/codex/tasks/task_e_68e4ba0a51448324b1acda7ec4da12a4