### PR TITLE
Replace deprecated Streamlit query param getter

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -93,12 +93,9 @@ def _get_page_from_query_params() -> Optional[str]:
     allowed = {"home", "cfg", "monitor", "docs"}
     candidate: Optional[str] = None
     try:
-        params = st.experimental_get_query_params()
-    except AttributeError:
-        try:
-            params = dict(st.query_params)  # type: ignore[attr-defined]
-        except Exception:
-            params = {}
+        params = dict(st.query_params)  # type: ignore[attr-defined]
+    except Exception:
+        params = {}
     value = params.get("page") if isinstance(params, dict) else None
     if isinstance(value, list):
         candidate = next((item for item in value if isinstance(item, str)), None)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -93,12 +93,9 @@ def _get_page_from_query_params() -> Optional[str]:
     allowed = {"home", "cfg", "monitor", "docs"}
     candidate: Optional[str] = None
     try:
-        params = st.experimental_get_query_params()
-    except AttributeError:
-        try:
-            params = dict(st.query_params)  # type: ignore[attr-defined]
-        except Exception:
-            params = {}
+        params = dict(st.query_params)  # type: ignore[attr-defined]
+    except Exception:
+        params = {}
     value = params.get("page") if isinstance(params, dict) else None
     if isinstance(value, list):
         candidate = next((item for item in value if isinstance(item, str)), None)


### PR DESCRIPTION
- Replace usage of `st.experimental_get_query_params` with `st.query_params` for page routing.
- Refresh the mirrored `/snapshots` entry for `streamlit_app.py`.

------
https://chatgpt.com/codex/tasks/task_e_68f218739cb88324a26b95a4a5d91d83