### PR TITLE
Fix AGG SQL execution quoting safeguards

### DIFF
--- a/snapshots/utils/checkdefs.p
+++ b/snapshots/utils/checkdefs.p
@@ -104,11 +104,15 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         ts_col = _quote_identifier(ts_col_raw)
         max_age = int(params.get("max_age_minutes", 1920))
         table_name = _quote_table_fqn(fqn)
-        return "\n".join([
+        rule_lines = [
             "SELECT (COUNT(*) > 0 AND COUNT({col}) > 0 AND".format(col=ts_col),
             "        TIMESTAMPDIFF('minute', MAX({col}), CURRENT_TIMESTAMP()) <= {max_age}) AS OK".format(col=ts_col, max_age=max_age),
             f"FROM {table_name}",
-        ]), True
+        ]
+        rule_sql = "\n".join(rule_lines).strip()
+        if rule_sql.endswith(';'):
+            rule_sql = rule_sql[:-1].rstrip()
+        return rule_sql, True
     if ttype == "ROW_COUNT":
         min_rows = int(params.get("min_rows", 1))
         table_name = _quote_table_fqn(fqn)

--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -69,16 +69,16 @@ def run_dq_config(session: Session, CONFIG_ID: str) -> str:
         try:
             is_agg = rule_expr_upper.startswith(AGG_PREFIX) or check_type.upper().startswith("AGG")
             if is_agg:
-                agg_sql = rule_expr_raw[len(AGG_PREFIX):].strip() if rule_expr_upper.startswith(AGG_PREFIX) else rule_expr_raw
-                if agg_sql:
-                    while len(agg_sql) >= 2 and agg_sql[0] == agg_sql[-1] and agg_sql[0] in {'"', "'"}:
-                        agg_sql = agg_sql[1:-1].strip()
-                    agg_sql = agg_sql.lstrip()
-                    while agg_sql and agg_sql[0] in {'"', "'"}:
-                        agg_sql = agg_sql[1:].lstrip()
-                    agg_sql = agg_sql.rstrip()
-                    while agg_sql and agg_sql[-1] in {'"', "'"}:
-                        agg_sql = agg_sql[:-1].rstrip()
+                agg_raw = rule_expr_raw[len(AGG_PREFIX):] if rule_expr_upper.startswith(AGG_PREFIX) else rule_expr_raw
+                agg_sql = (agg_raw or "").strip()
+                if agg_sql.endswith(';'):
+                    agg_sql = agg_sql[:-1]
+                agg_sql = agg_sql.strip()
+                upper_sql = agg_sql.upper()
+                if 'FROM ' in upper_sql and agg_sql.strip().upper().endswith('FROM'):
+                    raise ValueError(f"Incomplete SQL (ends after FROM). SQL[:200]={agg_sql[:200]}")
+                if agg_sql.count('"') % 2 != 0:
+                    raise ValueError(f"Unbalanced double quotes in AGG SQL. SQL[:200]={agg_sql[:200]}")
                 result_rows = session.sql(agg_sql).collect()
                 first_value = result_rows[0][0] if result_rows else False
                 ok = _normalize_bool(first_value)
@@ -98,7 +98,7 @@ def run_dq_config(session: Session, CONFIG_ID: str) -> str:
             failures = 0
             context_sql = agg_sql or failure_sql
             if context_sql:
-                error_msg = f"{exc} | SQL: {context_sql}"
+                error_msg = f"{exc} | SQL[:200]={context_sql[:200]}"
             else:
                 error_msg = str(exc)
 

--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -104,11 +104,15 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         ts_col = _quote_identifier(ts_col_raw)
         max_age = int(params.get("max_age_minutes", 1920))
         table_name = _quote_table_fqn(fqn)
-        return "\n".join([
+        rule_lines = [
             "SELECT (COUNT(*) > 0 AND COUNT({col}) > 0 AND".format(col=ts_col),
             "        TIMESTAMPDIFF('minute', MAX({col}), CURRENT_TIMESTAMP()) <= {max_age}) AS OK".format(col=ts_col, max_age=max_age),
             f"FROM {table_name}",
-        ]), True
+        ]
+        rule_sql = "\n".join(rule_lines).strip()
+        if rule_sql.endswith(';'):
+            rule_sql = rule_sql[:-1].rstrip()
+        return rule_sql, True
     if ttype == "ROW_COUNT":
         min_rows = int(params.get("min_rows", 1))
         table_name = _quote_table_fqn(fqn)


### PR DESCRIPTION
TASK: Fix AGG SQL execution so we never strip trailing quotes from FQNs.
- Prevent DQ_RUN_CONFIG from removing identifier quotes, add sanity checks, and improve error context.
- Ensure FRESHNESS rule builder returns semicolon-free SQL while preserving FQN quoting.
- Update mirrored snapshots.

------
https://chatgpt.com/codex/tasks/task_e_68f1fcabb30c8324bb7986f9cda13b64