### PR TITLE
Fix monitoring docs verification query

### DIFF
--- a/pages/docs.py
+++ b/pages/docs.py
@@ -113,7 +113,10 @@ def _build_verification_sql(fqns: Dict[str, Tuple[str, str, str]]) -> str:
         [
             f"SELECT COUNT(*) AS config_rows FROM {config_fqn};",
             f"SELECT config_id, COUNT(*) AS checks_per_config FROM {check_fqn} GROUP BY 1 ORDER BY 2 DESC;",
-            f"SELECT status, COUNT(*) AS runs FROM {results_fqn} GROUP BY 1 ORDER BY 2 DESC;",
+            (
+                "SELECT IFF(COALESCE(ok, FALSE), 'PASSED', 'FAILED') AS status, COUNT(*) AS runs "
+                f"FROM {results_fqn} GROUP BY 1 ORDER BY 2 DESC;"
+            ),
         ]
     )
 


### PR DESCRIPTION
## Summary
- fix the documentation verification SQL to derive run status from the OK flag instead of a non-existent column

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec9c25f4508324adb50775e4cbdf76