### PR TITLE
Adjust profiling result column ordering

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -210,10 +210,10 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
             "max_val",
             "avg_len",
             "whitespace_pct",
+            "error",
             "semantic_type",
             "confidence",
             "rationale",
-            "error",
         ]
         missing = [c for c in display_cols if c not in df.columns]
         df = df.reindex(columns=[c for c in display_cols if c not in missing] + [c for c in df.columns if c not in display_cols])
@@ -580,9 +580,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         ordered_columns = [
             "column_name",
             "data_type",
-            "Guessed Type",
-            "Confidence Badge",
-            "Confidence",
             "nulls",
             "null_pct",
             "distincts",
@@ -592,6 +589,9 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             "avg_len",
             "whitespace_pct",
             "error",
+            "Guessed Type",
+            "Confidence Badge",
+            "Confidence",
             "Confidence Rationale",
         ]
         display_df = display_df[[col for col in ordered_columns if col in display_df.columns] + [

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -210,10 +210,10 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
             "max_val",
             "avg_len",
             "whitespace_pct",
+            "error",
             "semantic_type",
             "confidence",
             "rationale",
-            "error",
         ]
         missing = [c for c in display_cols if c not in df.columns]
         df = df.reindex(columns=[c for c in display_cols if c not in missing] + [c for c in df.columns if c not in display_cols])
@@ -580,9 +580,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         ordered_columns = [
             "column_name",
             "data_type",
-            "Guessed Type",
-            "Confidence Badge",
-            "Confidence",
             "nulls",
             "null_pct",
             "distincts",
@@ -592,6 +589,9 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             "avg_len",
             "whitespace_pct",
             "error",
+            "Guessed Type",
+            "Confidence Badge",
+            "Confidence",
             "Confidence Rationale",
         ]
         display_df = display_df[[col for col in ordered_columns if col in display_df.columns] + [


### PR DESCRIPTION
- Move the confidence-related columns to the end of the profiling results table
- Update the mirrored snapshot to reflect the new column ordering

------
https://chatgpt.com/codex/tasks/task_e_68f66723074483248182f5d1d05ec993