### PR TITLE
Fix UNIQUE severity selection in Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -257,8 +257,24 @@ def render_config_editor():
                 checked = ("UNIQUE" in [(ec.check_type or "").upper() for ec in existing_checks if ec.column_name == col])
                 c_unique = st.checkbox("UNIQUE", value=checked, key=f"{sk}_chk_unique")
                 if c_unique and target_table:
-                    p_ignore_nulls = st.checkbox("Ignore NULLs", value=ex.get("params", {}).get("ignore_nulls", True), key=f"{sk}_p_un_ignore")
-                    sev = st.selectbox("Severity (UNIQUE)", ["ERROR", "WARN"], index=(0 if ex.get("severity","ERROR")=="ERROR" else 1), key=f"{sk}_sev_unique")
+                    p_ignore_nulls = st.checkbox(
+                        "Ignore NULLs",
+                        value=ex.get("params", {}).get("ignore_nulls", True),
+                        key=f"{sk}_p_un_ignore"
+                    )
+                    severity_options = ["ERROR", "WARN"]
+                    existing_severity = ex.get("severity", "ERROR")
+                    severity_index = (
+                        severity_options.index(existing_severity)
+                        if existing_severity in severity_options
+                        else 0
+                    )
+                    sev = st.selectbox(
+                        "Severity (UNIQUE)",
+                        severity_options,
+                        index=severity_index,
+                        key=f"{sk}_sev_unique"
+                    )
                     params = {"ignore_nulls": p_ignore_nulls}
                     rule, is_agg = build_rule_for_column_check(target_table, col, "UNIQUE", params)
                     check_rows.append(DQCheck(


### PR DESCRIPTION
## Summary
- break out the UNIQUE check severity selection logic for readability and to avoid syntax issues
- compute the severity dropdown index more defensively when restoring existing configuration values

## Testing
- python -m py_compile streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e504065a588324920c72d0d0ca9fb6