### PR TITLE
Ensure Run Now only executes on explicit request

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -616,7 +616,7 @@ def render_config_editor():
                 st.info(info_msg)
                 remember("info", info_msg)
 
-        if run_now_btn or apply_now:
+        if run_now_btn:
             results = run_now(session, dq_cfg, checks_rebound)
             st.info("Run Now results:")
             summary_lines: List[str] = []


### PR DESCRIPTION
## Summary
- call the Run Now routine only when the Run Now button is submitted so Save & Apply no longer executes it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7a888b8988324863814c342ee4ed8