### PR TITLE
Document snapshot mirroring workflow

### DIFF
--- a/.github/workflows/mirror-snapshots.yml
+++ b/.github/workflows/mirror-snapshots.yml
@@ -1,3 +1,4 @@
+# Mirror workflow keeps /snapshots in sync with Python sources.
 name: Mirror .py to /snapshots as .p
 
 on:

--- a/snapshots/tools/mirror_snapshots.p
+++ b/snapshots/tools/mirror_snapshots.p
@@ -1,4 +1,5 @@
 # tools/mirror_snapshots.py
+# Mirror Python source files into /snapshots with a .p extension.
 import shutil, pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]

--- a/tools/mirror_snapshots.py
+++ b/tools/mirror_snapshots.py
@@ -1,4 +1,5 @@
 # tools/mirror_snapshots.py
+# Mirror Python source files into /snapshots with a .p extension.
 import shutil, pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- document the local mirror script that copies Python sources into /snapshots as .p files
- annotate the GitHub Actions workflow that keeps the snapshot mirror in sync on dev_bs pushes
- regenerate the mirror snapshot of the mirror script to capture the new documentation comment

## Testing
- python tools/mirror_snapshots.py

------
https://chatgpt.com/codex/tasks/task_e_68ece13e194083249d4baae567c00f58