### PR TITLE
Safeguards & perf improvements

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 import streamlit as st
@@ -144,28 +144,126 @@ def open_config_editor(
     st.session_state["editor_target_fqn"] = target_fqn
     st.rerun()
 
+
+def _session_cache_token(session_obj) -> str:
+    for attr in ("session_id", "_session_id"):
+        token = getattr(session_obj, attr, None)
+        if token:
+            return str(token)
+    getter = getattr(session_obj, "get_session_id", None)
+    if callable(getter):
+        try:
+            token = getter()
+            if token:
+                return str(token)
+        except Exception:
+            pass
+    return str(id(session_obj))
+
+
+def _list_databases_cached(session_obj) -> List[str]:
+    if not session_obj:
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_databases(cache_token: str) -> List[str]:
+        try:
+            return list_databases(session_obj)
+        except Exception as exc:
+            st.error(f"Failed to list databases: {exc}")
+            return []
+
+    return _load_databases(_session_cache_token(session_obj))
+
+
+def _list_schemas_cached(session_obj, database: str) -> List[str]:
+    if not session_obj or not database:
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_schemas(cache_token: Tuple[str, str]) -> List[str]:
+        _, db_name = cache_token
+        try:
+            return list_schemas(session_obj, db_name)
+        except Exception as exc:
+            st.error(f"Failed to list schemas for {db_name}: {exc}")
+            return []
+
+    return _load_schemas((_session_cache_token(session_obj), database))
+
+
+def _list_tables_cached(session_obj, database: str, schema: str) -> List[str]:
+    if not session_obj or not (database and schema):
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_tables(cache_token: Tuple[str, str, str]) -> List[str]:
+        _, db_name, schema_name = cache_token
+        try:
+            return list_tables(session_obj, db_name, schema_name)
+        except Exception as exc:
+            st.error(f"Failed to list tables for {db_name}.{schema_name}: {exc}")
+            return []
+
+    return _load_tables((_session_cache_token(session_obj), database, schema))
+
+
+def _list_columns_cached(session_obj, database: str, schema: str, table: str) -> List[str]:
+    if not session_obj or not (database and schema and table):
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_columns(cache_token: Tuple[str, str, str, str]) -> List[str]:
+        _, db_name, schema_name, table_name = cache_token
+        try:
+            return list_columns(session_obj, db_name, schema_name, table_name)
+        except Exception as exc:
+            st.error(f"Failed to list columns for {db_name}.{schema_name}.{table_name}: {exc}")
+            return []
+
+    return _load_columns((_session_cache_token(session_obj), database, schema, table))
+
+
 def stateless_table_picker(preselect_fqn: Optional[str]):
     """Simple, stateless DB → Schema → Table picker. Returns (db, schema, table, fqn)."""
+
     def split_fqn(fqn):
-        if not fqn or fqn.count(".") != 2: return None, None, None
-        a,b,c = [p.strip('"') for p in fqn.split(".")]
-        return a,b,c
+        if not fqn or fqn.count(".") != 2:
+            return None, None, None
+        a, b, c = [p.strip('"') for p in fqn.split(".")]
+        return a, b, c
+
     pre_db, pre_sch, pre_tbl = split_fqn(preselect_fqn or "")
 
-    dbs = list_databases(session)
-    db_index = next((i for i,v in enumerate(dbs) if pre_db and v.upper()==pre_db.upper()), 0) if dbs else 0
+    dbs = _list_databases_cached(session)
+    db_index = (
+        next((i for i, v in enumerate(dbs) if pre_db and v.upper() == pre_db.upper()), 0)
+        if dbs
+        else 0
+    )
     db_sel = st.selectbox("Database", dbs or ["— none —"], index=db_index if dbs else 0)
-    if not dbs or db_sel == "— none —": return None, None, None, ""
+    if not dbs or db_sel == "— none —":
+        return None, None, None, ""
 
-    schemas = list_schemas(session, db_sel)
-    sch_index = next((i for i,v in enumerate(schemas) if pre_sch and v.upper()==pre_sch.upper()), 0) if schemas else 0
+    schemas = _list_schemas_cached(session, db_sel)
+    sch_index = (
+        next((i for i, v in enumerate(schemas) if pre_sch and v.upper() == pre_sch.upper()), 0)
+        if schemas
+        else 0
+    )
     sch_sel = st.selectbox("Schema", schemas or ["— none —"], index=sch_index if schemas else 0)
-    if not schemas or sch_sel == "— none —": return db_sel, None, None, ""
+    if not schemas or sch_sel == "— none —":
+        return db_sel, None, None, ""
 
-    tables = list_tables(session, db_sel, sch_sel)
-    tbl_index = next((i for i,v in enumerate(tables) if pre_tbl and v.upper()==pre_tbl.upper()), 0) if tables else 0
+    tables = _list_tables_cached(session, db_sel, sch_sel)
+    tbl_index = (
+        next((i for i, v in enumerate(tables) if pre_tbl and v.upper() == pre_tbl.upper()), 0)
+        if tables
+        else 0
+    )
     tbl_sel = st.selectbox("Table", tables or ["— none —"], index=tbl_index if tables else 0)
-    if not tables or tbl_sel == "— none —": return db_sel, sch_sel, None, ""
+    if not tables or tbl_sel == "— none —":
+        return db_sel, sch_sel, None, ""
 
     return db_sel, sch_sel, tbl_sel, fq_table(db_sel, sch_sel, tbl_sel)
 
@@ -398,7 +496,11 @@ def render_config_editor():
     st.caption(f"Target Table: {target_table or '— not selected —'}")
 
     # Columns (outside form). Sanitize defaults to avoid widget errors.
-    available_cols = list_columns(session, db_sel, sch_sel, tbl_sel) if (db_sel and sch_sel and tbl_sel) else []
+    available_cols = (
+        _list_columns_cached(session, db_sel, sch_sel, tbl_sel)
+        if (db_sel and sch_sel and tbl_sel)
+        else []
+    )
     st.markdown("### Columns")
     if existing_checks and "dq_cols_ms" not in st.session_state:
         raw_default = sorted({c.column_name for c in existing_checks if c.column_name})

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 import streamlit as st
@@ -144,28 +144,126 @@ def open_config_editor(
     st.session_state["editor_target_fqn"] = target_fqn
     st.rerun()
 
+
+def _session_cache_token(session_obj) -> str:
+    for attr in ("session_id", "_session_id"):
+        token = getattr(session_obj, attr, None)
+        if token:
+            return str(token)
+    getter = getattr(session_obj, "get_session_id", None)
+    if callable(getter):
+        try:
+            token = getter()
+            if token:
+                return str(token)
+        except Exception:
+            pass
+    return str(id(session_obj))
+
+
+def _list_databases_cached(session_obj) -> List[str]:
+    if not session_obj:
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_databases(cache_token: str) -> List[str]:
+        try:
+            return list_databases(session_obj)
+        except Exception as exc:
+            st.error(f"Failed to list databases: {exc}")
+            return []
+
+    return _load_databases(_session_cache_token(session_obj))
+
+
+def _list_schemas_cached(session_obj, database: str) -> List[str]:
+    if not session_obj or not database:
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_schemas(cache_token: Tuple[str, str]) -> List[str]:
+        _, db_name = cache_token
+        try:
+            return list_schemas(session_obj, db_name)
+        except Exception as exc:
+            st.error(f"Failed to list schemas for {db_name}: {exc}")
+            return []
+
+    return _load_schemas((_session_cache_token(session_obj), database))
+
+
+def _list_tables_cached(session_obj, database: str, schema: str) -> List[str]:
+    if not session_obj or not (database and schema):
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_tables(cache_token: Tuple[str, str, str]) -> List[str]:
+        _, db_name, schema_name = cache_token
+        try:
+            return list_tables(session_obj, db_name, schema_name)
+        except Exception as exc:
+            st.error(f"Failed to list tables for {db_name}.{schema_name}: {exc}")
+            return []
+
+    return _load_tables((_session_cache_token(session_obj), database, schema))
+
+
+def _list_columns_cached(session_obj, database: str, schema: str, table: str) -> List[str]:
+    if not session_obj or not (database and schema and table):
+        return []
+
+    @st.cache_data(ttl=300, show_spinner=False)
+    def _load_columns(cache_token: Tuple[str, str, str, str]) -> List[str]:
+        _, db_name, schema_name, table_name = cache_token
+        try:
+            return list_columns(session_obj, db_name, schema_name, table_name)
+        except Exception as exc:
+            st.error(f"Failed to list columns for {db_name}.{schema_name}.{table_name}: {exc}")
+            return []
+
+    return _load_columns((_session_cache_token(session_obj), database, schema, table))
+
+
 def stateless_table_picker(preselect_fqn: Optional[str]):
     """Simple, stateless DB → Schema → Table picker. Returns (db, schema, table, fqn)."""
+
     def split_fqn(fqn):
-        if not fqn or fqn.count(".") != 2: return None, None, None
-        a,b,c = [p.strip('"') for p in fqn.split(".")]
-        return a,b,c
+        if not fqn or fqn.count(".") != 2:
+            return None, None, None
+        a, b, c = [p.strip('"') for p in fqn.split(".")]
+        return a, b, c
+
     pre_db, pre_sch, pre_tbl = split_fqn(preselect_fqn or "")
 
-    dbs = list_databases(session)
-    db_index = next((i for i,v in enumerate(dbs) if pre_db and v.upper()==pre_db.upper()), 0) if dbs else 0
+    dbs = _list_databases_cached(session)
+    db_index = (
+        next((i for i, v in enumerate(dbs) if pre_db and v.upper() == pre_db.upper()), 0)
+        if dbs
+        else 0
+    )
     db_sel = st.selectbox("Database", dbs or ["— none —"], index=db_index if dbs else 0)
-    if not dbs or db_sel == "— none —": return None, None, None, ""
+    if not dbs or db_sel == "— none —":
+        return None, None, None, ""
 
-    schemas = list_schemas(session, db_sel)
-    sch_index = next((i for i,v in enumerate(schemas) if pre_sch and v.upper()==pre_sch.upper()), 0) if schemas else 0
+    schemas = _list_schemas_cached(session, db_sel)
+    sch_index = (
+        next((i for i, v in enumerate(schemas) if pre_sch and v.upper() == pre_sch.upper()), 0)
+        if schemas
+        else 0
+    )
     sch_sel = st.selectbox("Schema", schemas or ["— none —"], index=sch_index if schemas else 0)
-    if not schemas or sch_sel == "— none —": return db_sel, None, None, ""
+    if not schemas or sch_sel == "— none —":
+        return db_sel, None, None, ""
 
-    tables = list_tables(session, db_sel, sch_sel)
-    tbl_index = next((i for i,v in enumerate(tables) if pre_tbl and v.upper()==pre_tbl.upper()), 0) if tables else 0
+    tables = _list_tables_cached(session, db_sel, sch_sel)
+    tbl_index = (
+        next((i for i, v in enumerate(tables) if pre_tbl and v.upper() == pre_tbl.upper()), 0)
+        if tables
+        else 0
+    )
     tbl_sel = st.selectbox("Table", tables or ["— none —"], index=tbl_index if tables else 0)
-    if not tables or tbl_sel == "— none —": return db_sel, sch_sel, None, ""
+    if not tables or tbl_sel == "— none —":
+        return db_sel, sch_sel, None, ""
 
     return db_sel, sch_sel, tbl_sel, fq_table(db_sel, sch_sel, tbl_sel)
 
@@ -398,7 +496,11 @@ def render_config_editor():
     st.caption(f"Target Table: {target_table or '— not selected —'}")
 
     # Columns (outside form). Sanitize defaults to avoid widget errors.
-    available_cols = list_columns(session, db_sel, sch_sel, tbl_sel) if (db_sel and sch_sel and tbl_sel) else []
+    available_cols = (
+        _list_columns_cached(session, db_sel, sch_sel, tbl_sel)
+        if (db_sel and sch_sel and tbl_sel)
+        else []
+    )
     st.markdown("### Columns")
     if existing_checks and "dq_cols_ms" not in st.session_state:
         raw_default = sorted({c.column_name for c in existing_checks if c.column_name})


### PR DESCRIPTION
Safeguards & perf

- Allow full-table profiling scans while warning on large row counts and cap column top-N results to 10.
- Cache table, schema, column, and column-metadata lookups in the Streamlit UI and profile view for 5 minutes.
- Treat sampling values of 0 or None as full scans throughout profiling services and refresh snapshots.

------
https://chatgpt.com/codex/tasks/task_e_68f2463eb96c83249445d826e2d4ef11