### PR TITLE
Fix Snowflake task creation warehouse context

### DIFF
--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -163,7 +163,15 @@ def create_or_update_task(
             )
         return exc
 
+    if warehouse is None or str(warehouse).strip() == "":
+        raise ValueError(
+            "A warehouse is required to schedule tasks. "
+            "Select a warehouse in the app or configure a default in Snowflake before enabling schedules."
+        )
+
     try:
+        session.sql(f"USE WAREHOUSE {_quote(warehouse)}").collect()
+
         session.sql(
             f"""
              CREATE TASK IF NOT EXISTS {fqn}

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -163,7 +163,15 @@ def create_or_update_task(
             )
         return exc
 
+    if warehouse is None or str(warehouse).strip() == "":
+        raise ValueError(
+            "A warehouse is required to schedule tasks. "
+            "Select a warehouse in the app or configure a default in Snowflake before enabling schedules."
+        )
+
     try:
+        session.sql(f"USE WAREHOUSE {_quote(warehouse)}").collect()
+
         session.sql(
             f"""
              CREATE TASK IF NOT EXISTS {fqn}


### PR DESCRIPTION
Task: Fix Snowflake task creation warehouse context

- validate that a warehouse is provided before scheduling tasks
- switch the active Snowflake session warehouse before task DDL statements
- update the mirrored Python snapshot


------
https://chatgpt.com/codex/tasks/task_e_68ed024134e88324a83c4c10a94f6fed