### PR TITLE
Task: allow task names with leading digits

### DIFF
--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -122,8 +122,6 @@ def _safe_ident(value: Any) -> str:
     text = text.strip("_")
     if not text:
         text = "X"
-    if text[0].isdigit():
-        text = f"X_{text}"
     return text
 
 

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -122,8 +122,6 @@ def _safe_ident(value: Any) -> str:
     text = text.strip("_")
     if not text:
         text = "X"
-    if text[0].isdigit():
-        text = f"X_{text}"
     return text
 
 


### PR DESCRIPTION
* Remove the extra X_ prefix that was applied to task names derived from numeric configuration IDs.
* Refresh the mirrored snapshot to reflect the updated helper implementation.


------
https://chatgpt.com/codex/tasks/task_e_68ed06f3a1c483248212ba6af5cb9d45