### PR TITLE
Prevent Save & Apply from executing DQ checks

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -905,12 +905,14 @@ def render_config_editor():
                 st.warning(warn_msg)
                 remember("warning", warn_msg)
 
-            if run_task_via_system_proc_flag:
-                if not task_fqn:
-                    warn_msg = (
-                        "SYSTEM$TASK_FORCE_RUN fallback skipped because the task name could not be determined."
-                    )
-                    st.warning(warn_msg)
+        should_force_run = run_task_via_system_proc_flag and run_now_btn
+
+        if should_force_run:
+            if not task_fqn:
+                warn_msg = (
+                    "SYSTEM$TASK_FORCE_RUN fallback skipped because the task name could not be determined."
+                )
+                st.warning(warn_msg)
                     remember("warning", warn_msg)
                 elif not warehouse_name:
                     warn_msg = (
@@ -952,6 +954,13 @@ def render_config_editor():
                             )
                         st.info(info_msg)
                         remember("info", info_msg)
+        elif run_task_via_system_proc_flag:
+            info_msg = (
+                "SYSTEM$TASK_FORCE_RUN fallback is available when **Run Now** is used. "
+                "Save & Apply will only update the configuration."
+            )
+            st.info(info_msg)
+            remember("info", info_msg)
 
         st.session_state["last_notices"] = post_submit_notices
         st.session_state["cfg_mode"] = "list"; st.rerun()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -905,12 +905,14 @@ def render_config_editor():
                 st.warning(warn_msg)
                 remember("warning", warn_msg)
 
-            if run_task_via_system_proc_flag:
-                if not task_fqn:
-                    warn_msg = (
-                        "SYSTEM$TASK_FORCE_RUN fallback skipped because the task name could not be determined."
-                    )
-                    st.warning(warn_msg)
+        should_force_run = run_task_via_system_proc_flag and run_now_btn
+
+        if should_force_run:
+            if not task_fqn:
+                warn_msg = (
+                    "SYSTEM$TASK_FORCE_RUN fallback skipped because the task name could not be determined."
+                )
+                st.warning(warn_msg)
                     remember("warning", warn_msg)
                 elif not warehouse_name:
                     warn_msg = (
@@ -952,6 +954,13 @@ def render_config_editor():
                             )
                         st.info(info_msg)
                         remember("info", info_msg)
+        elif run_task_via_system_proc_flag:
+            info_msg = (
+                "SYSTEM$TASK_FORCE_RUN fallback is available when **Run Now** is used. "
+                "Save & Apply will only update the configuration."
+            )
+            st.info(info_msg)
+            remember("info", info_msg)
 
         st.session_state["last_notices"] = post_submit_notices
         st.session_state["cfg_mode"] = "list"; st.rerun()


### PR DESCRIPTION
* Gate the SYSTEM$TASK_FORCE_RUN fallback so it only executes when **Run Now** is used.
* Provide clarification messaging that Save & Apply will only update the configuration when the fallback option is enabled.
* Update mirrored snapshots.

------
https://chatgpt.com/codex/tasks/task_e_68f1320e0ef08324a11e9e97ddffaed3