### PR TITLE
Handle missing pandas dependency for Streamlit app

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -2,13 +2,20 @@ import json
 from typing import Dict, List, Optional
 from uuid import uuid4
 
+import streamlit as st
+
 try:
     import altair as alt
 except ModuleNotFoundError:
     alt = None  # type: ignore
 
-import pandas as pd
-import streamlit as st
+try:
+    import pandas as pd
+except ModuleNotFoundError as exc:  # pragma: no cover - env-specific guard
+    st.set_page_config(page_title="Zeus Data Quality", layout="wide")
+    st.error("Pandas is required to run this app. Please install the `pandas` package and restart.")
+    st.exception(exc)
+    st.stop()
 
 # --- Snowpark session (works in Snowsight; safe locally) ---
 try:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,13 +2,20 @@ import json
 from typing import Dict, List, Optional
 from uuid import uuid4
 
+import streamlit as st
+
 try:
     import altair as alt
 except ModuleNotFoundError:
     alt = None  # type: ignore
 
-import pandas as pd
-import streamlit as st
+try:
+    import pandas as pd
+except ModuleNotFoundError as exc:  # pragma: no cover - env-specific guard
+    st.set_page_config(page_title="Zeus Data Quality", layout="wide")
+    st.error("Pandas is required to run this app. Please install the `pandas` package and restart.")
+    st.exception(exc)
+    st.stop()
 
 # --- Snowpark session (works in Snowsight; safe locally) ---
 try:


### PR DESCRIPTION
Handle missing pandas dependency for Streamlit app
- guard the Streamlit app startup so missing pandas surfaces a helpful message instead of a blank page
- refresh the mirrored snapshot to reflect the updated import guard

------
https://chatgpt.com/codex/tasks/task_e_68ecfba0ef708324b7440614d93fd70e