### PR TITLE
Support start/end date aliases when fetching run results

### DIFF
--- a/utils/meta.py
+++ b/utils/meta.py
@@ -315,9 +315,21 @@ def fetch_run_results(
     check_types: Optional[List[str]] = None,
     ok: Optional[bool] = None,
     limit: int = 500,
+    *,
+    start_date: Optional[Any] = None,
+    end_date: Optional[Any] = None,
 ) -> List[Dict[str, Any]]:
     if not session:
         return []
+
+    # ``start_date`` and ``end_date`` were the original parameter names used by
+    # the Streamlit UI.  ``time_from``/``time_to`` were introduced later for
+    # clarity, so here we support both to remain backwards compatible with the
+    # existing calls from the app.
+    if start_date is not None and time_from is None:
+        time_from = start_date
+    if end_date is not None and time_to is None:
+        time_to = end_date
 
     sql = f"""
         SELECT RUN_ID, CONFIG_ID, CHECK_ID, CHECK_TYPE, RUN_TS, FAILURES, OK, ERROR_MSG


### PR DESCRIPTION
## Summary
- allow `fetch_run_results` to accept the original `start_date` and `end_date` keyword arguments used by the Streamlit UI
- translate the legacy keywords to the newer `time_from`/`time_to` parameters to preserve backwards compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9106146188324a3b94d58e42ceff9