### PR TITLE
Add Streamlit fallback stub for UI helpers

### DIFF
--- a/pages/ui_shared.py
+++ b/pages/ui_shared.py
@@ -5,7 +5,25 @@ import html
 from datetime import datetime
 from typing import Optional
 
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError:  # pragma: no cover - fallback for doc builds/tests
+    class _StreamlitStub:
+        """Minimal stub so helpers can be imported without Streamlit."""
+
+        secrets: dict[str, str] = {}
+        session_state: dict[str, object] = {}
+
+        def __getattr__(self, name):  # pragma: no cover - defensive guard
+            def _missing(*_args, **_kwargs):
+                raise RuntimeError(
+                    "Streamlit is required for UI rendering; install streamlit to use "
+                    f"`st.{name}()`"
+                )
+
+            return _missing
+
+    st = _StreamlitStub()
 
 try:  # pragma: no cover - optional metadata helper
     from utils.meta import metadata_db_schema


### PR DESCRIPTION
## Summary
- wrap the Streamlit import in a try/except within `pages/ui_shared.py`
- provide a lightweight stub so modules can import UI helpers even when Streamlit is not installed

## Testing
- python -m compileall pages/ui_shared.py

------
https://chatgpt.com/codex/tasks/task_e_68e960859e1c83249d7fd356b0f0d33d