### PR TITLE
feat: add shared Streamlit UI helpers

### DIFF
--- a/pages/configs.py
+++ b/pages/configs.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import streamlit as st
 
+from pages import ui_shared
 from utils import checkdefs, dmfs, meta, schedules
 from services import configs as configs_service
 
@@ -205,7 +206,8 @@ def _render_config_card(session, cfg: meta.DQConfig) -> None:
         )
         meta_row = []
         if cfg.status:
-            meta_row.append(f"<span class='badge{' badge-green' if (cfg.status or '').upper() == 'ACTIVE' else ''}'>{cfg.status}</span>")
+            tone = "success" if (cfg.status or "").upper() == "ACTIVE" else "info"
+            meta_row.append(ui_shared.pill(cfg.status, tone=tone))
         if cfg.owner:
             meta_row.append(f"<span class='small'>Owner: {cfg.owner}</span>")
         if cfg.run_as_role:
@@ -254,7 +256,7 @@ def _render_list_panel(session) -> None:
         st.caption("No configurations found with the current filters.")
     for cfg in filtered:
         _render_config_card(session, cfg)
-        st.markdown("<hr class='sf-hr' />", unsafe_allow_html=True)
+        ui_shared.divider()
 
 
 def _ensure_table_picker_defaults() -> None:
@@ -815,8 +817,12 @@ def _render_feedback() -> None:
 
 def render_configs(session) -> None:
     _ensure_base_state()
-    st.title("Data Quality Configurations")
-    st.caption("Manage data quality rules, schedules, and monitoring targets.")
+    ui_shared.page_header(
+        "Data Quality Configurations",
+        "Manage data quality rules, schedules, and monitoring targets.",
+        session=session,
+        show_version=True,
+    )
 
     list_col, editor_col = st.columns([1.2, 2.0])
     with list_col:
@@ -830,7 +836,7 @@ def render_configs(session) -> None:
             is_new = st.session_state.get("editor_is_new", False)
             _render_feedback()
             _render_general_details(is_new)
-            st.markdown("---")
+            ui_shared.divider()
             _render_target_picker(session)
             _render_column_selector(session)
             target_fqn = st.session_state.get("editor_target_fqn") or st.session_state.get("editor_target_fqn_display")
@@ -838,8 +844,8 @@ def render_configs(session) -> None:
                 _render_column_checks_section()
                 _render_table_checks_section()
             else:
-                st.warning("Select a target table to configure checks.")
-            st.markdown("---")
+                ui_shared.danger_note("Select a target table to configure checks.")
+            ui_shared.divider()
             _render_schedule_section()
             st.checkbox("Attach DMF views after saving", key="cfg_apply_dmfs", help="Applies check views immediately when saving.")
             _render_run_now(session)

--- a/pages/docs.py
+++ b/pages/docs.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Tuple
 
 import streamlit as st
 
+from pages import ui_shared
 from utils.checkdefs import SUPPORTED_COLUMN_CHECKS, SUPPORTED_TABLE_CHECKS
 from utils.meta import (
     DQ_CHECK_TBL,
@@ -236,7 +237,7 @@ def _build_markdown(
 def render_docs(session) -> None:
     """Render the documentation page."""
 
-    st.title("Documentation")
+    ui_shared.page_header("Documentation", session=session, show_version=True)
     db, schema, fqns = _resolve_metadata_fqns(session)
     counts = _fetch_table_counts(session, [(label, data[1]) for label, data in fqns.items()])
     verification_sql = _build_verification_sql(fqns)

--- a/pages/home.py
+++ b/pages/home.py
@@ -1,55 +1,20 @@
 """Streamlit Overview page for Zeus Data Quality."""
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Optional
-
 import streamlit as st
 
-try:
-    from utils.meta import metadata_db_schema
-except Exception:  # pragma: no cover - optional metadata helper
-    metadata_db_schema = None  # type: ignore
-
-
-def _build_caption(session) -> str:
-    """Return a descriptive caption with build metadata and session context."""
-    secrets = getattr(st, "secrets", {})
-
-    build_version = secrets.get("build_version") or secrets.get("version") or secrets.get("release")
-    build_timestamp = secrets.get("build_timestamp") or secrets.get("build_time")
-
-    parts = []
-    if build_version:
-        parts.append(f"Build {build_version}")
-    else:
-        parts.append("Local development build")
-
-    formatted_ts: Optional[str] = None
-    if isinstance(build_timestamp, (int, float)):
-        formatted_ts = datetime.fromtimestamp(build_timestamp).strftime("%Y-%m-%d %H:%M %Z")
-    elif isinstance(build_timestamp, str) and build_timestamp.strip():
-        formatted_ts = build_timestamp.strip()
-
-    if formatted_ts:
-        parts.append(f"generated {formatted_ts}")
-
-    if session and metadata_db_schema:
-        try:
-            db, schema = metadata_db_schema(session)
-            parts.append(f"metadata: {db}.{schema}")
-        except Exception:
-            parts.append("metadata: unknown")
-    elif session:
-        parts.append("connected to Snowflake session")
-
-    return " · ".join(parts)
+from pages import ui_shared
 
 
 def render_home(session) -> None:
     """Render the Zeus Data Quality overview page."""
-    st.title("Zeus Data Quality Overview")
-    st.caption(_build_caption(session))
+
+    ui_shared.page_header(
+        "Zeus Data Quality Overview",
+        session=session,
+        show_version=True,
+        include_metadata=True,
+    )
 
     st.markdown(
         """

--- a/pages/monitor.py
+++ b/pages/monitor.py
@@ -8,6 +8,7 @@ import altair as alt
 import pandas as pd
 import streamlit as st
 
+from pages import ui_shared
 from utils import checkdefs
 from utils.meta import fetch_config_map, fetch_run_results, fetch_timeseries_daily
 
@@ -267,8 +268,12 @@ def _render_results_table(results_df: pd.DataFrame, config_map: Dict[str, Dict[s
 def render_monitor(session) -> None:
     """Render the monitoring experience with filters, KPIs, charts, and run results."""
 
-    st.title("Monitor data quality runs")
-    st.caption("Row checks have views; aggregates don’t.")
+    ui_shared.page_header(
+        "Monitor data quality runs",
+        "Row checks have views; aggregates don’t.",
+        session=session,
+        show_version=True,
+    )
 
     _init_state()
     filters = dict(st.session_state.get("monitor_filters", {}))

--- a/pages/ui_shared.py
+++ b/pages/ui_shared.py
@@ -1,0 +1,118 @@
+"""Shared Streamlit UI helpers for Zeus Data Quality pages."""
+from __future__ import annotations
+
+import html
+from datetime import datetime
+from typing import Optional
+
+import streamlit as st
+
+try:  # pragma: no cover - optional metadata helper
+    from utils.meta import metadata_db_schema
+except Exception:  # pragma: no cover - optional metadata helper
+    metadata_db_schema = None  # type: ignore
+
+
+def build_caption(session=None, *, include_metadata: bool = True) -> str:
+    """Return a build/version caption with optional metadata context."""
+    secrets = getattr(st, "secrets", {})
+
+    build_version = (
+        secrets.get("build_version")
+        or secrets.get("version")
+        or secrets.get("release")
+    )
+    build_timestamp = secrets.get("build_timestamp") or secrets.get("build_time")
+
+    parts: list[str] = []
+    if build_version:
+        parts.append(f"Build {build_version}")
+    else:
+        parts.append("Local development build")
+
+    formatted_ts: Optional[str] = None
+    if isinstance(build_timestamp, (int, float)):
+        formatted_ts = datetime.fromtimestamp(build_timestamp).strftime(
+            "%Y-%m-%d %H:%M %Z"
+        )
+    elif isinstance(build_timestamp, str) and build_timestamp.strip():
+        formatted_ts = build_timestamp.strip()
+
+    if formatted_ts:
+        parts.append(f"generated {formatted_ts}")
+
+    if session:
+        if include_metadata and metadata_db_schema:
+            try:
+                db, schema = metadata_db_schema(session)
+                parts.append(f"metadata: {db}.{schema}")
+            except Exception:  # pragma: no cover - depends on session
+                parts.append("metadata: unknown")
+        else:
+            parts.append("connected to Snowflake session")
+
+    return " · ".join(parts)
+
+
+def page_header(
+    title: str,
+    subtitle: str | None = None,
+    *,
+    session=None,
+    show_version: bool = False,
+    include_metadata: bool = True,
+) -> None:
+    """Render a consistent page header with optional subtitle and version."""
+
+    st.title(title)
+    if subtitle:
+        st.caption(subtitle)
+    if show_version:
+        st.caption(build_caption(session, include_metadata=include_metadata))
+
+
+def divider(label: str | None = None) -> None:
+    """Insert a subtle horizontal divider with optional caption."""
+
+    st.markdown("<hr class='sf-hr' />", unsafe_allow_html=True)
+    if label:
+        st.caption(label)
+
+
+_PILL_STYLES = {
+    "info": ("#e5f6fd", "#cbeefb", "#055e86"),
+    "success": ("#eafaf0", "#d4f2df", "#0a5c2b"),
+    "warning": ("#fef3c7", "#fde68a", "#92400e"),
+    "danger": ("#fee2e2", "#fecaca", "#b91c1c"),
+}
+
+
+def pill(text: str, *, tone: str = "info") -> str:
+    """Return HTML for a rounded pill badge."""
+
+    bg, border, color = _PILL_STYLES.get(tone, _PILL_STYLES["info"])
+    safe_text = html.escape(text)
+    return (
+        "<span style=\""
+        "display:inline-block;padding:.15rem .55rem;border-radius:999px;"
+        "font-size:.75rem;font-weight:600;"
+        f"background:{bg};border:1px solid {border};color:{color};"
+        f"\">{safe_text}</span>"
+    )
+
+
+def danger_note(message: str, *, icon: str = "⚠️") -> None:
+    """Render a prominent warning note with a red accent."""
+
+    safe_message = html.escape(message)
+    note_html = (
+        "<div style=\""
+        "border-radius:10px;border:1px solid #fecaca;background:#fef2f2;"
+        "padding:.75rem 1rem;color:#991b1b;font-weight:500;"
+        "display:flex;gap:.5rem;align-items:flex-start;"
+        "\">"
+        f"<span>{icon}</span>"
+        f"<span>{safe_message}</span>"
+        "</div>"
+    )
+    st.markdown(note_html, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- add a shared `ui_shared` module that centralises page header, pill badge, divider, and danger note helpers for Streamlit pages
- refactor the home, configurations, monitor, and documentation pages to use the shared helpers and provide consistent build/version captions

## Testing
- python -m compileall pages

------
https://chatgpt.com/codex/tasks/task_e_68e93542d87083249c6c7a2dde16b708