### PR TITLE
Fix stored procedure name for DQ config runs

### DIFF
--- a/snapshots/utils/configs.p
+++ b/snapshots/utils/configs.p
@@ -12,7 +12,7 @@ import os
 # Defaults (adjust to your environment if different)
 DEFAULT_METADATA_DB = "ZEUS_ANALYTICS_SIMU"
 DEFAULT_METADATA_SCHEMA = "DISCOVERY"
-DEFAULT_PROC_NAME = "SP_RUN_DQ_CONFIG"  # or "DQ_RUN_CONFIG" if that's what you deploy
+DEFAULT_PROC_NAME = "DQ_RUN_CONFIG"
 
 
 def get_metadata_namespace():

--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -325,7 +325,7 @@ def create_or_update_task(
     schedule_cron: str = "0 8 * * *",
     tz: str = "Europe/Berlin",
     run_role: Any = None,
-    proc_name: str = "SP_RUN_DQ_CONFIG",
+    proc_name: str = "DQ_RUN_CONFIG",
 ) -> None:
     """Create or update the Snowflake task for the given configuration."""
 
@@ -360,7 +360,7 @@ def create_or_update_task(
             if meta_location:
                 hint += f" `{meta_location}`"
             hint += (
-                " exists, that the `SP_RUN_DQ_CONFIG(VARCHAR)` stored procedure is deployed "
+                " exists, that the `DQ_RUN_CONFIG(VARCHAR)` stored procedure is deployed "
                 "there, and that your role has privileges to use it."
             )
             return ValueError(message + "." + hint)

--- a/utils/configs.py
+++ b/utils/configs.py
@@ -12,7 +12,7 @@ import os
 # Defaults (adjust to your environment if different)
 DEFAULT_METADATA_DB = "ZEUS_ANALYTICS_SIMU"
 DEFAULT_METADATA_SCHEMA = "DISCOVERY"
-DEFAULT_PROC_NAME = "SP_RUN_DQ_CONFIG"  # or "DQ_RUN_CONFIG" if that's what you deploy
+DEFAULT_PROC_NAME = "DQ_RUN_CONFIG"
 
 
 def get_metadata_namespace():

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -325,7 +325,7 @@ def create_or_update_task(
     schedule_cron: str = "0 8 * * *",
     tz: str = "Europe/Berlin",
     run_role: Any = None,
-    proc_name: str = "SP_RUN_DQ_CONFIG",
+    proc_name: str = "DQ_RUN_CONFIG",
 ) -> None:
     """Create or update the Snowflake task for the given configuration."""
 
@@ -360,7 +360,7 @@ def create_or_update_task(
             if meta_location:
                 hint += f" `{meta_location}`"
             hint += (
-                " exists, that the `SP_RUN_DQ_CONFIG(VARCHAR)` stored procedure is deployed "
+                " exists, that the `DQ_RUN_CONFIG(VARCHAR)` stored procedure is deployed "
                 "there, and that your role has privileges to use it."
             )
             return ValueError(message + "." + hint)


### PR DESCRIPTION
Fix stored procedure name for DQ config runs
- Default the application to call the DQ_RUN_CONFIG stored procedure
- Update mirrored snapshots to reflect the stored procedure change

------
https://chatgpt.com/codex/tasks/task_e_68ef56479e8c8324b418b9b7af2c60da