### PR TITLE
Suspend tasks before altering configuration

### DIFF
--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -181,6 +181,8 @@ BEGIN
         '  COMMENT   = ' || '''' || REPLACE(v_comment, '''', '''''') || '''' || CHR(10) ||
         'AS CALL ' || v_proc_fqn || '(''' || REPLACE(v_config, '''', '''''') || ''')';
 
+    EXECUTE IMMEDIATE 'ALTER TASK ' || v_task_fqn || ' SUSPEND';
+
     EXECUTE IMMEDIATE
         'ALTER TASK ' || v_task_fqn || ' SET ' ||
         'WAREHOUSE = ' || v_wh_ident || ', ' ||


### PR DESCRIPTION
Suspend tasks before altering configuration

- suspend Snowflake DQ task prior to applying ALTER statements to avoid root-task graph update errors
- leave task resumed only when enable flag is true

------
https://chatgpt.com/codex/tasks/task_e_68f1d40ec67083248a3a0fe470b0910e