### PR TITLE
Fix freshness check SQL literal quoting

### DIFF
--- a/snapshots/utils/checkdefs.p
+++ b/snapshots/utils/checkdefs.p
@@ -55,7 +55,7 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         max_age = int(params.get("max_age_minutes", 1920))
         return "\n".join([
             f"SELECT (COUNT(*) > 0 AND COUNT(\"{ts_col}\") > 0 AND",
-            f"        TIMESTAMPDIFF('minute', MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
+            f"        TIMESTAMPDIFF(MINUTE, MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
             f"FROM {_q(fqn)}",
         ]), True
     if ttype == "ROW_COUNT":

--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -55,7 +55,7 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         max_age = int(params.get("max_age_minutes", 1920))
         return "\n".join([
             f"SELECT (COUNT(*) > 0 AND COUNT(\"{ts_col}\") > 0 AND",
-            f"        TIMESTAMPDIFF('minute', MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
+            f"        TIMESTAMPDIFF(MINUTE, MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
             f"FROM {_q(fqn)}",
         ]), True
     if ttype == "ROW_COUNT":


### PR DESCRIPTION
- replace the freshness TIMESTAMPDIFF call to use MINUTE without quotes to avoid escape characters in stored SQL
- refresh mirrored snapshot for updated checkdefs module

------
https://chatgpt.com/codex/tasks/task_e_68f1e1c4b0f883249baf7fb19d41ce4d