### PR TITLE
Consolidate config modules

### DIFF
--- a/services/configs.py
+++ b/services/configs.py
@@ -8,7 +8,7 @@ except Exception:
     Session = Any  # type: ignore
 
 from utils import dmfs, meta
-from utils.config import get_metadata_namespace
+from utils.configs import get_metadata_namespace
 
 @contextmanager
 def transaction(session: Session):

--- a/snapshots/services/configs.p
+++ b/snapshots/services/configs.p
@@ -8,7 +8,7 @@ except Exception:
     Session = Any  # type: ignore
 
 from utils import dmfs, meta
-from utils.config import get_metadata_namespace
+from utils.configs import get_metadata_namespace
 
 @contextmanager
 def transaction(session: Session):

--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -44,7 +44,7 @@ from utils import schedules
 from services.configs import save_config_and_checks, delete_config_full
 from services.state import get_state, set_state
 from utils.checkdefs import build_rule_for_column_check, build_rule_for_table_check
-from utils.config import get_metadata_namespace, get_proc_name
+from utils.configs import get_metadata_namespace, get_proc_name
 
 RUN_RESULTS_TBL = "DQ_RUN_RESULTS"
 

--- a/snapshots/utils/config.p
+++ b/snapshots/utils/config.p
@@ -1,18 +1,2 @@
-import os
-
-# Defaults (adjust to your environment if different)
-DEFAULT_METADATA_DB = "ZEUS_ANALYTICS_SIMU"
-DEFAULT_METADATA_SCHEMA = "DISCOVERY"
-DEFAULT_PROC_NAME = "SP_RUN_DQ_CONFIG"  # keep consistent with your deployment
-
-def get_metadata_namespace():
-    """Return the database and schema used for metadata objects."""
-
-    db = os.getenv("DQ_METADATA_DB", DEFAULT_METADATA_DB)
-    schema = os.getenv("DQ_METADATA_SCHEMA", DEFAULT_METADATA_SCHEMA)
-    return db, schema
-
-def get_proc_name():
-    """Return the stored procedure name used to execute DQ configurations."""
-
-    return os.getenv("DQ_PROC_NAME", DEFAULT_PROC_NAME)
+# Temporary shim: re-export from configs.py
+from .configs import *  # noqa

--- a/snapshots/utils/configs.p
+++ b/snapshots/utils/configs.p
@@ -1,0 +1,34 @@
+import os
+
+# Defaults (adjust to your environment if different)
+DEFAULT_METADATA_DB = "ZEUS_ANALYTICS_SIMU"
+DEFAULT_METADATA_SCHEMA = "DISCOVERY"
+DEFAULT_PROC_NAME = "SP_RUN_DQ_CONFIG"  # or "DQ_RUN_CONFIG" if that's what you deploy
+
+
+def get_metadata_namespace():
+    """
+    Returns (db, schema) for metadata objects: DQ_CONFIG, DQ_CHECK, DQ_RUN_RESULTS,
+    and the stored procedure that runs checks.
+    Override via env vars if present.
+    """
+    db = os.getenv("DQ_METADATA_DB", DEFAULT_METADATA_DB)
+    schema = os.getenv("DQ_METADATA_SCHEMA", DEFAULT_METADATA_SCHEMA)
+    return db, schema
+
+
+def get_proc_name():
+    """
+    Returns the stored procedure name used to run one config.
+    Override via env var DQ_PROC_NAME.
+    """
+    return os.getenv("DQ_PROC_NAME", DEFAULT_PROC_NAME)
+
+
+__all__ = [
+    "DEFAULT_METADATA_DB",
+    "DEFAULT_METADATA_SCHEMA",
+    "DEFAULT_PROC_NAME",
+    "get_metadata_namespace",
+    "get_proc_name",
+]

--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -7,6 +7,8 @@ try:  # pragma: no cover - optional dependency in some environments
     import streamlit as st
 except ModuleNotFoundError:  # pragma: no cover - defensive guard when Streamlit absent
     st = None  # type: ignore
+
+from utils.configs import get_proc_name
 from utils.meta import (
     DQConfig,
     DQCheck,
@@ -16,6 +18,7 @@ from utils.meta import (
 )
 
 AGG_PREFIX = "AGG:"
+PROC_NAME = get_proc_name()
 
 __all__ = [
     "AGG_PREFIX",
@@ -99,7 +102,7 @@ def preflight_requirements(
     db: str,
     schema: str,
     warehouse: str,
-    proc_name: str = "SP_RUN_DQ_CONFIG",
+    proc_name: str = PROC_NAME,
     arg_sig: str = "(VARCHAR)",
 ):
     """Validate that the required schema, procedure, and warehouse are usable."""

--- a/snapshots/utils/schedules.p
+++ b/snapshots/utils/schedules.p
@@ -1,8 +1,10 @@
 from typing import Any, Dict
 
+from utils.configs import get_metadata_namespace, get_proc_name
 from utils.dmfs import create_or_update_task, task_name_for_config
 from utils.meta import _parse_relation_name
-from utils.config import get_metadata_namespace, get_proc_name
+
+PROC_NAME = get_proc_name()
 
 
 def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
@@ -54,7 +56,7 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
             schedule_cron=schedule_cron,
             tz=schedule_tz,
             run_role=getattr(cfg, "run_as_role", None),
-            proc_name=get_proc_name(),
+            proc_name=PROC_NAME,
         )
     except Exception as exc:
         return {

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -44,7 +44,7 @@ from utils import schedules
 from services.configs import save_config_and_checks, delete_config_full
 from services.state import get_state, set_state
 from utils.checkdefs import build_rule_for_column_check, build_rule_for_table_check
-from utils.config import get_metadata_namespace, get_proc_name
+from utils.configs import get_metadata_namespace, get_proc_name
 
 RUN_RESULTS_TBL = "DQ_RUN_RESULTS"
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,18 +1,2 @@
-import os
-
-# Defaults (adjust to your environment if different)
-DEFAULT_METADATA_DB = "ZEUS_ANALYTICS_SIMU"
-DEFAULT_METADATA_SCHEMA = "DISCOVERY"
-DEFAULT_PROC_NAME = "SP_RUN_DQ_CONFIG"  # keep consistent with your deployment
-
-def get_metadata_namespace():
-    """Return the database and schema used for metadata objects."""
-
-    db = os.getenv("DQ_METADATA_DB", DEFAULT_METADATA_DB)
-    schema = os.getenv("DQ_METADATA_SCHEMA", DEFAULT_METADATA_SCHEMA)
-    return db, schema
-
-def get_proc_name():
-    """Return the stored procedure name used to execute DQ configurations."""
-
-    return os.getenv("DQ_PROC_NAME", DEFAULT_PROC_NAME)
+# Temporary shim: re-export from configs.py
+from .configs import *  # noqa

--- a/utils/configs.py
+++ b/utils/configs.py
@@ -1,0 +1,34 @@
+import os
+
+# Defaults (adjust to your environment if different)
+DEFAULT_METADATA_DB = "ZEUS_ANALYTICS_SIMU"
+DEFAULT_METADATA_SCHEMA = "DISCOVERY"
+DEFAULT_PROC_NAME = "SP_RUN_DQ_CONFIG"  # or "DQ_RUN_CONFIG" if that's what you deploy
+
+
+def get_metadata_namespace():
+    """
+    Returns (db, schema) for metadata objects: DQ_CONFIG, DQ_CHECK, DQ_RUN_RESULTS,
+    and the stored procedure that runs checks.
+    Override via env vars if present.
+    """
+    db = os.getenv("DQ_METADATA_DB", DEFAULT_METADATA_DB)
+    schema = os.getenv("DQ_METADATA_SCHEMA", DEFAULT_METADATA_SCHEMA)
+    return db, schema
+
+
+def get_proc_name():
+    """
+    Returns the stored procedure name used to run one config.
+    Override via env var DQ_PROC_NAME.
+    """
+    return os.getenv("DQ_PROC_NAME", DEFAULT_PROC_NAME)
+
+
+__all__ = [
+    "DEFAULT_METADATA_DB",
+    "DEFAULT_METADATA_SCHEMA",
+    "DEFAULT_PROC_NAME",
+    "get_metadata_namespace",
+    "get_proc_name",
+]

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -7,6 +7,8 @@ try:  # pragma: no cover - optional dependency in some environments
     import streamlit as st
 except ModuleNotFoundError:  # pragma: no cover - defensive guard when Streamlit absent
     st = None  # type: ignore
+
+from utils.configs import get_proc_name
 from utils.meta import (
     DQConfig,
     DQCheck,
@@ -16,6 +18,7 @@ from utils.meta import (
 )
 
 AGG_PREFIX = "AGG:"
+PROC_NAME = get_proc_name()
 
 __all__ = [
     "AGG_PREFIX",
@@ -99,7 +102,7 @@ def preflight_requirements(
     db: str,
     schema: str,
     warehouse: str,
-    proc_name: str = "SP_RUN_DQ_CONFIG",
+    proc_name: str = PROC_NAME,
     arg_sig: str = "(VARCHAR)",
 ):
     """Validate that the required schema, procedure, and warehouse are usable."""

--- a/utils/schedules.py
+++ b/utils/schedules.py
@@ -1,8 +1,10 @@
 from typing import Any, Dict
 
+from utils.configs import get_metadata_namespace, get_proc_name
 from utils.dmfs import create_or_update_task, task_name_for_config
 from utils.meta import _parse_relation_name
-from utils.config import get_metadata_namespace, get_proc_name
+
+PROC_NAME = get_proc_name()
 
 
 def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
@@ -54,7 +56,7 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
             schedule_cron=schedule_cron,
             tz=schedule_tz,
             run_role=getattr(cfg, "run_as_role", None),
-            proc_name=get_proc_name(),
+            proc_name=PROC_NAME,
         )
     except Exception as exc:
         return {


### PR DESCRIPTION
TASK: Consolidate config modules — merge config.py into configs.py and standardize imports

- add utils/configs.py as the canonical configuration module and expose metadata/proc helpers
- keep utils/config.py as a shim that re-exports the canonical module
- update imports and scheduling helpers to use the unified configuration accessors
- refresh mirrored Python snapshots

------
https://chatgpt.com/codex/tasks/task_e_68ee4752558c832488397e0aee8764ed