### PR TITLE
Remove duplicate top navigation buttons

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -995,35 +995,8 @@ with st.sidebar:
     dmf_role = st.text_input("DMF_ROLE", value=state.get("dmf_role") or "")
     set_state(run_as_role or None, dmf_role or None)
 
-nav_cols = st.columns(3)
-with nav_cols[0]:
-    st.button(
-        "🏠 Overview",
-        use_container_width=True,
-        type="primary" if current_page == "home" else "secondary",
-        key="top_nav_home",
-        on_click=navigate_to,
-        args=("home",),
-    )
-with nav_cols[1]:
-    st.button(
-        "⚙️ Configurations",
-        use_container_width=True,
-        type="primary" if current_page == "cfg" else "secondary",
-        key="top_nav_cfg",
-        on_click=navigate_to,
-        args=("cfg",),
-    )
-with nav_cols[2]:
-    st.button(
-        "📊 Monitor",
-        use_container_width=True,
-        type="primary" if current_page == "monitor" else "secondary",
-        key="top_nav_monitor",
-        on_click=navigate_to,
-        args=("monitor",),
-    )
-
+# Maintain a subtle separation between the sidebar navigation
+# and the main content area.
 st.markdown("<div class='sf-hr'></div>", unsafe_allow_html=True)
 
 page = st.session_state.get("page", "home")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -995,35 +995,8 @@ with st.sidebar:
     dmf_role = st.text_input("DMF_ROLE", value=state.get("dmf_role") or "")
     set_state(run_as_role or None, dmf_role or None)
 
-nav_cols = st.columns(3)
-with nav_cols[0]:
-    st.button(
-        "🏠 Overview",
-        use_container_width=True,
-        type="primary" if current_page == "home" else "secondary",
-        key="top_nav_home",
-        on_click=navigate_to,
-        args=("home",),
-    )
-with nav_cols[1]:
-    st.button(
-        "⚙️ Configurations",
-        use_container_width=True,
-        type="primary" if current_page == "cfg" else "secondary",
-        key="top_nav_cfg",
-        on_click=navigate_to,
-        args=("cfg",),
-    )
-with nav_cols[2]:
-    st.button(
-        "📊 Monitor",
-        use_container_width=True,
-        type="primary" if current_page == "monitor" else "secondary",
-        key="top_nav_monitor",
-        on_click=navigate_to,
-        args=("monitor",),
-    )
-
+# Maintain a subtle separation between the sidebar navigation
+# and the main content area.
 st.markdown("<div class='sf-hr'></div>", unsafe_allow_html=True)
 
 page = st.session_state.get("page", "home")


### PR DESCRIPTION
## Summary
- remove the redundant top navigation buttons so navigation only lives in the sidebar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecf09720b88324b03146e199a8e995