### PR TITLE
fix monitor chart timezone alignment

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1040,7 +1040,7 @@ def render_monitor():
     total_failures = int(failed_df["failures_num"].sum())
     configs_affected = int(failed_df["config_id"].nunique())
 
-    today = pd.Timestamp.utcnow().normalize()
+    today = pd.Timestamp.now(tz="UTC").normalize().tz_localize(None)
     start_date = today - pd.Timedelta(days=int(days) - 1)
     all_dates = pd.date_range(start=start_date, end=today, freq="D")
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1040,7 +1040,7 @@ def render_monitor():
     total_failures = int(failed_df["failures_num"].sum())
     configs_affected = int(failed_df["config_id"].nunique())
 
-    today = pd.Timestamp.utcnow().normalize()
+    today = pd.Timestamp.now(tz="UTC").normalize().tz_localize(None)
     start_date = today - pd.Timedelta(days=int(days) - 1)
     all_dates = pd.date_range(start=start_date, end=today, freq="D")
 


### PR DESCRIPTION
## Summary
- ensure monitor timeline date range uses timezone-naive dates for grouping
- refresh mirrored snapshot file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1ff02eef483249d97253d14bbedf4