### PR TITLE
Fix Snowflake Scripting syntax in SP_DQ_MANAGE_TASK

### DIFF
--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -138,22 +138,22 @@ BEGIN
     v_tz := TRIM(v_tz);
 
     IF v_db = '' THEN
-        RAISE STATEMENT_ERROR WITH MESSAGE = 'TARGET_DB is required';
+        RAISE STATEMENT_ERROR USING MESSAGE = 'TARGET_DB is required';
     END IF;
     IF v_schema = '' THEN
-        RAISE STATEMENT_ERROR WITH MESSAGE = 'TARGET_SCHEMA is required';
+        RAISE STATEMENT_ERROR USING MESSAGE = 'TARGET_SCHEMA is required';
     END IF;
     IF v_wh = '' THEN
-        RAISE STATEMENT_ERROR WITH MESSAGE = 'TASK_WAREHOUSE is required';
+        RAISE STATEMENT_ERROR USING MESSAGE = 'TASK_WAREHOUSE is required';
     END IF;
     IF v_proc = '' THEN
-        RAISE STATEMENT_ERROR WITH MESSAGE = 'PROC_NAME is required';
+        RAISE STATEMENT_ERROR USING MESSAGE = 'PROC_NAME is required';
     END IF;
     IF v_cron = '' THEN
-        RAISE STATEMENT_ERROR WITH MESSAGE = 'CRON is required';
+        RAISE STATEMENT_ERROR USING MESSAGE = 'CRON is required';
     END IF;
     IF v_tz = '' THEN
-        RAISE STATEMENT_ERROR WITH MESSAGE = 'TZ is required';
+        RAISE STATEMENT_ERROR USING MESSAGE = 'TZ is required';
     END IF;
 
     v_db_ident := '"' || REPLACE(v_db, '"', '""') || '"';


### PR DESCRIPTION
* Replace SP_DQ_MANAGE_TASK RAISE statements to use the `USING MESSAGE` form required by Snowflake Scripting.
* Mirror snapshot metadata after the stored procedure change.

------
https://chatgpt.com/codex/tasks/task_e_68f0d8c820648324ac7e00416cef557d