### PR TITLE
Update default freshness max age to 720 minutes

### DIFF
--- a/docs/streamlit_app_full.md
+++ b/docs/streamlit_app_full.md
@@ -324,7 +324,7 @@ def render_config_editor():
         # Table-level (always)
         st.markdown("### Table-level checks (always included)")
         ts_col = st.text_input("Freshness timestamp column", value="LOAD_TIMESTAMP")
-        max_age = st.number_input("Freshness max age (minutes)", min_value=1, value=1440)
+        max_age = st.number_input("Freshness max age (minutes)", min_value=1, value=720)
         min_rows = st.number_input("Minimum row count", min_value=0, value=1)
 
         if target_table:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -411,7 +411,7 @@ def render_config_editor():
         # Table-level (always)
         st.markdown("### Table-level checks (always included)")
         ts_col = st.text_input("Freshness timestamp column", value="LOAD_TIMESTAMP")
-        max_age = st.number_input("Freshness max age (minutes)", min_value=1, value=1440)
+        max_age = st.number_input("Freshness max age (minutes)", min_value=1, value=720)
         min_rows = st.number_input("Minimum row count", min_value=0, value=1)
 
         if target_table:

--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -49,7 +49,7 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict) -> str:
     ttype = (ttype or "").upper()
     if ttype == "FRESHNESS":
         ts_col = params.get("timestamp_column", "LOAD_TIMESTAMP")
-        max_age = int(params.get("max_age_minutes", 1440))
+        max_age = int(params.get("max_age_minutes", 720))
         return f"SELECT TIMESTAMPDIFF('minute', MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age} AS OK FROM {_q(fqn)}"
     if ttype == "ROW_COUNT":
         min_rows = int(params.get("min_rows", 1))


### PR DESCRIPTION
## Summary
- update the default freshness max age to 720 minutes in the Streamlit UI and backend rule builder
- align documentation with the new default value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50ff615c08324a4de06e24af38d86