### PR TITLE
Add DQRun dataclass to metadata helpers

### DIFF
--- a/utils/meta.py
+++ b/utils/meta.py
@@ -26,6 +26,7 @@ __all__ = [
     "DQ_RUN_RESULTS_TBL",
     "DQConfig",
     "DQCheck",
+    "DQRun",
     "_q",
     "fq_table",
     "metadata_db_schema",
@@ -71,6 +72,17 @@ class DQCheck:
     sample_rows: int = 0
     check_type: Optional[str] = None
     params_json: Optional[str] = None
+
+@dataclass
+class DQRun:
+    run_id: Optional[str]
+    config_id: Optional[str]
+    check_id: Optional[str]
+    check_type: Optional[str]
+    run_ts: Optional[datetime]
+    failures: Optional[int]
+    ok: Optional[bool]
+    error_msg: Optional[str] = None
 
 # ---------- Helpers ----------
 def _q(ident: str) -> str:


### PR DESCRIPTION
## Summary
- define a DQRun dataclass within utils.meta and export it via __all__
- ensure the metadata helpers expose the run model expected by the monitoring page

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e94b163c4c8324ae07d17746f5af39