### PR TITLE
Task 3 — Show guessed content in Profiling view (badges, filters)

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -32,6 +32,9 @@ class ColumnProfile:
     whitespace_pct: Optional[float]
     top_values: List[Dict[str, Any]]
     error: Optional[str] = None
+    semantic_type: Optional[str] = None
+    confidence: Optional[float] = None
+    rationale: Optional[str] = None
 
 
 def _split_fqn(fqn: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -115,6 +118,9 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
                 "whitespace_pct": round(profile.whitespace_pct, 2) if profile.whitespace_pct is not None else None,
                 "top_values": profile.top_values,
                 "error": profile.error,
+                "semantic_type": profile.semantic_type,
+                "confidence": profile.confidence,
+                "rationale": profile.rationale,
             }
         )
     df = pd.DataFrame.from_records(records)
@@ -130,11 +136,95 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
             "max_val",
             "avg_len",
             "whitespace_pct",
+            "semantic_type",
+            "confidence",
+            "rationale",
             "error",
         ]
         missing = [c for c in display_cols if c not in df.columns]
         df = df.reindex(columns=[c for c in display_cols if c not in missing] + [c for c in df.columns if c not in display_cols])
     return df
+
+
+def _confidence_badge_label(confidence: Optional[float]) -> str:
+    if confidence is None or (isinstance(confidence, float) and math.isnan(confidence)):
+        return "Unknown"
+    if confidence >= 0.9:
+        return "High"
+    if confidence >= 0.75:
+        return "Medium"
+    return "Low"
+
+
+def _format_confidence(value: Any) -> str:
+    try:
+        if value is None:
+            return ""
+        value_float = float(value)
+        if math.isnan(value_float):
+            return ""
+        return f"{value_float:.0%}"
+    except Exception:
+        return ""
+
+
+def _badge_css(value: Any) -> str:
+    label = str(value or "Unknown")
+    styles = {
+        "High": "background-color: #0f9960; color: #ffffff;",
+        "Medium": "background-color: #f7b731; color: #2b2b2b;",
+        "Low": "background-color: #9aa0a6; color: #1f1f1f;",
+        "Unknown": "background-color: #dfe1e5; color: #1f1f1f;",
+    }
+    base = styles.get(label, styles["Unknown"])
+    return "; ".join(
+        [
+            base.rstrip(";"),
+            "border-radius: 12px",
+            "font-weight: 600",
+            "text-align: center",
+            "padding: 0.15rem 0.4rem",
+            "display: inline-block",
+            "min-width: 4rem",
+        ]
+    )
+
+
+def _tooltip_styles() -> List[Dict[str, Any]]:
+    base_class = "confidence-tooltip"
+    text_class = f"{base_class}-text"
+    return [
+        {
+            "selector": f".{base_class}",
+            "props": [
+                ("position", "relative"),
+                ("display", "inline-block"),
+            ],
+        },
+        {
+            "selector": f".{base_class} .{text_class}",
+            "props": [
+                ("visibility", "hidden"),
+                ("width", "240px"),
+                ("background-color", "#31333F"),
+                ("color", "#ffffff"),
+                ("text-align", "left"),
+                ("border-radius", "4px"),
+                ("padding", "0.4rem"),
+                ("position", "absolute"),
+                ("z-index", "1"),
+                ("bottom", "125%"),
+                ("left", "50%"),
+                ("margin-left", "-120px"),
+                ("box-shadow", "0 2px 6px rgba(0, 0, 0, 0.2)"),
+                ("font-size", "0.75rem"),
+            ],
+        },
+        {
+            "selector": f".{base_class}:hover .{text_class}",
+            "props": [("visibility", "visible")],
+        },
+    ]
 
 
 def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: ARG001 - interface matches requirement
@@ -254,6 +344,9 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                             whitespace_pct=column.get("whitespace_pct"),
                             top_values=column.get("top_values") or [],
                             error=column.get("error"),
+                            semantic_type=column.get("semantic_type"),
+                            confidence=column.get("confidence"),
+                            rationale=column.get("rationale"),
                         )
                     )
                 profile_result = {
@@ -322,6 +415,13 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         unique_candidates = filter_cols[1].toggle("Unique candidates", value=False)
         low_cardinality = filter_cols[2].toggle("Low cardinality", value=False)
         whitespace_risk = filter_cols[3].toggle("Whitespace risk", value=False)
+        st.markdown("**Semantic tags**")
+        semantic_cols = st.columns(5)
+        filter_identifiers = semantic_cols[0].checkbox("Identifiers", value=False)
+        filter_financial = semantic_cols[1].checkbox("Financial", value=False)
+        filter_instrument = semantic_cols[2].checkbox("Instrument", value=False)
+        filter_geo = semantic_cols[3].checkbox("Geo", value=False)
+        filter_contact = semantic_cols[4].checkbox("Contact", value=False)
 
     save_enabled = bool(session and meta_db and meta_schema)
     if not save_enabled:
@@ -390,11 +490,69 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     if whitespace_risk:
         filtered_df = filtered_df[(filtered_df["whitespace_pct"].fillna(0) > 5)]
 
-    st.dataframe(
-        filtered_df.drop(columns=["top_values"], errors="ignore"),
-        hide_index=True,
-        use_container_width=True,
-    )
+    semantic_filter_map = {
+        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN"},
+        "Financial": {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
+        "Instrument": {"ISIN", "TICKER/SYMBOL"},
+        "Geo": {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
+        "Contact": {"EMAIL", "PHONE"},
+    }
+    active_semantic_filters: List[str] = []
+    if filter_identifiers:
+        active_semantic_filters.append("Identifiers")
+    if filter_financial:
+        active_semantic_filters.append("Financial")
+    if filter_instrument:
+        active_semantic_filters.append("Instrument")
+    if filter_geo:
+        active_semantic_filters.append("Geo")
+    if filter_contact:
+        active_semantic_filters.append("Contact")
+
+    if active_semantic_filters:
+        allowed_types = set()
+        for key in active_semantic_filters:
+            allowed_types.update(semantic_filter_map.get(key, set()))
+        filtered_df = filtered_df[filtered_df["semantic_type"].isin(allowed_types)]
+    display_df = filtered_df.drop(columns=["top_values"], errors="ignore").copy()
+    if not display_df.empty:
+        display_df["Confidence"] = display_df["confidence"].apply(lambda val: float(val) if val is not None else None)
+        display_df["Confidence Badge"] = display_df["confidence"].apply(_confidence_badge_label)
+        rationale_series = filtered_df.get("rationale", pd.Series(dtype="object"))
+        display_df = display_df.drop(columns=["confidence"], errors="ignore")
+        display_df = display_df.rename(columns={"semantic_type": "Guessed Type"})
+        ordered_columns = [
+            "column_name",
+            "data_type",
+            "Guessed Type",
+            "Confidence Badge",
+            "Confidence",
+            "nulls",
+            "null_pct",
+            "distincts",
+            "distinct_pct",
+            "min_val",
+            "max_val",
+            "avg_len",
+            "whitespace_pct",
+            "error",
+            "rationale",
+        ]
+        display_df = display_df[[col for col in ordered_columns if col in display_df.columns] + [
+            col for col in display_df.columns if col not in ordered_columns
+        ]]
+        tooltip_df = pd.DataFrame("", index=display_df.index, columns=display_df.columns)
+        tooltip_df["Confidence Badge"] = rationale_series.reindex(display_df.index).fillna("")
+        styler = (
+            display_df.style.format({"Confidence": _format_confidence})
+            .applymap(_badge_css, subset=["Confidence Badge"])
+            .set_tooltips(tooltip_df, css_class="confidence-tooltip")
+            .hide(axis="columns", subset=["rationale"])
+            .set_table_styles(_tooltip_styles(), overwrite=False)
+        )
+        st.dataframe(styler, hide_index=True, use_container_width=True)
+    else:
+        st.dataframe(display_df, hide_index=True, use_container_width=True)
 
     if filtered_df.empty:
         st.info("No columns matched the selected filters.")

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -32,6 +32,9 @@ class ColumnProfile:
     whitespace_pct: Optional[float]
     top_values: List[Dict[str, Any]]
     error: Optional[str] = None
+    semantic_type: Optional[str] = None
+    confidence: Optional[float] = None
+    rationale: Optional[str] = None
 
 
 def _split_fqn(fqn: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -115,6 +118,9 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
                 "whitespace_pct": round(profile.whitespace_pct, 2) if profile.whitespace_pct is not None else None,
                 "top_values": profile.top_values,
                 "error": profile.error,
+                "semantic_type": profile.semantic_type,
+                "confidence": profile.confidence,
+                "rationale": profile.rationale,
             }
         )
     df = pd.DataFrame.from_records(records)
@@ -130,11 +136,95 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
             "max_val",
             "avg_len",
             "whitespace_pct",
+            "semantic_type",
+            "confidence",
+            "rationale",
             "error",
         ]
         missing = [c for c in display_cols if c not in df.columns]
         df = df.reindex(columns=[c for c in display_cols if c not in missing] + [c for c in df.columns if c not in display_cols])
     return df
+
+
+def _confidence_badge_label(confidence: Optional[float]) -> str:
+    if confidence is None or (isinstance(confidence, float) and math.isnan(confidence)):
+        return "Unknown"
+    if confidence >= 0.9:
+        return "High"
+    if confidence >= 0.75:
+        return "Medium"
+    return "Low"
+
+
+def _format_confidence(value: Any) -> str:
+    try:
+        if value is None:
+            return ""
+        value_float = float(value)
+        if math.isnan(value_float):
+            return ""
+        return f"{value_float:.0%}"
+    except Exception:
+        return ""
+
+
+def _badge_css(value: Any) -> str:
+    label = str(value or "Unknown")
+    styles = {
+        "High": "background-color: #0f9960; color: #ffffff;",
+        "Medium": "background-color: #f7b731; color: #2b2b2b;",
+        "Low": "background-color: #9aa0a6; color: #1f1f1f;",
+        "Unknown": "background-color: #dfe1e5; color: #1f1f1f;",
+    }
+    base = styles.get(label, styles["Unknown"])
+    return "; ".join(
+        [
+            base.rstrip(";"),
+            "border-radius: 12px",
+            "font-weight: 600",
+            "text-align: center",
+            "padding: 0.15rem 0.4rem",
+            "display: inline-block",
+            "min-width: 4rem",
+        ]
+    )
+
+
+def _tooltip_styles() -> List[Dict[str, Any]]:
+    base_class = "confidence-tooltip"
+    text_class = f"{base_class}-text"
+    return [
+        {
+            "selector": f".{base_class}",
+            "props": [
+                ("position", "relative"),
+                ("display", "inline-block"),
+            ],
+        },
+        {
+            "selector": f".{base_class} .{text_class}",
+            "props": [
+                ("visibility", "hidden"),
+                ("width", "240px"),
+                ("background-color", "#31333F"),
+                ("color", "#ffffff"),
+                ("text-align", "left"),
+                ("border-radius", "4px"),
+                ("padding", "0.4rem"),
+                ("position", "absolute"),
+                ("z-index", "1"),
+                ("bottom", "125%"),
+                ("left", "50%"),
+                ("margin-left", "-120px"),
+                ("box-shadow", "0 2px 6px rgba(0, 0, 0, 0.2)"),
+                ("font-size", "0.75rem"),
+            ],
+        },
+        {
+            "selector": f".{base_class}:hover .{text_class}",
+            "props": [("visibility", "visible")],
+        },
+    ]
 
 
 def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: ARG001 - interface matches requirement
@@ -254,6 +344,9 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                             whitespace_pct=column.get("whitespace_pct"),
                             top_values=column.get("top_values") or [],
                             error=column.get("error"),
+                            semantic_type=column.get("semantic_type"),
+                            confidence=column.get("confidence"),
+                            rationale=column.get("rationale"),
                         )
                     )
                 profile_result = {
@@ -322,6 +415,13 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         unique_candidates = filter_cols[1].toggle("Unique candidates", value=False)
         low_cardinality = filter_cols[2].toggle("Low cardinality", value=False)
         whitespace_risk = filter_cols[3].toggle("Whitespace risk", value=False)
+        st.markdown("**Semantic tags**")
+        semantic_cols = st.columns(5)
+        filter_identifiers = semantic_cols[0].checkbox("Identifiers", value=False)
+        filter_financial = semantic_cols[1].checkbox("Financial", value=False)
+        filter_instrument = semantic_cols[2].checkbox("Instrument", value=False)
+        filter_geo = semantic_cols[3].checkbox("Geo", value=False)
+        filter_contact = semantic_cols[4].checkbox("Contact", value=False)
 
     save_enabled = bool(session and meta_db and meta_schema)
     if not save_enabled:
@@ -390,11 +490,81 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     if whitespace_risk:
         filtered_df = filtered_df[(filtered_df["whitespace_pct"].fillna(0) > 5)]
 
-    st.dataframe(
-        filtered_df.drop(columns=["top_values"], errors="ignore"),
-        hide_index=True,
-        use_container_width=True,
-    )
+    semantic_filter_map = {
+        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN"},
+        "Financial": {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
+        "Instrument": {"ISIN", "TICKER/SYMBOL"},
+        "Geo": {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
+        "Contact": {"EMAIL", "PHONE"},
+    }
+    active_semantic_filters: List[str] = []
+    if filter_identifiers:
+        active_semantic_filters.append("Identifiers")
+    if filter_financial:
+        active_semantic_filters.append("Financial")
+    if filter_instrument:
+        active_semantic_filters.append("Instrument")
+    if filter_geo:
+        active_semantic_filters.append("Geo")
+    if filter_contact:
+        active_semantic_filters.append("Contact")
+
+    if active_semantic_filters:
+        allowed_types = set()
+        for key in active_semantic_filters:
+            allowed_types.update(semantic_filter_map.get(key, set()))
+        filtered_df = filtered_df[filtered_df["semantic_type"].isin(allowed_types)]
+    display_df = filtered_df.drop(columns=["top_values"], errors="ignore").copy()
+    if not display_df.empty:
+        if "confidence" in display_df.columns:
+            display_df["Confidence"] = display_df["confidence"].apply(
+                lambda val: float(val) if val is not None else None
+            )
+            display_df["Confidence Badge"] = display_df["confidence"].apply(_confidence_badge_label)
+            display_df = display_df.drop(columns=["confidence"], errors="ignore")
+        else:
+            display_df["Confidence"] = None
+            display_df["Confidence Badge"] = "Unknown"
+        rationale_series = filtered_df.get("rationale", pd.Series(dtype="object"))
+        display_df = display_df.rename(columns={"semantic_type": "Guessed Type"})
+        if "Guessed Type" in display_df.columns:
+            display_df["Guessed Type"] = display_df["Guessed Type"].fillna("Unknown")
+        ordered_columns = [
+            "column_name",
+            "data_type",
+            "Guessed Type",
+            "Confidence Badge",
+            "Confidence",
+            "nulls",
+            "null_pct",
+            "distincts",
+            "distinct_pct",
+            "min_val",
+            "max_val",
+            "avg_len",
+            "whitespace_pct",
+            "error",
+            "rationale",
+        ]
+        display_df = display_df[[col for col in ordered_columns if col in display_df.columns] + [
+            col for col in display_df.columns if col not in ordered_columns
+        ]]
+        tooltip_df = pd.DataFrame("", index=display_df.index, columns=display_df.columns)
+        if "Confidence Badge" in tooltip_df.columns:
+            tooltip_df["Confidence Badge"] = rationale_series.reindex(display_df.index).fillna("")
+        styler = display_df.style.format({"Confidence": _format_confidence})
+        if "Confidence Badge" in display_df.columns:
+            styler = styler.applymap(_badge_css, subset=["Confidence Badge"])
+        styler = styler.set_tooltips(tooltip_df, css_class="confidence-tooltip")
+        hide_columns: List[str] = []
+        if "rationale" in display_df.columns:
+            hide_columns.append("rationale")
+        if hide_columns:
+            styler = styler.hide(axis="columns", subset=hide_columns)
+        styler = styler.set_table_styles(_tooltip_styles(), overwrite=False)
+        st.dataframe(styler, hide_index=True, use_container_width=True)
+    else:
+        st.dataframe(display_df, hide_index=True, use_container_width=True)
 
     if filtered_df.empty:
         st.info("No columns matched the selected filters.")


### PR DESCRIPTION
Task 3 — Show guessed content in Profiling view (badges, filters)

- expose semantic type, confidence, and rationale data in the profiling view dataclass and frame builder
- display guessed type with confidence badges and tooltip styling while formatting confidence percentages
- add semantic quick filters (identifiers, financial, instrument, geo, contact) to the profiling grid alongside existing filters

------
https://chatgpt.com/codex/tasks/task_e_68f608af46c4832488a117c7bf2ddf24