### PR TITLE
Fix Run Now aggregate SQL sanitization

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -12,14 +12,16 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
             sql = rule[len(AGG_PREFIX):].strip()
             if sql:
                 # Remove any wrapping quotes that may surround the SQL text.
-                if sql[0] == sql[-1] and sql[0] in {'"', "'"}:
+                while len(sql) >= 2 and sql[0] == sql[-1] and sql[0] in {'"', "'"}:
                     sql = sql[1:-1].strip()
                 # Snowflake can surface statements such as `'SELECT ...''` when
                 # values were stored with escaped quotes. Strip any leading or
                 # trailing quote characters that remain so we execute the raw
                 # SQL statement.
+                sql = sql.lstrip()
                 while sql and sql[0] in {'"', "'"}:
                     sql = sql[1:].lstrip()
+                sql = sql.rstrip()
                 while sql and sql[-1] in {'"', "'"}:
                     sql = sql[:-1].rstrip()
             df = session.sql(sql)

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -12,14 +12,16 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
             sql = rule[len(AGG_PREFIX):].strip()
             if sql:
                 # Remove any wrapping quotes that may surround the SQL text.
-                if sql[0] == sql[-1] and sql[0] in {'"', "'"}:
+                while len(sql) >= 2 and sql[0] == sql[-1] and sql[0] in {'"', "'"}:
                     sql = sql[1:-1].strip()
                 # Snowflake can surface statements such as `'SELECT ...''` when
                 # values were stored with escaped quotes. Strip any leading or
                 # trailing quote characters that remain so we execute the raw
                 # SQL statement.
+                sql = sql.lstrip()
                 while sql and sql[0] in {'"', "'"}:
                     sql = sql[1:].lstrip()
+                sql = sql.rstrip()
                 while sql and sql[-1] in {'"', "'"}:
                     sql = sql[:-1].rstrip()
             df = session.sql(sql)

--- a/snapshots/utils/checkdefs.p
+++ b/snapshots/utils/checkdefs.p
@@ -55,7 +55,7 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         max_age = int(params.get("max_age_minutes", 1920))
         return "\n".join([
             f"SELECT (COUNT(*) > 0 AND COUNT(\"{ts_col}\") > 0 AND",
-            f"        TIMESTAMPDIFF(MINUTE, MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
+            f"        TIMESTAMPDIFF('minute', MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
             f"FROM {_q(fqn)}",
         ]), True
     if ttype == "ROW_COUNT":

--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -68,6 +68,15 @@ def run_dq_config(session: Session, CONFIG_ID: str) -> str:
             is_agg = rule_expr_upper.startswith(AGG_PREFIX) or check_type.upper().startswith("AGG")
             if is_agg:
                 agg_sql = rule_expr_raw[len(AGG_PREFIX):].strip() if rule_expr_upper.startswith(AGG_PREFIX) else rule_expr_raw
+                if agg_sql:
+                    while len(agg_sql) >= 2 and agg_sql[0] == agg_sql[-1] and agg_sql[0] in {'"', "'"}:
+                        agg_sql = agg_sql[1:-1].strip()
+                    agg_sql = agg_sql.lstrip()
+                    while agg_sql and agg_sql[0] in {'"', "'"}:
+                        agg_sql = agg_sql[1:].lstrip()
+                    agg_sql = agg_sql.rstrip()
+                    while agg_sql and agg_sql[-1] in {'"', "'"}:
+                        agg_sql = agg_sql[:-1].rstrip()
                 result_rows = session.sql(agg_sql).collect()
                 first_value = result_rows[0][0] if result_rows else False
                 ok = _normalize_bool(first_value)

--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -55,7 +55,7 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         max_age = int(params.get("max_age_minutes", 1920))
         return "\n".join([
             f"SELECT (COUNT(*) > 0 AND COUNT(\"{ts_col}\") > 0 AND",
-            f"        TIMESTAMPDIFF(MINUTE, MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
+            f"        TIMESTAMPDIFF('minute', MAX(\"{ts_col}\"), CURRENT_TIMESTAMP()) <= {max_age}) AS OK",
             f"FROM {_q(fqn)}",
         ]), True
     if ttype == "ROW_COUNT":


### PR DESCRIPTION
Fix Run Now aggregate SQL sanitization
- strip any lingering quote characters around aggregate statements in the stored procedure before execution
- ensure Run Now executions no longer send malformed SQL when legacy rules contain wrapped statements

------
https://chatgpt.com/codex/tasks/task_e_68f1e7e854048324bfbfc639702b4beb