### PR TITLE
TASK: Make SP_DQ_MANAGE_TASK compile by removing RAISE statements and returning explicit error strings; update app to interpret them

### DIFF
--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -427,7 +427,7 @@ def create_or_update_task(
             arg_sig="(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)",
         )
 
-        session.sql(
+        result = session.sql(
             'CALL "ZEUS_ANALYTICS_SIMU"."DISCOVERY"."SP_DQ_MANAGE_TASK"(?, ?, ?, ?, ?, ?, ?, ?)',
             params=[
                 db_name,
@@ -442,6 +442,13 @@ def create_or_update_task(
         ).collect()
     except Exception as exc:  # pragma: no cover - Snowflake specific
         raise _handle_task_error(exc)
+
+    if not result:
+        raise ValueError("Task management procedure returned no result")
+
+    message = str(result[0][0])
+    if message.upper().startswith("ERROR:"):
+        raise ValueError(message[6:].strip())
 
 
 def run_task_now(session, db: Any, schema: Any, config_id: Any):

--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -138,22 +138,22 @@ BEGIN
     v_tz := TRIM(v_tz);
 
     IF (v_db = '') THEN
-        RAISE STATEMENT_ERROR USING MESSAGE = 'TARGET_DB is required';
+        RETURN 'ERROR: TARGET_DB is required';
     END IF;
     IF (v_schema = '') THEN
-        RAISE STATEMENT_ERROR USING MESSAGE = 'TARGET_SCHEMA is required';
+        RETURN 'ERROR: TARGET_SCHEMA is required';
     END IF;
     IF (v_wh = '') THEN
-        RAISE STATEMENT_ERROR USING MESSAGE = 'TASK_WAREHOUSE is required';
+        RETURN 'ERROR: TASK_WAREHOUSE is required';
     END IF;
     IF (v_proc = '') THEN
-        RAISE STATEMENT_ERROR USING MESSAGE = 'PROC_NAME is required';
+        RETURN 'ERROR: PROC_NAME is required';
     END IF;
     IF (v_cron = '') THEN
-        RAISE STATEMENT_ERROR USING MESSAGE = 'CRON is required';
+        RETURN 'ERROR: CRON is required';
     END IF;
     IF (v_tz = '') THEN
-        RAISE STATEMENT_ERROR USING MESSAGE = 'TZ is required';
+        RETURN 'ERROR: TZ is required';
     END IF;
 
     v_db_ident := '"' || REPLACE(v_db, '"', '""') || '"';
@@ -195,7 +195,7 @@ BEGIN
         EXECUTE IMMEDIATE 'ALTER TASK ' || v_task_fqn || ' RESUME';
     END IF;
 
-    RETURN 'TASK ' || v_task_fqn || ' UPDATED';
+    RETURN 'OK: TASK ' || v_task_fqn || ' UPDATED';
 END;
 $$;
 

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -427,7 +427,7 @@ def create_or_update_task(
             arg_sig="(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)",
         )
 
-        session.sql(
+        result = session.sql(
             'CALL "ZEUS_ANALYTICS_SIMU"."DISCOVERY"."SP_DQ_MANAGE_TASK"(?, ?, ?, ?, ?, ?, ?, ?)',
             params=[
                 db_name,
@@ -442,6 +442,13 @@ def create_or_update_task(
         ).collect()
     except Exception as exc:  # pragma: no cover - Snowflake specific
         raise _handle_task_error(exc)
+
+    if not result:
+        raise ValueError("Task management procedure returned no result")
+
+    message = str(result[0][0])
+    if message.upper().startswith("ERROR:"):
+        raise ValueError(message[6:].strip())
 
 
 def run_task_now(session, db: Any, schema: Any, config_id: Any):


### PR DESCRIPTION
TASK: Make SP_DQ_MANAGE_TASK compile by removing RAISE statements and returning explicit error strings; update app to interpret them

- Replace RAISE statements in SP_DQ_MANAGE_TASK with explicit error returns and prepend the success message with OK:
- Update dmfs task management flow to surface ERROR responses from the stored procedure
- Refresh mirrored snapshots after the dmfs.py change

------
https://chatgpt.com/codex/tasks/task_e_68f0f43620408324aba66691f8dbec8d