### PR TITLE
fix: refresh profile UI after run

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -176,6 +176,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     "top_n": int(top_n),
                 }
                 st.session_state["profile_results"] = profile_result
+                st.rerun()
 
     if suggest_cfg and profile_result:
         suggestion = build_profile_suggestion(profile_result)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -176,6 +176,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     "top_n": int(top_n),
                 }
                 st.session_state["profile_results"] = profile_result
+                st.rerun()
 
     if suggest_cfg and profile_result:
         suggestion = build_profile_suggestion(profile_result)


### PR DESCRIPTION
- trigger a rerun after saving profile results so the suggestion button enables
- mirror the updated profile view into the snapshots directory

------
https://chatgpt.com/codex/tasks/task_e_68f5cf777c348324a20085b7f017302a