### PR TITLE
Fix preview count button initialization

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -266,6 +266,8 @@ def render_config_editor():
     if "_dq_table_ts_col" not in st.session_state:
         st.session_state["_dq_table_ts_col"] = ts_default
 
+    preview_counts = False
+
     with st.form("cfg_form", clear_on_submit=False):
         st.subheader("Configuration")
         name = st.text_input("Name", value=(cfg.name if cfg else ""))


### PR DESCRIPTION
## Summary
- initialize `preview_counts` before rendering the configuration form to avoid NameError when not defined

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7ae32c7a4832480ebeaf24a0c2c9c