### PR TITLE
Update query param handling for Streamlit navigation

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -118,19 +118,14 @@ def navigate_to(page: str) -> None:
     """Update the current page selection in session state."""
     st.session_state["page"] = page
     try:
-        # Streamlit < 1.32
-        st.experimental_set_query_params(page=page)
-    except AttributeError:
-        # Streamlit >= 1.32 exposes ``st.query_params``
-        try:
-            current = dict(st.query_params)  # type: ignore[attr-defined]
-        except Exception:
-            current = {}
-        current["page"] = page
-        try:
-            st.query_params = current  # type: ignore[attr-defined]
-        except Exception:
-            pass
+        current = dict(st.query_params)  # type: ignore[attr-defined]
+    except Exception:
+        current = {}
+    current["page"] = page
+    try:
+        st.query_params = current  # type: ignore[attr-defined]
+    except Exception:
+        pass
     if page == "home":
         st.session_state["cfg_mode"] = "list"
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -118,19 +118,14 @@ def navigate_to(page: str) -> None:
     """Update the current page selection in session state."""
     st.session_state["page"] = page
     try:
-        # Streamlit < 1.32
-        st.experimental_set_query_params(page=page)
-    except AttributeError:
-        # Streamlit >= 1.32 exposes ``st.query_params``
-        try:
-            current = dict(st.query_params)  # type: ignore[attr-defined]
-        except Exception:
-            current = {}
-        current["page"] = page
-        try:
-            st.query_params = current  # type: ignore[attr-defined]
-        except Exception:
-            pass
+        current = dict(st.query_params)  # type: ignore[attr-defined]
+    except Exception:
+        current = {}
+    current["page"] = page
+    try:
+        st.query_params = current  # type: ignore[attr-defined]
+    except Exception:
+        pass
     if page == "home":
         st.session_state["cfg_mode"] = "list"
 


### PR DESCRIPTION
- replace the deprecated `st.experimental_set_query_params` usage with `st.query_params` for page navigation
- refresh the mirrored snapshots to capture the updated Streamlit app

------
https://chatgpt.com/codex/tasks/task_e_68f5c80f68f0832481b2cfbeb971febb