### PR TITLE
Quote task FQN when executing Run Now

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -89,8 +89,13 @@ def build_task_fqn(target_table_fqn: Optional[str], config_id: Optional[str]) ->
     if len(parts) != 3:
         return None
     db, schema, _ = parts
+
+    def quote_ident(identifier: str) -> str:
+        identifier = identifier.strip('"')
+        return f'"{identifier}"'
+
     task_name = f'"DQ_TASK_{config_id.upper()}"'
-    return f"{db}.{schema}.{task_name}"
+    return f"{quote_ident(db)}.{quote_ident(schema)}.{task_name}"
 
 def render_home():
     st.title("Zeus Data Quality")


### PR DESCRIPTION
## Summary
- ensure the Run Now handler builds a fully quoted task name from the target table and configuration id
- execute the Snowflake task directly and surface a submission confirmation message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eccade0dbc83248694692e608fd963