### PR TITLE
Hardcode DMF scheduling warehouse

### DIFF
--- a/snapshots/utils/dmfs.p
+++ b/snapshots/utils/dmfs.p
@@ -20,6 +20,9 @@ from utils.meta import (
 AGG_PREFIX = "AGG:"
 PROC_NAME = get_proc_name()
 
+# Temporary warehouse override until dynamic selection is restored.
+DEFAULT_WAREHOUSE = "DQ_WH"
+
 __all__ = [
     "AGG_PREFIX",
     "attach_dmfs",
@@ -32,6 +35,7 @@ __all__ = [
     "preflight_requirements",
     "create_or_update_task",
     "run_task_now",
+    "DEFAULT_WAREHOUSE",
 ]
 
 
@@ -490,13 +494,10 @@ def create_or_update_task(
             return ValueError(message + "." + hint)
         return exc
 
-    if warehouse is None or str(warehouse).strip() == "":
-        raise ValueError(
-            "A warehouse is required to schedule tasks. "
-            "Select a warehouse in the app or configure a default in Snowflake before enabling schedules."
-        )
-
-    warehouse_name = str(warehouse).strip()
+    # Until the UI supports selecting a warehouse reliably, always fall back to
+    # the default DMF warehouse so that task creation succeeds without manual
+    # session context tweaks.
+    warehouse_name = DEFAULT_WAREHOUSE
     run_role_name = str(run_role).strip() if run_role is not None else ""
     cron_expression = str(schedule_cron or "").strip()
     timezone_name = str(tz or "").strip()

--- a/snapshots/utils/schedules.p
+++ b/snapshots/utils/schedules.p
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.configs import get_metadata_namespace, get_proc_name
-from utils.dmfs import create_or_update_task, task_name_for_config, _q
+from utils.dmfs import DEFAULT_WAREHOUSE, create_or_update_task, task_name_for_config, _q
 from utils.meta import _parse_relation_name
 
 PROC_NAME = get_proc_name()
@@ -33,13 +33,7 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
             "task": base_task_name,
         }
 
-    try:
-        warehouse = session.get_current_warehouse()
-    except Exception:  # pragma: no cover - defensive branch
-        warehouse = None
-
-    if not warehouse:
-        return {"status": "NO_WAREHOUSE", "task": base_task_name}
+    warehouse = DEFAULT_WAREHOUSE
 
     schedule_cron = (getattr(cfg, "schedule_cron", None) or "0 8 * * *").strip() or "0 8 * * *"
     schedule_tz = (getattr(cfg, "schedule_timezone", None) or "Europe/Berlin").strip() or "Europe/Berlin"

--- a/utils/dmfs.py
+++ b/utils/dmfs.py
@@ -20,6 +20,9 @@ from utils.meta import (
 AGG_PREFIX = "AGG:"
 PROC_NAME = get_proc_name()
 
+# Temporary warehouse override until dynamic selection is restored.
+DEFAULT_WAREHOUSE = "DQ_WH"
+
 __all__ = [
     "AGG_PREFIX",
     "attach_dmfs",
@@ -32,6 +35,7 @@ __all__ = [
     "preflight_requirements",
     "create_or_update_task",
     "run_task_now",
+    "DEFAULT_WAREHOUSE",
 ]
 
 
@@ -490,13 +494,10 @@ def create_or_update_task(
             return ValueError(message + "." + hint)
         return exc
 
-    if warehouse is None or str(warehouse).strip() == "":
-        raise ValueError(
-            "A warehouse is required to schedule tasks. "
-            "Select a warehouse in the app or configure a default in Snowflake before enabling schedules."
-        )
-
-    warehouse_name = str(warehouse).strip()
+    # Until the UI supports selecting a warehouse reliably, always fall back to
+    # the default DMF warehouse so that task creation succeeds without manual
+    # session context tweaks.
+    warehouse_name = DEFAULT_WAREHOUSE
     run_role_name = str(run_role).strip() if run_role is not None else ""
     cron_expression = str(schedule_cron or "").strip()
     timezone_name = str(tz or "").strip()

--- a/utils/schedules.py
+++ b/utils/schedules.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.configs import get_metadata_namespace, get_proc_name
-from utils.dmfs import create_or_update_task, task_name_for_config, _q
+from utils.dmfs import DEFAULT_WAREHOUSE, create_or_update_task, task_name_for_config, _q
 from utils.meta import _parse_relation_name
 
 PROC_NAME = get_proc_name()
@@ -33,13 +33,7 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
             "task": base_task_name,
         }
 
-    try:
-        warehouse = session.get_current_warehouse()
-    except Exception:  # pragma: no cover - defensive branch
-        warehouse = None
-
-    if not warehouse:
-        return {"status": "NO_WAREHOUSE", "task": base_task_name}
+    warehouse = DEFAULT_WAREHOUSE
 
     schedule_cron = (getattr(cfg, "schedule_cron", None) or "0 8 * * *").strip() or "0 8 * * *"
     schedule_tz = (getattr(cfg, "schedule_timezone", None) or "Europe/Berlin").strip() or "Europe/Berlin"


### PR DESCRIPTION
Hardcode DMF scheduling warehouse
- Force DMF task management to always use the DQ_WH warehouse
- Default schedule helper to DQ_WH and refresh mirrored snapshots

------
https://chatgpt.com/codex/tasks/task_e_68f110f5edf08324b751ff58e5e8b577