### PR TITLE
Fix aggregate SQL quoting

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -10,8 +10,18 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
         rule = (chk.rule_expr or '').strip()
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()
-            if sql and sql[0] == sql[-1] and sql[0] in {'"', "'"}:
-                sql = sql[1:-1].strip()
+            if sql:
+                # Remove any wrapping quotes that may surround the SQL text.
+                if sql[0] == sql[-1] and sql[0] in {'"', "'"}:
+                    sql = sql[1:-1].strip()
+                # Snowflake can surface statements such as `'SELECT ...''` when
+                # values were stored with escaped quotes. Strip any leading or
+                # trailing quote characters that remain so we execute the raw
+                # SQL statement.
+                while sql and sql[0] in {'"', "'"}:
+                    sql = sql[1:].lstrip()
+                while sql and sql[-1] in {'"', "'"}:
+                    sql = sql[:-1].rstrip()
             df = session.sql(sql)
             r = df.collect()[0]
             ok = bool((r[0] if not hasattr(r, 'asDict') else list(r.asDict().values())[0]))

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -10,8 +10,18 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
         rule = (chk.rule_expr or '').strip()
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()
-            if sql and sql[0] == sql[-1] and sql[0] in {'"', "'"}:
-                sql = sql[1:-1].strip()
+            if sql:
+                # Remove any wrapping quotes that may surround the SQL text.
+                if sql[0] == sql[-1] and sql[0] in {'"', "'"}:
+                    sql = sql[1:-1].strip()
+                # Snowflake can surface statements such as `'SELECT ...''` when
+                # values were stored with escaped quotes. Strip any leading or
+                # trailing quote characters that remain so we execute the raw
+                # SQL statement.
+                while sql and sql[0] in {'"', "'"}:
+                    sql = sql[1:].lstrip()
+                while sql and sql[-1] in {'"', "'"}:
+                    sql = sql[:-1].rstrip()
             df = session.sql(sql)
             r = df.collect()[0]
             ok = bool((r[0] if not hasattr(r, 'asDict') else list(r.asDict().values())[0]))


### PR DESCRIPTION
Fix aggregate SQL quoting
- Strip wrapping quotes when executing aggregate rules so aggregate checks run without stray quote syntax errors.
- Refresh snapshot mirror.

------
https://chatgpt.com/codex/tasks/task_e_68f1e5f371c08324a1d0b56a42ad165d