### PR TITLE
Fix Streamlit page imports

### DIFF
--- a/pages/configs.py
+++ b/pages/configs.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import streamlit as st
 
-from .ui_shared import danger_note, divider, page_header, pill
+from pages.ui_shared import danger_note, divider, page_header, pill
 from services.configs import delete_config_full, save_config_and_checks
 from utils import dmfs
 from utils.checkdefs import (

--- a/pages/docs.py
+++ b/pages/docs.py
@@ -6,7 +6,7 @@ from typing import Dict, Iterable, List, Tuple
 
 import streamlit as st
 
-from .ui_shared import page_header
+from pages.ui_shared import page_header
 from utils.checkdefs import SUPPORTED_COLUMN_CHECKS, SUPPORTED_TABLE_CHECKS
 from utils.meta import (
     DQ_CHECK_TBL,

--- a/pages/home.py
+++ b/pages/home.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import streamlit as st
 
-from .ui_shared import page_header
+from pages.ui_shared import page_header
 
 
 def render_home(session, app_version: str | None = None) -> None:

--- a/pages/monitor.py
+++ b/pages/monitor.py
@@ -8,7 +8,7 @@ import altair as alt
 import pandas as pd
 import streamlit as st
 
-from .ui_shared import page_header
+from pages.ui_shared import page_header
 from utils.checkdefs import SUPPORTED_COLUMN_CHECKS, SUPPORTED_TABLE_CHECKS
 from utils.meta import fetch_config_map, fetch_run_results, fetch_timeseries_daily
 


### PR DESCRIPTION
## Summary
- switch Streamlit page modules to use absolute imports for shared UI helpers
- ensure config, docs, home, and monitor pages can be executed without package context issues

## Testing
- python -m compileall pages

------
https://chatgpt.com/codex/tasks/task_e_68e95bee3c988324ad01ad594df295e2