### PR TITLE
Task: Guard failure counts from null values

### DIFF
--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -60,7 +60,7 @@ def run_dq_config(session: Session, CONFIG_ID: str) -> str:
         rule_expr_upper = rule_expr_raw.upper()
 
         ok = False
-        failures = None
+        failures = 0
         error_msg = None
 
         try:
@@ -83,7 +83,7 @@ def run_dq_config(session: Session, CONFIG_ID: str) -> str:
                 ok = failures == 0
         except Exception as exc:
             ok = False
-            failures = None
+            failures = 0
             error_msg = str(exc)
 
         session.sql(


### PR DESCRIPTION
- Default failure counts to zero in `run_dq_config` to avoid inserting `None` into numeric columns.
- Ensure exception handling records zero failures so DQ results remain numeric-friendly.

------
https://chatgpt.com/codex/tasks/task_e_68f1d93980d08324a6d205388311ab63