### PR TITLE
Refactor task creation logic for fully qualified task management

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -46,10 +46,9 @@ from services.state import get_state, set_state
 from utils.checkdefs import build_rule_for_column_check, build_rule_for_table_check
 from utils.configs import get_metadata_namespace, get_proc_name
 
-RUN_RESULTS_TBL = "DQ_RUN_RESULTS"
-
 METADATA_DB, METADATA_SCHEMA = get_metadata_namespace()
 PROC_NAME = get_proc_name()
+RUN_RESULTS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_RUN_RESULTS"
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
 

--- a/snapshots/utils/meta.p
+++ b/snapshots/utils/meta.p
@@ -14,9 +14,13 @@ try:
 except Exception:
     Session = Any  # type: ignore
 
+from utils.configs import get_metadata_namespace
+
+METADATA_DB, METADATA_SCHEMA = get_metadata_namespace()
+
 # Override with fully-qualified names if desired (e.g., "DB.SCHEMA.DQ_CONFIG")
-DQ_CONFIG_TBL: str = "DQ_CONFIG"
-DQ_CHECK_TBL: str = "DQ_CHECK"
+DQ_CONFIG_TBL: str = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CONFIG"
+DQ_CHECK_TBL: str = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 
 __all__ = [
     "DQ_CONFIG_TBL",

--- a/snapshots/utils/schedules.p
+++ b/snapshots/utils/schedules.p
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.configs import get_metadata_namespace, get_proc_name
-from utils.dmfs import create_or_update_task, task_name_for_config
+from utils.dmfs import create_or_update_task, task_name_for_config, _q
 from utils.meta import _parse_relation_name
 
 PROC_NAME = get_proc_name()
@@ -46,6 +46,8 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
 
     meta_db, meta_schema = get_metadata_namespace()
 
+    task_fqn = _q(meta_db, meta_schema, base_task_name)
+
     try:
         create_or_update_task(
             session,
@@ -59,13 +61,6 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
             proc_name=PROC_NAME,
         )
     except Exception as exc:
-        return {
-            "status": "FALLBACK",
-            "reason": str(exc),
-            "task": f"{meta_db}.{meta_schema}.{base_task_name}",
-        }
+        return {"status": "FALLBACK", "reason": str(exc), "task": task_fqn}
 
-    return {
-        "status": "TASK_CREATED",
-        "task": f"{meta_db}.{meta_schema}.{base_task_name}",
-    }
+    return {"status": "TASK_CREATED", "task": task_fqn}

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -46,10 +46,9 @@ from services.state import get_state, set_state
 from utils.checkdefs import build_rule_for_column_check, build_rule_for_table_check
 from utils.configs import get_metadata_namespace, get_proc_name
 
-RUN_RESULTS_TBL = "DQ_RUN_RESULTS"
-
 METADATA_DB, METADATA_SCHEMA = get_metadata_namespace()
 PROC_NAME = get_proc_name()
+RUN_RESULTS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_RUN_RESULTS"
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
 

--- a/utils/meta.py
+++ b/utils/meta.py
@@ -14,9 +14,13 @@ try:
 except Exception:
     Session = Any  # type: ignore
 
+from utils.configs import get_metadata_namespace
+
+METADATA_DB, METADATA_SCHEMA = get_metadata_namespace()
+
 # Override with fully-qualified names if desired (e.g., "DB.SCHEMA.DQ_CONFIG")
-DQ_CONFIG_TBL: str = "DQ_CONFIG"
-DQ_CHECK_TBL: str = "DQ_CHECK"
+DQ_CONFIG_TBL: str = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CONFIG"
+DQ_CHECK_TBL: str = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 
 __all__ = [
     "DQ_CONFIG_TBL",

--- a/utils/schedules.py
+++ b/utils/schedules.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.configs import get_metadata_namespace, get_proc_name
-from utils.dmfs import create_or_update_task, task_name_for_config
+from utils.dmfs import create_or_update_task, task_name_for_config, _q
 from utils.meta import _parse_relation_name
 
 PROC_NAME = get_proc_name()
@@ -46,6 +46,8 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
 
     meta_db, meta_schema = get_metadata_namespace()
 
+    task_fqn = _q(meta_db, meta_schema, base_task_name)
+
     try:
         create_or_update_task(
             session,
@@ -59,13 +61,6 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
             proc_name=PROC_NAME,
         )
     except Exception as exc:
-        return {
-            "status": "FALLBACK",
-            "reason": str(exc),
-            "task": f"{meta_db}.{meta_schema}.{base_task_name}",
-        }
+        return {"status": "FALLBACK", "reason": str(exc), "task": task_fqn}
 
-    return {
-        "status": "TASK_CREATED",
-        "task": f"{meta_db}.{meta_schema}.{base_task_name}",
-    }
+    return {"status": "TASK_CREATED", "task": task_fqn}


### PR DESCRIPTION
TASK: Refactor task creation logic to remove all "USE ..." statements and rely entirely on fully qualified identifiers.

- replace context-changing SQL with session validation and centralized quoting helpers in task utilities
- switch task preflight checks and metadata operations to fully qualified INFORMATION_SCHEMA queries without bind parameters
- propagate fully qualified metadata names to Streamlit scheduling flows and snapshot mirrors

------
https://chatgpt.com/codex/tasks/task_e_68ef4f9f11d883248d2627ca65c540c8