### PR TITLE
Fix DQ task creation schema

### DIFF
--- a/snapshots/utils/schedules.p
+++ b/snapshots/utils/schedules.p
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.dmfs import create_or_update_task, task_name_for_config
-from utils.meta import _parse_relation_name
+from utils.meta import _parse_relation_name, metadata_db_schema
 
 
 def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
@@ -42,10 +42,19 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
     schedule_tz = (getattr(cfg, "schedule_timezone", None) or "Europe/Berlin").strip() or "Europe/Berlin"
 
     try:
+        meta_db, meta_schema = metadata_db_schema(session)
+    except Exception as exc:
+        return {
+            "status": "FALLBACK",
+            "reason": f"Unable to determine metadata schema: {exc}",
+            "task": base_task_name,
+        }
+
+    try:
         create_or_update_task(
             session,
-            db,
-            schema,
+            meta_db,
+            meta_schema,
             warehouse,
             cfg.config_id,
             schedule_cron=schedule_cron,
@@ -55,10 +64,10 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
         return {
             "status": "FALLBACK",
             "reason": str(exc),
-            "task": f"{db}.{schema}.{base_task_name}",
+            "task": f"{meta_db}.{meta_schema}.{base_task_name}",
         }
 
     return {
         "status": "TASK_CREATED",
-        "task": f"{db}.{schema}.{base_task_name}",
+        "task": f"{meta_db}.{meta_schema}.{base_task_name}",
     }

--- a/utils/schedules.py
+++ b/utils/schedules.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.dmfs import create_or_update_task, task_name_for_config
-from utils.meta import _parse_relation_name
+from utils.meta import _parse_relation_name, metadata_db_schema
 
 
 def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
@@ -42,10 +42,19 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
     schedule_tz = (getattr(cfg, "schedule_timezone", None) or "Europe/Berlin").strip() or "Europe/Berlin"
 
     try:
+        meta_db, meta_schema = metadata_db_schema(session)
+    except Exception as exc:
+        return {
+            "status": "FALLBACK",
+            "reason": f"Unable to determine metadata schema: {exc}",
+            "task": base_task_name,
+        }
+
+    try:
         create_or_update_task(
             session,
-            db,
-            schema,
+            meta_db,
+            meta_schema,
             warehouse,
             cfg.config_id,
             schedule_cron=schedule_cron,
@@ -55,10 +64,10 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
         return {
             "status": "FALLBACK",
             "reason": str(exc),
-            "task": f"{db}.{schema}.{base_task_name}",
+            "task": f"{meta_db}.{meta_schema}.{base_task_name}",
         }
 
     return {
         "status": "TASK_CREATED",
-        "task": f"{db}.{schema}.{base_task_name}",
+        "task": f"{meta_db}.{meta_schema}.{base_task_name}",
     }


### PR DESCRIPTION
## Summary
- ensure DQ tasks are created in the metadata schema where the DQ tables live instead of the target table schema
- add a defensive fallback when the metadata schema cannot be determined

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecf64f54f08324b79934b8b0938569