### PR TITLE
Add docstrings to DQ metadata utilities

### DIFF
--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -1,5 +1,7 @@
+"""Convenience helpers for attaching and detaching Data Monitoring Framework views."""
+
 import re
-from typing import List, Optional, Set, Tuple
+from typing import List, Set, Tuple
 from utils.meta import DQConfig, DQCheck, _q, DQ_CONFIG_TBL, DQ_CHECK_TBL, metadata_db_schema
 
 AGG_PREFIX = "AGG:"

--- a/utils/meta.py
+++ b/utils/meta.py
@@ -1,3 +1,10 @@
+"""Utility helpers and data models for interacting with DQ metadata tables.
+
+The functions in this module intentionally avoid depending on Snowpark at
+import time so they can be reused in environments where the Snowpark Python
+client is not installed.  Snowflake objects are loaded lazily via duck typing.
+"""
+
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple


### PR DESCRIPTION
## Summary
- add a module-level docstring to `utils/meta.py` clarifying that helpers avoid a hard dependency on Snowpark at import time
- add a module-level docstring to `utils/dmfs.py` documenting the helper module's purpose

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c247a9588324bef8cebea6c451b2