### PR TITLE
Fix aggregate runner quoting for freshness checks

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -10,6 +10,8 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
         rule = (chk.rule_expr or '').strip()
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()
+            if sql and sql[0] == sql[-1] and sql[0] in {'"', "'"}:
+                sql = sql[1:-1].strip()
             df = session.sql(sql)
             r = df.collect()[0]
             ok = bool((r[0] if not hasattr(r, 'asDict') else list(r.asDict().values())[0]))

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -10,6 +10,8 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
         rule = (chk.rule_expr or '').strip()
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()
+            if sql and sql[0] == sql[-1] and sql[0] in {'"', "'"}:
+                sql = sql[1:-1].strip()
             df = session.sql(sql)
             r = df.collect()[0]
             ok = bool((r[0] if not hasattr(r, 'asDict') else list(r.asDict().values())[0]))


### PR DESCRIPTION
* Strip surrounding quotes when executing aggregate check SQL to avoid Snowflake syntax errors
* Update mirrored snapshot for `services/runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68f1dfdf96b88324863a1ea396d255a4