### PR TITLE
Fix SP_DQ_MANAGE_TASK bind syntax

### DIFF
--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -174,14 +174,14 @@ BEGIN
         '  COMMENT   = ?' || CHR(10) ||
         'AS' || CHR(10) ||
         '  CALL ' || v_proc_fqn || '(?)'
-        USING (v_sched, v_comment, v_config);
+        USING v_sched, v_comment, v_config;
 
     EXECUTE IMMEDIATE
         'ALTER TASK ' || v_task_fqn || ' SET' || CHR(10) ||
         '  WAREHOUSE = ' || v_wh_ident || ',' || CHR(10) ||
         '  SCHEDULE  = ?,' || CHR(10) ||
         '  COMMENT   = ?'
-        USING (v_sched, v_comment);
+        USING v_sched, v_comment;
 
     IF v_enable THEN
         EXECUTE IMMEDIATE 'ALTER TASK ' || v_task_fqn || ' RESUME';


### PR DESCRIPTION
Fix SP_DQ_MANAGE_TASK bind syntax

- Correct EXECUTE IMMEDIATE USING clause syntax in task management procedure

------
https://chatgpt.com/codex/tasks/task_e_68ef8f64f4008324a1876834f218c0e8