### PR TITLE
Fix syntax error when enabling DQ tasks

### DIFF
--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -150,6 +150,8 @@ def create_or_update_task(
     schedule_expr = f"USING CRON {schedule_cron} {tz}"
     comment = f"Auto task for DQ config {config_id}"
 
+    procedure_fqn = _q(database, schema, "SP_RUN_DQ_CONFIG")
+
     session.sql(
         f"""
          CREATE TASK IF NOT EXISTS {fqn}
@@ -157,7 +159,7 @@ def create_or_update_task(
            SCHEDULE = ?
            COMMENT = ?
          AS
-           CALL "{database}"."{schema}".SP_RUN_DQ_CONFIG(?);
+           CALL {procedure_fqn}(?);
         """,
         params=[warehouse, schedule_expr, comment, config_id],
     ).collect()

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -150,6 +150,8 @@ def create_or_update_task(
     schedule_expr = f"USING CRON {schedule_cron} {tz}"
     comment = f"Auto task for DQ config {config_id}"
 
+    procedure_fqn = _q(database, schema, "SP_RUN_DQ_CONFIG")
+
     session.sql(
         f"""
          CREATE TASK IF NOT EXISTS {fqn}
@@ -157,7 +159,7 @@ def create_or_update_task(
            SCHEDULE = ?
            COMMENT = ?
          AS
-           CALL "{database}"."{schema}".SP_RUN_DQ_CONFIG(?);
+           CALL {procedure_fqn}(?);
         """,
         params=[warehouse, schedule_expr, comment, config_id],
     ).collect()


### PR DESCRIPTION
Fix syntax error when enabling DQ tasks
- Quote the stored procedure when creating DQ tasks so generated SQL is valid
- Mirror updated utils/dmfs snapshot

------
https://chatgpt.com/codex/tasks/task_e_68ecfe5c55a48324b1b9d02009603675