### PR TITLE
Make Save & Apply create/enable tasks via SP_DQ_MANAGE_TASK

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -839,12 +839,11 @@ def render_config_editor():
                         meta_db or "",
                         meta_schema or "",
                     )
-                    if meta_db and meta_schema and warehouse_name:
+                    if meta_db and meta_schema:
                         preflight_requirements(
                             session,
                             meta_db,
                             meta_schema,
-                            warehouse_name,
                             proc_name=PROC_NAME,
                             arg_sig="(VARCHAR)",
                         )
@@ -852,7 +851,6 @@ def render_config_editor():
                             session,
                             meta_db,
                             meta_schema,
-                            warehouse_name,
                             proc_name="SP_DQ_MANAGE_TASK",
                             arg_sig="(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)",
                         )

--- a/snapshots/utils/schedules.p
+++ b/snapshots/utils/schedules.p
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.configs import get_metadata_namespace, get_proc_name
-from utils.dmfs import DEFAULT_WAREHOUSE, create_or_update_task, task_name_for_config, _q
+from utils.dmfs import DEFAULT_WAREHOUSE, task_name_for_config, _q
 from utils.meta import _parse_relation_name
 
 PROC_NAME = get_proc_name()
@@ -43,18 +43,31 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
     task_fqn = _q(meta_db, meta_schema, base_task_name)
 
     try:
-        create_or_update_task(
-            session,
-            meta_db,
-            meta_schema,
-            warehouse,
-            cfg.config_id,
-            schedule_cron=schedule_cron,
-            tz=schedule_tz,
-            run_role=getattr(cfg, "run_as_role", None),
-            proc_name=PROC_NAME,
-        )
+        result = session.sql(
+            f'CALL {_q(meta_db, meta_schema, "SP_DQ_MANAGE_TASK")}(?, ?, ?, ?, ?, ?, ?, ?)',
+            params=[
+                meta_db,
+                meta_schema,
+                warehouse,
+                str(cfg.config_id),
+                PROC_NAME,
+                schedule_cron,
+                schedule_tz,
+                True,
+            ],
+        ).collect()
     except Exception as exc:
         return {"status": "FALLBACK", "reason": str(exc), "task": task_fqn}
+
+    if not result:
+        return {
+            "status": "FALLBACK",
+            "reason": "Task management procedure returned no result",
+            "task": task_fqn,
+        }
+
+    message = str(result[0][0])
+    if message.upper().startswith("ERROR:"):
+        return {"status": "FALLBACK", "reason": message, "task": task_fqn}
 
     return {"status": "TASK_CREATED", "task": task_fqn}

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -839,12 +839,11 @@ def render_config_editor():
                         meta_db or "",
                         meta_schema or "",
                     )
-                    if meta_db and meta_schema and warehouse_name:
+                    if meta_db and meta_schema:
                         preflight_requirements(
                             session,
                             meta_db,
                             meta_schema,
-                            warehouse_name,
                             proc_name=PROC_NAME,
                             arg_sig="(VARCHAR)",
                         )
@@ -852,7 +851,6 @@ def render_config_editor():
                             session,
                             meta_db,
                             meta_schema,
-                            warehouse_name,
                             proc_name="SP_DQ_MANAGE_TASK",
                             arg_sig="(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)",
                         )

--- a/utils/schedules.py
+++ b/utils/schedules.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from utils.configs import get_metadata_namespace, get_proc_name
-from utils.dmfs import DEFAULT_WAREHOUSE, create_or_update_task, task_name_for_config, _q
+from utils.dmfs import DEFAULT_WAREHOUSE, task_name_for_config, _q
 from utils.meta import _parse_relation_name
 
 PROC_NAME = get_proc_name()
@@ -43,18 +43,31 @@ def ensure_task_for_config(session, cfg) -> Dict[str, Any]:
     task_fqn = _q(meta_db, meta_schema, base_task_name)
 
     try:
-        create_or_update_task(
-            session,
-            meta_db,
-            meta_schema,
-            warehouse,
-            cfg.config_id,
-            schedule_cron=schedule_cron,
-            tz=schedule_tz,
-            run_role=getattr(cfg, "run_as_role", None),
-            proc_name=PROC_NAME,
-        )
+        result = session.sql(
+            f'CALL {_q(meta_db, meta_schema, "SP_DQ_MANAGE_TASK")}(?, ?, ?, ?, ?, ?, ?, ?)',
+            params=[
+                meta_db,
+                meta_schema,
+                warehouse,
+                str(cfg.config_id),
+                PROC_NAME,
+                schedule_cron,
+                schedule_tz,
+                True,
+            ],
+        ).collect()
     except Exception as exc:
         return {"status": "FALLBACK", "reason": str(exc), "task": task_fqn}
+
+    if not result:
+        return {
+            "status": "FALLBACK",
+            "reason": "Task management procedure returned no result",
+            "task": task_fqn,
+        }
+
+    message = str(result[0][0])
+    if message.upper().startswith("ERROR:"):
+        return {"status": "FALLBACK", "reason": message, "task": task_fqn}
 
     return {"status": "TASK_CREATED", "task": task_fqn}


### PR DESCRIPTION
TASK: Make Save & Apply create/enable tasks ONLY via SP_DQ_MANAGE_TASK; remove app-side DDL and temp tasks

- routed task scheduling to call SP_DQ_MANAGE_TASK directly and handle returned status codes
- updated DMF task helper to rely solely on the stored procedure and simplified error propagation
- relaxed session preflight requirements and UI checks so schedules no longer depend on warehouse visibility
- refreshed the snapshots mirror

------
https://chatgpt.com/codex/tasks/task_e_68f138f545c88324ab2d06eaa627b684