### PR TITLE
Remove disallowed session mutations causing “Unsupported statement type 'ALTER_SESSION'” in Streamlit

### DIFF
--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -112,8 +112,6 @@ def ensure_session_context(session, role: str, warehouse: str, db: str, schema: 
     if issues:
         raise ValueError(" ".join(issues))
 
-    session.sql("ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE").collect()
-
 
 if st is not None:  # pragma: no cover - decorator depends on Streamlit runtime
 

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -112,8 +112,6 @@ def ensure_session_context(session, role: str, warehouse: str, db: str, schema: 
     if issues:
         raise ValueError(" ".join(issues))
 
-    session.sql("ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE").collect()
-
 
 if st is not None:  # pragma: no cover - decorator depends on Streamlit runtime
 


### PR DESCRIPTION
- Removed the ALTER SESSION enforcement from `ensure_session_context` to avoid session mutations during app operations.
- Regenerated snapshot mirrors to reflect the updated session checks.


------
https://chatgpt.com/codex/tasks/task_e_68ef54681f088324a34443ec5433cdc1