### PR TITLE
Include text fields in MIN_MAX profiling metrics

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -695,7 +695,7 @@ def run_table_profile(
             f"{distinct_expr.format(col=qcol)} AS DISTINCTS",
             f"SUM(CASE WHEN {qcol} IS NOT NULL THEN 1 ELSE 0 END) AS NON_NULLS_COUNT",
         ]
-        if _is_numeric(dtype) or _is_temporal(dtype):
+        if _is_numeric(dtype) or _is_temporal(dtype) or _is_string_type(dtype):
             metrics_sql.extend(
                 [
                     f"MIN({qcol}) AS MIN_VAL",

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -695,7 +695,7 @@ def run_table_profile(
             f"{distinct_expr.format(col=qcol)} AS DISTINCTS",
             f"SUM(CASE WHEN {qcol} IS NOT NULL THEN 1 ELSE 0 END) AS NON_NULLS_COUNT",
         ]
-        if _is_numeric(dtype) or _is_temporal(dtype):
+        if _is_numeric(dtype) or _is_temporal(dtype) or _is_string_type(dtype):
             metrics_sql.extend(
                 [
                     f"MIN({qcol}) AS MIN_VAL",


### PR DESCRIPTION
- allow table profiling queries to compute min and max values for string columns
- refresh mirrored profiling snapshot

------
https://chatgpt.com/codex/tasks/task_e_68f731688ac4832495aca88069f26979