### PR TITLE
Docs: polish tone, spacing, and export readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,87 @@
-# zeus_data_quality
+# Zeus Data Quality
 
-Interim data quality solution for Zeus until a governance-native alternative is available.
+Zeus Data Quality brings monitoring, profiling, and remediation workflows directly into Snowflake so data owners can spot and resolve issues before they affect reporting.
+
+## Product snapshot
+- **Use case**: Centralise data quality rules for business-critical tables without exporting data.
+- **Audience**: Data stewards, analytics teams, and governance leads who need audit-ready oversight.
+- **Delivery**: Streamlit in Snowflake front end, Snowpark stored procedures, and scheduled Snowflake tasks.
+
+> **Note:** The Streamlit application inherits the active Snowsight session. Role, warehouse, and database context stay with the signed-in user.
 
 ## Version history
 
 | Version | Highlights |
 |---------|------------|
-| v1.3    | Added profiling feature and support for guessed content recommendations. |
-| v1.2    | Incremental usability and stability refinements. |
-| v1.1    | Streamlined configuration flows and scheduling defaults. |
-| v1.0    | Base application release. |
+| v1.3    | Added profiling capabilities and semantic recommendations.
+| v1.2    | Improved usability flows and hardened scheduling defaults.
+| v1.1    | Simplified configuration and task orchestration.
+| v1.0    | Initial release.
 
-## Technical overview
+## Platform overview
 
-> **Platform & Tools used**
-> - Design iterations pair **ChatGPT (GPT-5 Thinking)** with the **Codex execution container** for controlled code changes.
-> - **GitHub Actions** orchestrate CI and mirror repository sources into Snowflake-friendly `.p` snapshots.
-> - This toolchain balances rapid delivery with auditable, reproducible change management.
-
-### Architecture
-- **Streamlit-in-Snowflake (SiS)** hosts the primary UI (`streamlit_app.py`). The app runs with the current Snowflake session context and never issues `USE` statements; role, warehouse, and database selection stay inherited from Snowsight.
-- **Snowpark** powers data processing inside stored procedures and Dynamic Table Function (DMF) evaluations. Snowpark sessions are bound to the Streamlit session’s context and respect the `EXECUTE AS CALLER` pattern to avoid privilege elevation surprises.
-- **Dynamic Masking Functions (DMFs)** back the profiling and semantics engines by returning views of failing rows. Aggregate checks (`AGG:`) execute within Snowpark and push summarized results back into metadata tables instead of DMF outputs.
-- **Tasks and stored procedures**: every saved configuration creates a `DQ_TASK_<CONFIG_ID>` task scheduled for 08:00 Europe/Berlin. Tasks call the `DQ_RUN_CONFIG(VARCHAR)` stored procedure, which orchestrates Snowpark jobs and writes outcomes to `DQ_RESULTS` tables.
-- _Diagram placeholders_: `docs/diagrams/architecture.png` for the high-level platform flow and `docs/diagrams/data-movement.png` for task orchestration (to be supplied).
+### Application architecture
+- **Streamlit in Snowflake** hosts the UI (`streamlit_app.py`) and runs inside the customer Snowflake account.
+- **Snowpark** executes stored procedures and Dynamic Monitoring Framework (DMF) checks in-database, respecting caller context.
+- **DMF views** expose failing rows for each rule, while aggregate checks summarise results in metadata tables.
+- **Scheduled tasks** (`DQ_TASK_<CONFIG_ID>`) call `DQ_RUN_CONFIG(VARCHAR)` each morning at 08:00 Europe/Berlin.
 
 ### Modules and services
-- **Profiling** (`services/profiling`, `utils/profile_rules.py`): calculates column-level statistics, DMF validation rules, and anomaly thresholds.
-- **Semantics** (`services/semantics`, `views/semantics`): defines table- and column-level business rules, including DMF-backed failed-row surfacing.
-- **Scheduling** (`services/scheduler`, `sql/CREATE_RESULTS_AND_SP.SQL`): handles task creation, cron alignment, and stored procedure deployment.
-- **Meta utilities** (`utils`, `tools`): shared helpers for Snowflake connectivity, logging, migration management, and snapshot mirroring.
+- **Profiling** (`services/profiling`, `utils/profile_rules.py`): Computes statistics, semantic tags, and recommendations.
+- **Semantics** (`services/semantics`, `views/semantics`): Manages business rules and DMF-backed failure surfacing.
+- **Scheduling** (`services/scheduler`, `sql/CREATE_RESULTS_AND_SP.SQL`): Creates tasks and deploys stored procedures.
+- **Shared utilities** (`utils`, `tools`): Cover Snowflake connectivity, logging, migrations, and snapshot mirroring.
 
-### Developer platform and delivery flow
-- Primary development happens through **ChatGPT (GPT-5 Thinking)** paired with the **Codex container** for local execution and testing.
-- GitHub flow relies on short-lived feature branches targeting `dev_bs`. The “Auto PR & Squash Merge to dev_bs” workflow opens pull requests automatically, waits for checks, squashes, and deletes merged branches. Developers never push to `main` or `dev_bs` directly.
-- Snapshot mirroring keeps `.py` sources accessible in restricted environments: `tools/mirror_snapshots.py` mirrors code into `/snapshots/*.p`, with `.github/workflows/mirror-snapshots.yml` committing updates on pushes to `dev_bs`.
-- Auto-generated pull requests require concise titles and bullet-point summaries. All CI workflows must remain enabled to preserve the automation chain.
+### Delivery guardrails
+- Develop on short-lived branches that target `dev_bs`; rely on the "Auto PR & Squash Merge to dev_bs" workflow for merges.
+- Keep snapshot mirroring enabled via `tools/mirror_snapshots.py` and `.github/workflows/mirror-snapshots.yml`.
+- Maintain concise pull request titles with bullet summaries; do not disable existing CI workflows.
 
-### Operational constraints and preflight checks
-- Streamlit SQL must use positional `?` parameters with `params=[...]` (no named parameters) and omit `USE` statements to comply with Snowsight execution restrictions.
-- Stored procedures execute with `EXECUTE AS CALLER`; every new procedure should be reviewed to ensure no inadvertent privilege escalation.
-- Bootstrap scripts perform preflight checks for metadata tables (`DQ_CONFIG`, `DQ_CHECK`, `DQ_RESULTS`) and stored procedures. Run `sql/run_dq_config.sql` if preflight validation fails before enabling schedules.
+## Operational guidance
 
-## Source snapshots for copy/paste
-To view code in environments where `.py` is blocked, this repo generates read-only mirrors under `/snapshots` with `.p` extension.
+### Preflight checklist
+- Use positional `?` parameters with `params=[...]` for all Streamlit SQL execution.
+- Confirm stored procedures run with `EXECUTE AS CALLER` to keep privileges aligned with Snowflake roles.
+- Run the bootstrap scripts (`sql/run_dq_config.sql`) if metadata tables (`DQ_CONFIG`, `DQ_CHECK`, `DQ_RESULTS`) are missing.
 
-Run:
-  python -m tools snapshot
+### Working with source snapshots
+To support environments that block `.py` files, the repository mirrors all Python sources into `/snapshots` with `.p` extensions.
 
-Outputs:
-  - snapshots/<same structure>.p
-  - snapshots/SOURCE_SNAPSHOT.md
+```
+python -m tools snapshot
+```
 
-Do not edit files in `/snapshots`; they are generated from the real sources.
+Outputs include mirrored files under `/snapshots` and a generated `snapshots/SOURCE_SNAPSHOT.md`. Do not edit snapshot files directly; rerun the mirror script instead.
 
-## Data governance for EU and German stakeholders
+## Data governance commitments
 
-### Regulatory alignment made simple
-- **GDPR**: Customer datasets stay inside Snowflake’s EU region. We only persist configuration metadata, run logs, and profiling statistics—never the underlying personal data values. Metadata is scoped to the minimum necessary fields, fulfilling data minimisation and purpose limitation duties.
-- **BaFin circulars & supervisory expectations**: Governance controls (roles, approvals, audit trail) remain embedded in the Snowflake security model so financial institutions can evidence proportional safeguards without re-platforming.
-- **MiFID II record-keeping**: Historical task runs, check definitions, and remediation notes are retained to demonstrate monitoring of data feeding regulated reporting.
-- **EU AI Act (draft principles)**: Optional AI-assisted features observe transparency and human-in-the-loop principles, working exclusively on metadata and retaining prompt/response fingerprints for traceability.
+### Regulatory alignment
+- **GDPR**: All processing occurs in the Snowflake EU region; only metadata, logs, and profiling statistics persist.
+- **BaFin**: Role-based approvals and audit trails stay within the Snowflake security model for supervised institutions.
+- **MiFID II**: Historical tasks, check definitions, and remediation notes remain available for regulatory evidence.
+- **EU AI Act (draft)**: Optional AI-assisted features focus on metadata, retain prompt fingerprints, and enforce human oversight.
 
-### What the platform stores—and what it avoids
-- **Configurations**: Check definitions, scheduling metadata, and Snowflake object references only.
-- **Task and run results**: Status flags, row counts, exception summaries, timestamps, and operator notes. Profiling and AI helper features log statistics (e.g., min/max, distinct counts) but never surface raw values.
-- **No PII export**: Profiling outputs, semantic checks, and AI recommendations rely on metadata. Sample rows or customer-identifying values never leave the secure Snowflake tenancy.
-- **EU-only processing**: All computation and storage sit in the customer’s Snowflake EU account; the Streamlit front-end reuses the active Snowsight session without rerouting traffic abroad.
+### What is stored
+- **Configurations**: Object references, scheduling metadata, and rule definitions.
+- **Run results**: Status values, row counts, summaries, timestamps, and operator notes.
+- **Profiling outputs**: Aggregated statistics only—no raw personal data.
 
-### Access control and operational safety nets
-- **Roles-first access**: Streamlit executes `EXECUTE AS CALLER`, inheriting the signed-in user’s Snowflake role. Only authorised roles can view configurations or results; sensitive views remain masked downstream.
-- **Role-gated advanced features**: AI-assisted prompts can be toggled per configuration and are visible only to users with the `DQ_AI_REVIEWER` role (or the customer-defined equivalent).
-- **Audit trail clarity**: Every run records the triggering task, execution timestamps, Snowflake role, and outcome. When AI assistance is enabled, the prompt hash, anonymised prompt payload, and model identifier are stored alongside the run metadata for traceability.
+### Access and safety controls
+- Streamlit executes with the caller's role; access to configurations and results follows Snowflake grants.
+- AI-assisted prompts are role-gated (for example, `DQ_AI_REVIEWER`) and default to manual review.
+- Every run logs its triggering task, role, timing, and procedure outcome for traceability.
 
-### Data quality dimensions and enforcing checks
-- **Completeness**: Null/blank detection rules and row-count comparisons ensure required attributes are populated.
-- **Accuracy**: Range validations, referential checks, and semantic rules compare metadata against trusted reference sources.
-- **Consistency**: Cross-table reconciliations and format validations catch mismatches between related datasets.
-- **Timeliness**: Task schedules monitor late-arriving data by comparing expected and actual refresh timestamps.
-- **Uniqueness**: Key integrity checks flag duplicate business identifiers or unexpected cardinality changes.
+### Quality dimensions
+- **Completeness**: Null detection and row-count comparisons.
+- **Accuracy**: Range, referential, and semantic checks.
+- **Consistency**: Cross-table and format validations.
+- **Timeliness**: Freshness checks against timestamp columns.
+- **Uniqueness**: Duplicate detection for key identifiers.
 
-Each dimension maps to explicit check templates stored in the configuration metadata and executed within Snowpark; failed checks land in metadata tables for remediation without exposing raw customer data.
+### Customer data protections
+- AI helpers use metadata only; raw values never enter model prompts.
+- Statistical insights, schema drift indicators, and anomaly scores drive recommendations while keeping PII protected.
+- Feature toggles allow organisations to disable AI helpers globally or per configuration.
+- Operators see which model assisted, review prompt hashes, and approve guidance before it becomes active.
 
-### Customer data protection messaging
-- **No raw data to language models**: Optional AI helpers summarise profiling metadata only. Raw customer data never enters model prompts or responses.
-- **Metadata-only insights**: Statistical summaries, schema drift indicators, and anomaly scores drive recommendations while keeping PII shielded.
-- **Feature toggles for comfort**: Organisations can disable AI helpers globally or per configuration; defaults favour manual review in regulated environments.
-- **Transparent operator experience**: Users see when AI assistance is active, which model provided guidance, and can review prompt hashes before accepting suggestions.
-
-This governance layer gives compliance, risk, and business teams a shared language for understanding how Zeus Data Quality protects customer information while maintaining the rigor expected by EU and German regulators.
+Zeus Data Quality provides a shared foundation for compliance, risk, and business teams to monitor critical Snowflake assets without moving data out of the platform.

--- a/readme_dev.md
+++ b/readme_dev.md
@@ -1,18 +1,30 @@
-# Zeus Data Quality — Dev Notes
+# Zeus Data Quality — Developer Notes
 
-- Entrypoint: `streamlit_app.py` (Streamlit-in-Snowflake).
-- SQL params: use positional `?` with `params=[...]` (no named dict params).
-- “DMFs” are **views of failing rows**; aggregate checks (`AGG:`) are **not attached**.
-- Discovery via **INFORMATION_SCHEMA** (SHOW fallback). **No `RESULT_SCAN`**.
-- Picker is **stateless**; editor persists one key: `editor_target_fqn`.
-- Metadata tables: `DQ_CONFIG`, `DQ_CHECK` (created automatically).
-- Daily task: `DQ_TASK_<CONFIG_ID>` at 08:00 Europe/Berlin.
+This reference keeps implementation details crisp so engineers can support the Streamlit application and Snowflake assets without digging through code.
 
-## First run
-- Open the app in Snowsight. The Configurations page will create tables on first save.
-- If you see permission errors, check role/warehouse privileges.
+## Core entry points
+- **Streamlit app**: `streamlit_app.py` (Streamlit in Snowflake deployment).
+- **Configuration storage**: `DQ_CONFIG`, `DQ_CHECK`, and `DQ_RUN_RESULTS` metadata tables.
+- **Runner procedure**: `DQ_RUN_CONFIG(VARCHAR)` orchestrates DMF and aggregate checks.
+
+> **Tip:** The table picker remains stateless. Persist the selected table in `editor_target_fqn` when reopening the editor.
+
+## First run checklist
+1. Open the app in Snowsight. Saving the first configuration creates metadata tables automatically.
+2. Confirm the active role and warehouse can create tasks and execute stored procedures in the metadata schema.
+3. If permissions fail, rerun [`sql/CREATE_RESULTS_AND_SP.SQL`](sql/CREATE_RESULTS_AND_SP.SQL) or `sql/run_dq_config.sql`.
+
+## Working with SQL from Streamlit
+- Always use positional placeholders (`?`) with `params=[...]`; named parameters are blocked in Snowsight Streamlit.
+- DMF artefacts are views of failing rows. Aggregate checks (prefixed `AGG:`) never materialise DMF views.
+- Discovery pulls from `INFORMATION_SCHEMA` (with `SHOW` as a fallback) and avoids `RESULT_SCAN` usage.
+
+## Scheduling behaviour
+- Each configuration maps to `DQ_TASK_<CONFIG_ID>` scheduled for 08:00 Europe/Berlin.
+- Tasks call the stored procedure with `EXECUTE AS CALLER`, inheriting the user’s context and warehouse.
+- Toggle enablement directly in Streamlit; the app creates, resumes, or suspends the Snowflake task as needed.
 
 ## Troubleshooting task creation
-- Creating a schedule requires the stored procedure `DQ_RUN_CONFIG(VARCHAR)` to be deployed in the metadata schema (the same database + schema that contain `DQ_CONFIG` and `DQ_CHECK`).
-- If the Configurations page reports `Stored procedure DQ_RUN_CONFIG(VARCHAR) not found` or the task creation error `SQL compilation error: Object does not exist`, rerun the bootstrap script from [`sql/CREATE_RESULTS_AND_SP.SQL`](sql/CREATE_RESULTS_AND_SP.SQL) (or `sql/run_dq_config.sql`) in the desired schema to redeploy the stored procedure.
-- After redeploying the stored procedure, retry enabling the schedule from the app. Tasks are created as `DQ_TASK_<CONFIG_ID>` in the metadata schema and require access to the target warehouse.
+- Missing procedure errors (`Object does not exist`) point to the runner procedure being absent from the metadata schema.
+- After redeploying the procedure, retry schedule creation so the task can bind to the target warehouse.
+- Review `DQ_RUN_RESULTS` for the latest execution message if a run fails after scheduling.

--- a/snapshots/views/docs_view.p
+++ b/snapshots/views/docs_view.p
@@ -35,7 +35,7 @@ def render_docs(
     run_results_table: str,
 ) -> None:
     """Render the documentation tabs for the Streamlit application."""
-    st.header("📘 Zeus Data Quality – Documentation")
+    st.header("Zeus Data Quality documentation")
 
     tabs = st.tabs(
         [
@@ -79,37 +79,39 @@ def render_docs(
         st.subheader("User Guide")
         st.markdown(
             """
-### What this app does
-- **Purpose**: Keeps critical tables under watch so data issues are caught before they reach reporting.
-- **Audience**: Data owners, analysts, and ops leads who need a quick health summary without writing SQL.
+#### What the app delivers
+- **Purpose**: Monitor critical Snowflake tables so issues surface before reporting deadlines.
+- **Audience**: Data owners, analysts, and operations leads who prefer guided workflows over ad-hoc SQL.
 
-### Create a configuration
-1. **Select a source** – choose the database, schema, and table you care about.
-2. **Name the setup** – give the configuration a business-friendly name so others recognise it.
-3. **Pick columns** – for each column decide which checks should guard it.
-4. **Review table-level options** – confirm the timestamp used for freshness and volume tracking.
-5. **Save & Apply** – the app stores the rules and schedules the daily run (08:00 Europe/Berlin by default).
+#### Create a configuration
+1. **Select a source** – choose the database, schema, and table to protect.
+2. **Name the setup** – use a business-friendly title so teams recognise the coverage.
+3. **Pick columns** – decide which checks apply to each column based on risk.
+4. **Review table options** – confirm the timestamp and warehouse before saving.
+5. **Save and apply** – the configuration is stored and the daily 08:00 (Europe/Berlin) task is scheduled.
 
-### Checks in plain language
-- **Uniqueness**: Flags duplicate values where every row should be distinct (for example, order IDs).
-- **Null Count**: Watches how many blanks appear so missing information is caught quickly.
-- **Minimum / Maximum**: Ensures numbers stay within an acceptable range, highlighting outliers.
-- **Whitespace**: Spots accidental leading or trailing spaces that can break joins or filters.
-- **Format Distribution**: Monitors standard patterns such as IBAN, ISIN, or email formats and alerts when the mix changes.
-- **Value Distribution**: Tracks the share of categories (e.g., product types) and calls out unusual shifts.
-- **Freshness**: Confirms new records keep arriving on time based on the chosen timestamp column.
-- **Row Count Anomaly**: Detects sudden spikes or drops in total rows compared with recent history.
-- **Aggregate (AGG) Checks**: Custom business rules that summarise data (for example, totals or ratios) to confirm aggregated results still look right.
+> **Tip:** Use **Save** to draft changes and **Save and apply** once the table is ready for monitoring.
 
-### Run & monitor results
-- **Run Now** triggers an immediate evaluation when you want to double-check a change.
-- **Daily task** executes automatically using the saved schedule so you get continuous coverage.
-- **Results** appear on the Monitor page where you can filter by table, check type, or status and download issue details.
+#### Checks in plain language
+- **Uniqueness** identifies duplicate business keys.
+- **Null count** tracks missing information.
+- **Minimum/maximum** keeps numeric ranges within agreed limits.
+- **Whitespace** flags leading or trailing spaces that break joins.
+- **Format distribution** watches identifier patterns such as IBAN, ISIN, or email.
+- **Value distribution** monitors the mix of categories and highlights unusual shifts.
+- **Freshness** confirms data arrives on time based on the chosen timestamp column.
+- **Row count anomaly** spots sudden volume changes relative to recent history.
+- **Aggregate checks** support custom totals or ratios when business validation requires them.
 
-### Troubleshooting basics
-- **Warehouse**: Make sure the designated compute warehouse is running and has capacity.
-- **Role**: Use the business role granted access to the monitored tables and metadata schema.
-- **Procedure**: If runs fail, review the latest procedure message in the Monitor tab or rerun the stored procedure from Snowflake with the configuration name.
+#### Run and monitor results
+- **Run now** performs an immediate evaluation for spot checks.
+- **Daily tasks** operate automatically once a schedule is enabled.
+- **Monitor** surfaces outcomes with filters by table, check type, or status; results can be downloaded for follow-up.
+
+#### Troubleshooting essentials
+- Verify the Snowflake warehouse is running and sized for the workload.
+- Confirm the active role has access to the source objects and metadata schema.
+- Review stored procedure messages in the Monitor tab or execute the procedure manually for detailed logs.
             """
         )
 
@@ -117,79 +119,73 @@ def render_docs(
         st.subheader("Profiling")
         st.markdown(
             """
-### Why profile first?
-Profiling runs lightweight column statistics so you understand shape, completeness, and content **before** locking a data quality policy. It highlights high-risk fields, confirms business keys, and surfaces unexpected formats that deserve a rule.
+#### Why profile first
+Profiling runs lightweight column statistics so you understand data shape and completeness before finalising monitoring rules. The output points to high-risk fields, validates business keys, and surfaces unexpected formats.
 
-### Metrics collected per column
-- **Null % / Null count** – identify missing data hotspots.
-- **Distinct % / Distinct count** – confirm uniqueness or spot categorical fields.
-- **Min / Max** – verify ranges for numbers and timestamps.
-- **Average length** – catch truncated strings or atypical ID lengths.
-- **Whitespace %** – flags leading/trailing spaces that break joins.
-- **Top values** – show the most common values (configurable Top N) to reveal dominant categories or odd outliers.
+#### Metrics collected per column
+- **Null percentage and count** highlight missing data hotspots.
+- **Distinct percentage and count** confirm uniqueness or signal categorical fields.
+- **Minimum and maximum** verify numeric and timestamp ranges.
+- **Average length** spots truncated strings or inconsistent identifiers.
+- **Whitespace percentage** exposes formatting issues that can break joins.
+- **Top values** display the most frequent categories or potential outliers.
 
-### Guessed content & confidence
-- Each column receives semantic badges such as **IBAN**, **ISIN**, **EMAIL**, **ACCOUNT_ID**, **ORDER_ID**, **PRICE**, **CURRENCY**, **COUNTRY**, **TIMESTAMP**, **ENUM**, and more depending on detected patterns.
-- Confidence badges are colour coded: **High** (green), **Medium** (amber), **Low** (grey), and **Unknown** (neutral) when the profiler has insufficient evidence.
-- Hover the *Confidence Rationale* tooltip in the grid for a short explanation (e.g., "Regex match on 92% of rows" or "Length variance too high").
+#### Semantic insights and confidence
+- Columns receive semantic suggestions such as IBAN, ISIN, email, account ID, country, or timestamp based on detected patterns.
+- Confidence levels appear as High, Medium, Low, or Unknown with colour coding in the grid.
+- Hover the **Confidence rationale** tooltip to see why a tag was chosen (for example, "Regex match on 92% of rows").
 
-### Filters that guide DQ design
-- Toggle filters for **High null %**, **Unique candidates**, **Low cardinality**, and **Whitespace risk** to find columns that deserve specific checks.
-- Use semantic tag filters (Identifiers, Financial, Instrument, Geo, Contact) to focus on IBAN/ISIN/email style fields when planning format, uniqueness, or reference validations.
-- Combine the insights to decide which fields need **uniqueness**, **null bounds**, **pattern** or **distribution** checks inside the Configurations editor.
+#### Filters that guide design
+- Apply filters for high null percentage, unique candidates, low cardinality, or whitespace risk to shortlist columns.
+- Use semantic tag filters (Identifiers, Financial, Instrument, Geography, Contact) to concentrate on sensitive fields.
+- Combine these insights to select uniqueness, null, pattern, or distribution checks inside the configuration editor.
 
-### Performance & accuracy notes
-- Sampling defaults to the recommended percentage (typically 10%) based on table size. Set the input to **0** for a full scan when accuracy matters more than speed.
-- Distinct counts switch to Snowflake `APPROX_COUNT_DISTINCT` automatically when the profiler touches large row volumes, trading tiny error (<1%) for faster feedback.
+#### Performance and accuracy notes
+- Sampling defaults to a recommended percentage based on table size; set the value to `0` when a full scan is required.
+- Large tables automatically switch distinct counts to `APPROX_COUNT_DISTINCT`, balancing accuracy (within ~1%) and speed.
 - The summary banner reports rows profiled, sampling choice, and runtime so you can judge cost before rerunning.
 
-### Persisting and using results
-- Enable **💾 Save Profile** (once a Snowflake session and metadata targets are configured) to store the run in metadata for auditing or to compare over time.
-- Click **✨ Suggest DQ Config** after a run to pre-fill the configuration editor with recommended column checks based on the discovered metrics, speeding up the creation of a new monitoring setup.
+#### Persisting and reusing results
+- Enable **Save profile** once metadata targets are configured to store runs for auditing or historical comparison.
+- Use **Suggest DQ config** after profiling to pre-populate the configuration editor with recommended checks.
             """
         )
 
     with tabs[2]:
-        st.subheader("Snowflake-native DQ Framework narrative")
+        st.subheader("Snowflake-native data quality framework")
         st.markdown(
             f"""
 ### Data Monitoring Framework (DMF) checks
-* **Purpose**: Every row-level rule becomes a Data Monitoring Framework (DMF) check that Snowflake can execute in-database.
-* **Failing-row views**: For each active check we create `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` inside `{_safe_quote(metadata_db)}.{_safe_quote(metadata_schema)}`.
-  * View body: `SELECT * FROM <source> WHERE NOT (<rule_predicate>)` so investigators can explore bad rows without copying data.
-  * **Safety**: Names are generated from UUID-style identifiers to avoid collisions, and views are created with `CREATE OR REPLACE` to prevent residual state.
-* **Attach / detach lifecycle**:
-  * On **Save & Apply**, DMF checks are created or refreshed and granted to the application role as needed.
-  * On delete or when a config detaches from a table, the app drops only the unused views (skipping shared tables) to keep the metadata schema clean.
+- Each row-level rule becomes a DMF view that runs inside Snowflake.
+- Failing rows surface in `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` within `{_safe_quote(metadata_db)}.{_safe_quote(metadata_schema)}`.
+- Views follow the pattern `SELECT * FROM <source> WHERE NOT (<rule_predicate>)`, using generated identifiers to avoid collisions.
+- Save and apply creates or refreshes the views and grants access. Removing a config cleans up unused artefacts.
 
-### Aggregate (AGG) table-level checks
-* Freshness and Row Count Anomaly run as **aggregate SQL queries** directly against the source table.
-* Because they summarise the whole table (no row payload), they do **not** materialise DMF views—results are stored only in `{run_results_table}`.
-* Freshness compares the latest timestamp in the chosen column, while Row Count Anomaly uses robust statistics over recent daily totals to spot spikes or droughts.
+### Aggregate table-level checks
+- Freshness and row-count anomaly checks execute as aggregate SQL directly against the source table.
+- Because they summarise the entire table, they store only results in `{run_results_table}` and do not create DMF views.
+- Freshness compares the latest timestamp in the monitored column; row-count anomaly looks at recent history for spikes or droughts.
 
 ### Stored procedures orchestrating runs
-* `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` is a Snowpark Python stored procedure.
-  * Accepts a configuration ID, executes every check (DMF and AGG), captures failure counts, and records outcomes in `{run_results_table}`.
-* `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages scheduling via **EXECUTE AS CALLER** so Snowflake authorisation stays with the business role.
-  * Handles create/update for tasks, enforces warehouse selection, and flips enablement flags without leaving the platform.
+- `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` (Snowpark Python) receives a configuration ID, evaluates every check, and records outcomes in `{run_results_table}`.
+- `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages task lifecycle with `EXECUTE AS CALLER`, ensuring warehouse and privilege alignment.
 
 ### Tasks per configuration
-* Each config is paired with a dedicated task: `DQ_TASK_<CONFIG_ID>` within `{metadata_db}.{metadata_schema}`.
-* The task body runs `CALL {proc_name}('<CONFIG_ID>')` and inherits the caller’s warehouse (the app defaults to an internal DQ warehouse unless you override it).
-* Scheduling uses Snowflake cron syntax with IANA time zones, so `0 8 * * * Europe/Berlin` means 08:00 local time every day.
-* Enabling/disabling simply toggles the Snowflake task state—no need for external schedulers.
+- Each configuration owns a Snowflake task `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`.
+- The task runs `CALL {proc_name}('<CONFIG_ID>')`, inheriting the caller's warehouse by default.
+- Cron syntax with IANA time zones supports 08:00 Europe/Berlin schedules and any overrides defined by administrators.
 
 ### Roles, context, and required grants
-* Procedures execute **AS CALLER**, ensuring the running role’s data access policies are honoured.
-* The application expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both stored procedures.
-* When deployed as a Streamlit-in-Snowflake app, ownership of metadata objects stays with the application role so auditors can trace every change.
+- Procedures execute as caller so data access policies remain intact.
+- The app expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both procedures.
+- Streamlit in Snowflake keeps ownership with the application role, simplifying audits and change tracking.
 
-### Why Snowflake for data quality?
-* **In-database compute** keeps checks close to the data—no egress, no shadow copies, just Snowflake warehouses doing the work.
-* **Snowpark Python** powers the runner procedure, letting us blend Python orchestration with native SQL performance.
-* **Streamlit in Snowflake** delivers the UI right where the data lives, eliminating context switching for data stewards.
-* **INFORMATION_SCHEMA & Account Usage** supply rich metadata for monitoring configurations, tasks, and run history.
-* **Governed sharing & roles** ensure DMF views, tasks, and procedures respect enterprise security while still being explorable when incidents occur.
+### Why Snowflake for data quality
+- In-database compute keeps checks near the data—no egress or shadow copies.
+- Snowpark Python combines orchestration logic with native SQL execution.
+- Streamlit in Snowflake provides the UI where teams already work.
+- INFORMATION_SCHEMA and Account Usage power metadata-driven discovery and monitoring.
+- Governed sharing and roles ensure DMF views, tasks, and procedures respect enterprise security boundaries.
             """
         )
 
@@ -268,27 +264,27 @@ digraph W {
         st.subheader("Technical Overview")
         st.markdown(
             f"""
-**Runtime**
-- Streamlit (in Snowflake) using Snowpark Python.
+#### Runtime
+- Streamlit in Snowflake using Snowpark Python.
 
-**Metadata & Results**
+#### Metadata and results
 - Configs: `{cfg_tbl_display}`
-- Checks:  `{chk_tbl_display}`
+- Checks: `{chk_tbl_display}`
 - Results: `{run_results_table}`
 
-**Procedures**
-- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` – evaluates checks and logs into results.
-- Task Manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` – creates/updates task. **EXECUTE AS CALLER**.
+#### Procedures
+- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` evaluates checks and logs to the results table.
+- Task manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` creates or updates tasks and runs as caller.
 
-**Tasks**
-- One per config: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`; body: `CALL {proc_name}('<CONFIG_ID>')`.
+#### Tasks
+- One per configuration: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}` with body `CALL {proc_name}('<CONFIG_ID>')`.
 
-**Warehouses**
-- Schedules run on default app WH (e.g., `DQ_WH`).
+#### Warehouses
+- Schedules run on the default application warehouse (for example, `DQ_WH`).
             """
         )
 
-        st.markdown("**Required Privileges (caller role)**")
+        st.markdown("#### Required privileges for the caller role")
         st.code(
             f"""
 USAGE ON WAREHOUSE DQ_WH
@@ -301,25 +297,24 @@ EXECUTE ON PROCEDURE {metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)
         )
 
     with tabs[4]:
-        st.subheader("Data Governance & Security")
+        st.subheader("Data Governance and Security")
         st.markdown(
             """
-**Roles & Isolation**
-- App runs with a specific **caller role** and uses **EXECUTE AS CALLER** for task management.
-- Config/results live in a dedicated metadata schema to isolate privileges.
+#### Roles and isolation
+- The application runs with a defined caller role and relies on `EXECUTE AS CALLER` when managing tasks.
+- Configuration and results tables live in a dedicated metadata schema to control privileges.
 
-**Traceability**
-- `DQ_RUN_RESULTS` logs: run timestamp, check id/type, failures, `OK` flag, and error messages if any.
-- Tasks: one per config, auditable in ACCOUNT usage views.
+#### Traceability
+- `DQ_RUN_RESULTS` captures timestamps, check identifiers, failure counts, success flags, and error messages.
+- Each configuration owns a Snowflake task, which is auditable through ACCOUNT USAGE views.
 
-**Access Patterns**
-- Read-only access to source tables for checks.
-- Controlled write access only to metadata objects (config/checks/results).
-- DMF failing-row views live in metadata schema (no writes to source).
+#### Access patterns
+- Source tables are read-only; writes are limited to metadata objects for configs, checks, and results.
+- DMF failing-row views remain in the metadata schema so investigators avoid querying production tables directly.
 
-**PII / Sensitive Data**
-- Prefer checks that don’t materialize sensitive columns in logs. Views expose only what investigators need.
-- If required, add column masking on sensitive attributes in metadata views.
+#### Handling sensitive data
+- Prefer checks that avoid materialising personal data in logs; views expose only what investigators need.
+- Apply column masking to metadata views when sensitive attributes require additional protection.
             """
         )
 

--- a/views/docs_view.py
+++ b/views/docs_view.py
@@ -35,7 +35,7 @@ def render_docs(
     run_results_table: str,
 ) -> None:
     """Render the documentation tabs for the Streamlit application."""
-    st.header("📘 Zeus Data Quality – Documentation")
+    st.header("Zeus Data Quality documentation")
 
     tabs = st.tabs(
         [
@@ -79,37 +79,39 @@ def render_docs(
         st.subheader("User Guide")
         st.markdown(
             """
-### What this app does
-- **Purpose**: Keeps critical tables under watch so data issues are caught before they reach reporting.
-- **Audience**: Data owners, analysts, and ops leads who need a quick health summary without writing SQL.
+#### What the app delivers
+- **Purpose**: Monitor critical Snowflake tables so issues surface before reporting deadlines.
+- **Audience**: Data owners, analysts, and operations leads who prefer guided workflows over ad-hoc SQL.
 
-### Create a configuration
-1. **Select a source** – choose the database, schema, and table you care about.
-2. **Name the setup** – give the configuration a business-friendly name so others recognise it.
-3. **Pick columns** – for each column decide which checks should guard it.
-4. **Review table-level options** – confirm the timestamp used for freshness and volume tracking.
-5. **Save & Apply** – the app stores the rules and schedules the daily run (08:00 Europe/Berlin by default).
+#### Create a configuration
+1. **Select a source** – choose the database, schema, and table to protect.
+2. **Name the setup** – use a business-friendly title so teams recognise the coverage.
+3. **Pick columns** – decide which checks apply to each column based on risk.
+4. **Review table options** – confirm the timestamp and warehouse before saving.
+5. **Save and apply** – the configuration is stored and the daily 08:00 (Europe/Berlin) task is scheduled.
 
-### Checks in plain language
-- **Uniqueness**: Flags duplicate values where every row should be distinct (for example, order IDs).
-- **Null Count**: Watches how many blanks appear so missing information is caught quickly.
-- **Minimum / Maximum**: Ensures numbers stay within an acceptable range, highlighting outliers.
-- **Whitespace**: Spots accidental leading or trailing spaces that can break joins or filters.
-- **Format Distribution**: Monitors standard patterns such as IBAN, ISIN, or email formats and alerts when the mix changes.
-- **Value Distribution**: Tracks the share of categories (e.g., product types) and calls out unusual shifts.
-- **Freshness**: Confirms new records keep arriving on time based on the chosen timestamp column.
-- **Row Count Anomaly**: Detects sudden spikes or drops in total rows compared with recent history.
-- **Aggregate (AGG) Checks**: Custom business rules that summarise data (for example, totals or ratios) to confirm aggregated results still look right.
+> **Tip:** Use **Save** to draft changes and **Save and apply** once the table is ready for monitoring.
 
-### Run & monitor results
-- **Run Now** triggers an immediate evaluation when you want to double-check a change.
-- **Daily task** executes automatically using the saved schedule so you get continuous coverage.
-- **Results** appear on the Monitor page where you can filter by table, check type, or status and download issue details.
+#### Checks in plain language
+- **Uniqueness** identifies duplicate business keys.
+- **Null count** tracks missing information.
+- **Minimum/maximum** keeps numeric ranges within agreed limits.
+- **Whitespace** flags leading or trailing spaces that break joins.
+- **Format distribution** watches identifier patterns such as IBAN, ISIN, or email.
+- **Value distribution** monitors the mix of categories and highlights unusual shifts.
+- **Freshness** confirms data arrives on time based on the chosen timestamp column.
+- **Row count anomaly** spots sudden volume changes relative to recent history.
+- **Aggregate checks** support custom totals or ratios when business validation requires them.
 
-### Troubleshooting basics
-- **Warehouse**: Make sure the designated compute warehouse is running and has capacity.
-- **Role**: Use the business role granted access to the monitored tables and metadata schema.
-- **Procedure**: If runs fail, review the latest procedure message in the Monitor tab or rerun the stored procedure from Snowflake with the configuration name.
+#### Run and monitor results
+- **Run now** performs an immediate evaluation for spot checks.
+- **Daily tasks** operate automatically once a schedule is enabled.
+- **Monitor** surfaces outcomes with filters by table, check type, or status; results can be downloaded for follow-up.
+
+#### Troubleshooting essentials
+- Verify the Snowflake warehouse is running and sized for the workload.
+- Confirm the active role has access to the source objects and metadata schema.
+- Review stored procedure messages in the Monitor tab or execute the procedure manually for detailed logs.
             """
         )
 
@@ -117,79 +119,73 @@ def render_docs(
         st.subheader("Profiling")
         st.markdown(
             """
-### Why profile first?
-Profiling runs lightweight column statistics so you understand shape, completeness, and content **before** locking a data quality policy. It highlights high-risk fields, confirms business keys, and surfaces unexpected formats that deserve a rule.
+#### Why profile first
+Profiling runs lightweight column statistics so you understand data shape and completeness before finalising monitoring rules. The output points to high-risk fields, validates business keys, and surfaces unexpected formats.
 
-### Metrics collected per column
-- **Null % / Null count** – identify missing data hotspots.
-- **Distinct % / Distinct count** – confirm uniqueness or spot categorical fields.
-- **Min / Max** – verify ranges for numbers and timestamps.
-- **Average length** – catch truncated strings or atypical ID lengths.
-- **Whitespace %** – flags leading/trailing spaces that break joins.
-- **Top values** – show the most common values (configurable Top N) to reveal dominant categories or odd outliers.
+#### Metrics collected per column
+- **Null percentage and count** highlight missing data hotspots.
+- **Distinct percentage and count** confirm uniqueness or signal categorical fields.
+- **Minimum and maximum** verify numeric and timestamp ranges.
+- **Average length** spots truncated strings or inconsistent identifiers.
+- **Whitespace percentage** exposes formatting issues that can break joins.
+- **Top values** display the most frequent categories or potential outliers.
 
-### Guessed content & confidence
-- Each column receives semantic badges such as **IBAN**, **ISIN**, **EMAIL**, **ACCOUNT_ID**, **ORDER_ID**, **PRICE**, **CURRENCY**, **COUNTRY**, **TIMESTAMP**, **ENUM**, and more depending on detected patterns.
-- Confidence badges are colour coded: **High** (green), **Medium** (amber), **Low** (grey), and **Unknown** (neutral) when the profiler has insufficient evidence.
-- Hover the *Confidence Rationale* tooltip in the grid for a short explanation (e.g., "Regex match on 92% of rows" or "Length variance too high").
+#### Semantic insights and confidence
+- Columns receive semantic suggestions such as IBAN, ISIN, email, account ID, country, or timestamp based on detected patterns.
+- Confidence levels appear as High, Medium, Low, or Unknown with colour coding in the grid.
+- Hover the **Confidence rationale** tooltip to see why a tag was chosen (for example, "Regex match on 92% of rows").
 
-### Filters that guide DQ design
-- Toggle filters for **High null %**, **Unique candidates**, **Low cardinality**, and **Whitespace risk** to find columns that deserve specific checks.
-- Use semantic tag filters (Identifiers, Financial, Instrument, Geo, Contact) to focus on IBAN/ISIN/email style fields when planning format, uniqueness, or reference validations.
-- Combine the insights to decide which fields need **uniqueness**, **null bounds**, **pattern** or **distribution** checks inside the Configurations editor.
+#### Filters that guide design
+- Apply filters for high null percentage, unique candidates, low cardinality, or whitespace risk to shortlist columns.
+- Use semantic tag filters (Identifiers, Financial, Instrument, Geography, Contact) to concentrate on sensitive fields.
+- Combine these insights to select uniqueness, null, pattern, or distribution checks inside the configuration editor.
 
-### Performance & accuracy notes
-- Sampling defaults to the recommended percentage (typically 10%) based on table size. Set the input to **0** for a full scan when accuracy matters more than speed.
-- Distinct counts switch to Snowflake `APPROX_COUNT_DISTINCT` automatically when the profiler touches large row volumes, trading tiny error (<1%) for faster feedback.
+#### Performance and accuracy notes
+- Sampling defaults to a recommended percentage based on table size; set the value to `0` when a full scan is required.
+- Large tables automatically switch distinct counts to `APPROX_COUNT_DISTINCT`, balancing accuracy (within ~1%) and speed.
 - The summary banner reports rows profiled, sampling choice, and runtime so you can judge cost before rerunning.
 
-### Persisting and using results
-- Enable **💾 Save Profile** (once a Snowflake session and metadata targets are configured) to store the run in metadata for auditing or to compare over time.
-- Click **✨ Suggest DQ Config** after a run to pre-fill the configuration editor with recommended column checks based on the discovered metrics, speeding up the creation of a new monitoring setup.
+#### Persisting and reusing results
+- Enable **Save profile** once metadata targets are configured to store runs for auditing or historical comparison.
+- Use **Suggest DQ config** after profiling to pre-populate the configuration editor with recommended checks.
             """
         )
 
     with tabs[2]:
-        st.subheader("Snowflake-native DQ Framework narrative")
+        st.subheader("Snowflake-native data quality framework")
         st.markdown(
             f"""
 ### Data Monitoring Framework (DMF) checks
-* **Purpose**: Every row-level rule becomes a Data Monitoring Framework (DMF) check that Snowflake can execute in-database.
-* **Failing-row views**: For each active check we create `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` inside `{_safe_quote(metadata_db)}.{_safe_quote(metadata_schema)}`.
-  * View body: `SELECT * FROM <source> WHERE NOT (<rule_predicate>)` so investigators can explore bad rows without copying data.
-  * **Safety**: Names are generated from UUID-style identifiers to avoid collisions, and views are created with `CREATE OR REPLACE` to prevent residual state.
-* **Attach / detach lifecycle**:
-  * On **Save & Apply**, DMF checks are created or refreshed and granted to the application role as needed.
-  * On delete or when a config detaches from a table, the app drops only the unused views (skipping shared tables) to keep the metadata schema clean.
+- Each row-level rule becomes a DMF view that runs inside Snowflake.
+- Failing rows surface in `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` within `{_safe_quote(metadata_db)}.{_safe_quote(metadata_schema)}`.
+- Views follow the pattern `SELECT * FROM <source> WHERE NOT (<rule_predicate>)`, using generated identifiers to avoid collisions.
+- Save and apply creates or refreshes the views and grants access. Removing a config cleans up unused artefacts.
 
-### Aggregate (AGG) table-level checks
-* Freshness and Row Count Anomaly run as **aggregate SQL queries** directly against the source table.
-* Because they summarise the whole table (no row payload), they do **not** materialise DMF views—results are stored only in `{run_results_table}`.
-* Freshness compares the latest timestamp in the chosen column, while Row Count Anomaly uses robust statistics over recent daily totals to spot spikes or droughts.
+### Aggregate table-level checks
+- Freshness and row-count anomaly checks execute as aggregate SQL directly against the source table.
+- Because they summarise the entire table, they store only results in `{run_results_table}` and do not create DMF views.
+- Freshness compares the latest timestamp in the monitored column; row-count anomaly looks at recent history for spikes or droughts.
 
 ### Stored procedures orchestrating runs
-* `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` is a Snowpark Python stored procedure.
-  * Accepts a configuration ID, executes every check (DMF and AGG), captures failure counts, and records outcomes in `{run_results_table}`.
-* `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages scheduling via **EXECUTE AS CALLER** so Snowflake authorisation stays with the business role.
-  * Handles create/update for tasks, enforces warehouse selection, and flips enablement flags without leaving the platform.
+- `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` (Snowpark Python) receives a configuration ID, evaluates every check, and records outcomes in `{run_results_table}`.
+- `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages task lifecycle with `EXECUTE AS CALLER`, ensuring warehouse and privilege alignment.
 
 ### Tasks per configuration
-* Each config is paired with a dedicated task: `DQ_TASK_<CONFIG_ID>` within `{metadata_db}.{metadata_schema}`.
-* The task body runs `CALL {proc_name}('<CONFIG_ID>')` and inherits the caller’s warehouse (the app defaults to an internal DQ warehouse unless you override it).
-* Scheduling uses Snowflake cron syntax with IANA time zones, so `0 8 * * * Europe/Berlin` means 08:00 local time every day.
-* Enabling/disabling simply toggles the Snowflake task state—no need for external schedulers.
+- Each configuration owns a Snowflake task `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`.
+- The task runs `CALL {proc_name}('<CONFIG_ID>')`, inheriting the caller's warehouse by default.
+- Cron syntax with IANA time zones supports 08:00 Europe/Berlin schedules and any overrides defined by administrators.
 
 ### Roles, context, and required grants
-* Procedures execute **AS CALLER**, ensuring the running role’s data access policies are honoured.
-* The application expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both stored procedures.
-* When deployed as a Streamlit-in-Snowflake app, ownership of metadata objects stays with the application role so auditors can trace every change.
+- Procedures execute as caller so data access policies remain intact.
+- The app expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both procedures.
+- Streamlit in Snowflake keeps ownership with the application role, simplifying audits and change tracking.
 
-### Why Snowflake for data quality?
-* **In-database compute** keeps checks close to the data—no egress, no shadow copies, just Snowflake warehouses doing the work.
-* **Snowpark Python** powers the runner procedure, letting us blend Python orchestration with native SQL performance.
-* **Streamlit in Snowflake** delivers the UI right where the data lives, eliminating context switching for data stewards.
-* **INFORMATION_SCHEMA & Account Usage** supply rich metadata for monitoring configurations, tasks, and run history.
-* **Governed sharing & roles** ensure DMF views, tasks, and procedures respect enterprise security while still being explorable when incidents occur.
+### Why Snowflake for data quality
+- In-database compute keeps checks near the data—no egress or shadow copies.
+- Snowpark Python combines orchestration logic with native SQL execution.
+- Streamlit in Snowflake provides the UI where teams already work.
+- INFORMATION_SCHEMA and Account Usage power metadata-driven discovery and monitoring.
+- Governed sharing and roles ensure DMF views, tasks, and procedures respect enterprise security boundaries.
             """
         )
 
@@ -268,27 +264,27 @@ digraph W {
         st.subheader("Technical Overview")
         st.markdown(
             f"""
-**Runtime**
-- Streamlit (in Snowflake) using Snowpark Python.
+#### Runtime
+- Streamlit in Snowflake using Snowpark Python.
 
-**Metadata & Results**
+#### Metadata and results
 - Configs: `{cfg_tbl_display}`
-- Checks:  `{chk_tbl_display}`
+- Checks: `{chk_tbl_display}`
 - Results: `{run_results_table}`
 
-**Procedures**
-- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` – evaluates checks and logs into results.
-- Task Manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` – creates/updates task. **EXECUTE AS CALLER**.
+#### Procedures
+- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` evaluates checks and logs to the results table.
+- Task manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` creates or updates tasks and runs as caller.
 
-**Tasks**
-- One per config: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`; body: `CALL {proc_name}('<CONFIG_ID>')`.
+#### Tasks
+- One per configuration: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}` with body `CALL {proc_name}('<CONFIG_ID>')`.
 
-**Warehouses**
-- Schedules run on default app WH (e.g., `DQ_WH`).
+#### Warehouses
+- Schedules run on the default application warehouse (for example, `DQ_WH`).
             """
         )
 
-        st.markdown("**Required Privileges (caller role)**")
+        st.markdown("#### Required privileges for the caller role")
         st.code(
             f"""
 USAGE ON WAREHOUSE DQ_WH
@@ -301,25 +297,24 @@ EXECUTE ON PROCEDURE {metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)
         )
 
     with tabs[4]:
-        st.subheader("Data Governance & Security")
+        st.subheader("Data Governance and Security")
         st.markdown(
             """
-**Roles & Isolation**
-- App runs with a specific **caller role** and uses **EXECUTE AS CALLER** for task management.
-- Config/results live in a dedicated metadata schema to isolate privileges.
+#### Roles and isolation
+- The application runs with a defined caller role and relies on `EXECUTE AS CALLER` when managing tasks.
+- Configuration and results tables live in a dedicated metadata schema to control privileges.
 
-**Traceability**
-- `DQ_RUN_RESULTS` logs: run timestamp, check id/type, failures, `OK` flag, and error messages if any.
-- Tasks: one per config, auditable in ACCOUNT usage views.
+#### Traceability
+- `DQ_RUN_RESULTS` captures timestamps, check identifiers, failure counts, success flags, and error messages.
+- Each configuration owns a Snowflake task, which is auditable through ACCOUNT USAGE views.
 
-**Access Patterns**
-- Read-only access to source tables for checks.
-- Controlled write access only to metadata objects (config/checks/results).
-- DMF failing-row views live in metadata schema (no writes to source).
+#### Access patterns
+- Source tables are read-only; writes are limited to metadata objects for configs, checks, and results.
+- DMF failing-row views remain in the metadata schema so investigators avoid querying production tables directly.
 
-**PII / Sensitive Data**
-- Prefer checks that don’t materialize sensitive columns in logs. Views expose only what investigators need.
-- If required, add column masking on sensitive attributes in metadata views.
+#### Handling sensitive data
+- Prefer checks that avoid materialising personal data in logs; views expose only what investigators need.
+- Apply column masking to metadata views when sensitive attributes require additional protection.
             """
         )
 


### PR DESCRIPTION
- Refresh README with concise positioning, guardrails, and governance messaging in a business-ready tone.
- Update developer notes for clearer checklists and callouts that match the production workflow.
- Rework the Streamlit documentation tab structure and regenerate the mirrored snapshot to maintain parity.

------
https://chatgpt.com/codex/tasks/task_e_68f65407450483249d027409d85f4c7e