### PR TITLE
Handle missing Streamlit secrets gracefully

### DIFF
--- a/pages/ui_shared.py
+++ b/pages/ui_shared.py
@@ -43,7 +43,10 @@ def build_caption(session=None, *, include_metadata: bool = True) -> str:
         empty configuration instead of surfacing an exception to the user.
         """
 
-        if not secrets:
+        if secrets is None:
+            return None
+
+        if isinstance(secrets, dict) and not secrets:
             return None
 
         getter = getattr(secrets, "get", None)


### PR DESCRIPTION
## Summary
- avoid calling truthiness checks on Streamlit secrets when the secrets file is missing
- safely guard lookups so local development without secrets.toml no longer raises

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec8c9d12bc8324b9fe0d7168033300