### PR TITLE
Fix task procedure conditional and trim usage

### DIFF
--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -162,7 +162,7 @@ BEGIN
 
     v_safe_config := REGEXP_REPLACE(UPPER(v_config), '[^A-Z0-9_]', '_');
     v_safe_config := REGEXP_REPLACE(v_safe_config, '_+', '_');
-    v_safe_config := TRIM(BOTH '_' FROM v_safe_config);
+    v_safe_config := TRIM(v_safe_config, '_');
     IF (v_safe_config = '') THEN
         v_safe_config := 'X';
     END IF;
@@ -191,7 +191,7 @@ BEGIN
         'SCHEDULE  = ' || '''' || REPLACE(v_sched, '''', '''''') || '''' || ', ' ||
         'COMMENT   = ' || '''' || REPLACE(v_comment, '''', '''''') || '''';
 
-    IF v_enable THEN
+    IF (v_enable) THEN
         EXECUTE IMMEDIATE 'ALTER TASK ' || v_task_fqn || ' RESUME';
     END IF;
 


### PR DESCRIPTION
Task: Fix task procedure syntax

- Wrap the v_enable condition with parentheses in the task procedure
- Switch the TRIM call to the supported two-argument form for safe config normalization

------
https://chatgpt.com/codex/tasks/task_e_68f0f77b67388324acbde0ed7e7642f0