### PR TITLE
Profiling: detect REF_CODE and DATE_IN_TEXT signals

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -222,8 +222,9 @@ def _derive_name_hints(column_name: str) -> Dict[str, bool]:
         "amount": {"amount", "amt", "value"},
         "price": {"price", "rate"},
         "quantity": {"qty", "quantity", "volume"},
-        "timestamp": {"timestamp", "datetime", "created", "updated"},
+        "timestamp": {"timestamp", "datetime", "created", "updated", "date"},
         "boolean": {"flag"},
+        "code": {"code", "lookup"},
     }
     hints: Dict[str, bool] = {}
     for key, keywords in tokens.items():
@@ -251,6 +252,8 @@ SEMANTIC_TYPE_CANDIDATES: Tuple[str, ...] = (
     "UUID",
     "URL",
     "PHONE",
+    "REFERENCE_CODE",
+    "DATE_IN_TEXT",
 )
 
 
@@ -270,6 +273,9 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
     references = signals.get("reference_matches", {}) or {}
     hints = signals.get("hints", {}) or {}
     length = signals.get("length", {}) or {}
+    string_stats = signals.get("string_stats", {}) or {}
+    date_patterns = signals.get("date_patterns", {}) or {}
+    date_parse = signals.get("date_parse", {}) or {}
 
     def _as_float(value: Any) -> Optional[float]:
         try:
@@ -282,6 +288,18 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
     length_min = _as_float(length.get("min"))
     length_max = _as_float(length.get("max"))
     length_avg = _as_float(length.get("avg"))
+    distinct_ratio_signal = _as_float(string_stats.get("distinct_ratio"))
+    top1_ratio_signal = _as_float(string_stats.get("top1_ratio"))
+    top3_ratio_signal = _as_float(string_stats.get("top3_ratio"))
+    numeric_like_ratio_signal = _as_float(string_stats.get("numeric_like_ratio"))
+    best_date_ratio = _as_float(date_parse.get("best_ratio"))
+    best_date_format = date_parse.get("best_format")
+    parsed_date_min = date_parse.get("parsed_min")
+    parsed_date_max = date_parse.get("parsed_max")
+    yyyymmdd_pattern_ratio = _as_float(date_patterns.get("yyyymmdd_ratio"))
+    ddmmyyyy_pattern_ratio = _as_float(date_patterns.get("ddmmyyyy_ratio"))
+    iso_pattern_ratio = _as_float(date_patterns.get("iso_ymd_ratio"))
+    column_name_lower = (column_entry.get("column_name") or "").lower()
 
     distinct_pct_raw = column_entry.get("distinct_pct")
     distinct_pct = float(distinct_pct_raw) if distinct_pct_raw is not None else None
@@ -354,6 +372,42 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
         _boost("PHONE", 70.0 * min(phone_ratio, 1.0), f"{phone_ratio:.0%} values match phone pattern")
     if hints.get("phone"):
         _boost("PHONE", 12.0, "column name references phone")
+
+    if best_date_ratio is not None and best_date_ratio >= 0.6:
+        format_labels = {
+            "yyyymmdd": "YYYYMMDD",
+            "ddmmyyyy": "DDMMYYYY",
+            "iso": "YYYY-MM-DD",
+        }
+        label = format_labels.get(str(best_date_format or "").lower(), str(best_date_format or "text date").upper())
+        _boost(
+            "DATE_IN_TEXT",
+            85.0 * min(best_date_ratio, 1.0),
+            f"{best_date_ratio:.0%} of values parse as {label}",
+        )
+        if parsed_date_min or parsed_date_max:
+            _boost(
+                "DATE_IN_TEXT",
+                8.0,
+                "parsed range {start} → {end}".format(
+                    start=parsed_date_min or "?",
+                    end=parsed_date_max or "?",
+                ),
+            )
+    else:
+        pattern_ratio = max(
+            iso_pattern_ratio or 0.0,
+            yyyymmdd_pattern_ratio or 0.0,
+            ddmmyyyy_pattern_ratio or 0.0,
+        )
+        if pattern_ratio >= 0.7:
+            _boost(
+                "DATE_IN_TEXT",
+                40.0 * pattern_ratio,
+                f"{pattern_ratio:.0%} of values resemble date patterns",
+            )
+    if "date" in column_name_lower and not _is_temporal(data_type):
+        _boost("DATE_IN_TEXT", 10.0, "column name references date but stored as string")
 
     currency_ref = _ratio(references, "reference_currency_code")
     if currency_ref > 0:
@@ -450,6 +504,28 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
         _boost("ACCOUNT_ID", 8.0, "generic identifier naming")
         _boost("ORDER_ID", 8.0)
         _boost("TRADE_ID", 8.0)
+
+    consistent_length = False
+    if length_min is not None and length_max is not None:
+        consistent_length = math.isclose(length_min, length_max, rel_tol=0.0, abs_tol=1.0)
+
+    if distinct_ratio_signal is not None and distinct_ratio_signal >= 0.25:
+        dominance_ok = (top1_ratio_signal is None or top1_ratio_signal <= 0.2) and (
+            top3_ratio_signal is None or top3_ratio_signal <= 0.45
+        )
+        if dominance_ok:
+            reason = (
+                f"{distinct_ratio_signal:.0%} of values unique with low mode dominance"
+            )
+            _boost("REFERENCE_CODE", 35.0 + min(distinct_ratio_signal, 1.0) * 40.0, reason)
+            if hints.get("code") or "code" in column_name_lower or hints.get("reference"):
+                _boost("REFERENCE_CODE", 12.0, "column name implies reference code")
+            if consistent_length and length_min is not None:
+                _boost("REFERENCE_CODE", 8.0, f"values share consistent length ≈ {length_min:.0f}")
+            if 0.05 <= (numeric_like_ratio_signal or 0.0) <= 0.95:
+                _boost("REFERENCE_CODE", 6.0, "mix of digits suggests coded identifiers")
+            if char_alnum >= 0.6:
+                _boost("REFERENCE_CODE", 4.0, "alphanumeric composition typical of codes")
 
     if distinct_pct is not None and distinct_pct >= 70.0:
         _boost("ACCOUNT_ID", 12.0, "high uniqueness typical for identifiers")
@@ -715,6 +791,12 @@ def run_table_profile(
 
         char_pattern_aliases: Dict[str, str] = {}
         regex_aliases: Dict[str, str] = {}
+        ref_match_aliases: Dict[str, str] = {}
+        date_pattern_aliases: Dict[str, str] = {}
+        date_parse_aliases: Dict[str, str] = {}
+        date_parse_min_aliases: Dict[str, str] = {}
+        date_parse_max_aliases: Dict[str, str] = {}
+        numeric_like_alias: Optional[str] = None
         if is_string:
             metrics_sql.extend(
                 [
@@ -736,8 +818,6 @@ def run_table_profile(
                     f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{pattern_sql}') THEN 1 ELSE 0 END) AS {alias}"
                 )
                 char_pattern_aliases[key] = alias
-
-            ref_match_aliases: Dict[str, str] = {}
             for ref_key, values in (
                 ("country_codes", reference_sets.get("country_codes", set())),
                 ("country_names", reference_sets.get("country_names", set())),
@@ -754,10 +834,57 @@ def run_table_profile(
                 )
                 signal_key = REFERENCE_SIGNAL_NAMES.get(ref_key, ref_key)
                 ref_match_aliases[signal_key] = alias
+
+            numeric_like_alias = "STRING_NUMERIC_LIKE_ROWS"
+            numeric_like_pattern = r"^\d+(\.\d+)?$".replace("\\", "\\\\")
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{numeric_like_pattern}') THEN 1 ELSE 0 END) AS {numeric_like_alias}"
+            )
+
+            date_pattern_aliases = {
+                "yyyymmdd_ratio": "STRING_DATE_YYYYMMDD_MATCHES",
+                "ddmmyyyy_ratio": "STRING_DATE_DDMMYYYY_MATCHES",
+                "iso_ymd_ratio": "STRING_DATE_ISO_YMD_MATCHES",
+            }
+            date_pattern_numeric = r"^\d{8}$".replace("\\", "\\\\")
+            date_pattern_iso = r"^\d{4}-\d{2}-\d{2}$".replace("\\", "\\\\")
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{date_pattern_numeric}') THEN 1 ELSE 0 END) AS {date_pattern_aliases['yyyymmdd_ratio']}"
+            )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{date_pattern_numeric}') THEN 1 ELSE 0 END) AS {date_pattern_aliases['ddmmyyyy_ratio']}"
+            )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{date_pattern_iso}') THEN 1 ELSE 0 END) AS {date_pattern_aliases['iso_ymd_ratio']}"
+            )
+
+            date_parse_aliases = {
+                "yyyymmdd": "STRING_DATE_PARSE_YYYYMMDD",
+                "ddmmyyyy": "STRING_DATE_PARSE_DDMMYYYY",
+                "iso": "STRING_DATE_PARSE_ISO",
+            }
+            for key, fmt in (("yyyymmdd", "YYYYMMDD"), ("ddmmyyyy", "DDMMYYYY"), ("iso", "YYYY-MM-DD")):
+                alias = date_parse_aliases[key]
+                metrics_sql.append(
+                    f"SUM(CASE WHEN TRY_TO_DATE({qcol}::STRING, '{fmt}') IS NOT NULL THEN 1 ELSE 0 END) AS {alias}"
+                )
+                date_parse_min_aliases[key] = f"STRING_DATE_MIN_{key.upper()}"
+                date_parse_max_aliases[key] = f"STRING_DATE_MAX_{key.upper()}"
+                metrics_sql.append(
+                    f"MIN(TRY_TO_DATE({qcol}::STRING, '{fmt}')) AS {date_parse_min_aliases[key]}"
+                )
+                metrics_sql.append(
+                    f"MAX(TRY_TO_DATE({qcol}::STRING, '{fmt}')) AS {date_parse_max_aliases[key]}"
+                )
         else:
             char_pattern_aliases = {}
             regex_aliases = {}
             ref_match_aliases = {}
+            date_pattern_aliases = {}
+            date_parse_aliases = {}
+            date_parse_min_aliases = {}
+            date_parse_max_aliases = {}
+            numeric_like_alias = None
 
         sql = "SELECT " + ", ".join(metrics_sql) + f" FROM {sampled_ref}"
         try:
@@ -855,6 +982,57 @@ def run_table_profile(
             ratio = (float(matches) / float(non_nulls)) if non_nulls else 0.0
             reference_ratios[key] = ratio
 
+        numeric_like_ratio: Optional[float] = None
+        if numeric_like_alias:
+            matches_raw = _extract_row_value(row, numeric_like_alias, 0)
+            try:
+                matches = int(matches_raw)
+            except Exception:
+                matches = 0
+            numeric_like_ratio = (float(matches) / float(non_nulls)) if non_nulls else 0.0
+
+        date_pattern_ratios: Dict[str, Optional[float]] = {}
+        for key, alias in date_pattern_aliases.items():
+            matches_raw = _extract_row_value(row, alias, 0)
+            try:
+                matches = int(matches_raw)
+            except Exception:
+                matches = 0
+            date_pattern_ratios[key] = (float(matches) / float(non_nulls)) if non_nulls else 0.0
+
+        date_parse_counts: Dict[str, int] = {}
+        date_parse_ratios: Dict[str, Optional[float]] = {}
+        parsed_min_values: Dict[str, Optional[Any]] = {}
+        parsed_max_values: Dict[str, Optional[Any]] = {}
+        for key, alias in date_parse_aliases.items():
+            matches_raw = _extract_row_value(row, alias, 0)
+            try:
+                matches = int(matches_raw)
+            except Exception:
+                matches = 0
+            date_parse_counts[key] = matches
+            date_parse_ratios[key] = (float(matches) / float(non_nulls)) if non_nulls else 0.0
+            parsed_min_values[key] = _extract_row_value(row, date_parse_min_aliases.get(key, ""))
+            parsed_max_values[key] = _extract_row_value(row, date_parse_max_aliases.get(key, ""))
+
+        best_date_key: Optional[str] = None
+        best_date_ratio = 0.0
+        for key, ratio in date_parse_ratios.items():
+            ratio_val = float(ratio or 0.0)
+            if ratio_val >= best_date_ratio and date_parse_counts.get(key, 0) > 0:
+                # prefer earlier key ordering when ratios equal
+                if not math.isclose(ratio_val, best_date_ratio) or best_date_key is None:
+                    best_date_ratio = ratio_val
+                    best_date_key = key
+
+        parsed_date_min: Optional[str] = None
+        parsed_date_max: Optional[str] = None
+        if best_date_key:
+            best_min = parsed_min_values.get(best_date_key)
+            best_max = parsed_max_values.get(best_date_key)
+            parsed_date_min = str(best_min) if best_min is not None else None
+            parsed_date_max = str(best_max) if best_max is not None else None
+
         hints = _derive_name_hints(name)
 
         top_values: List[Dict[str, Any]] = []
@@ -885,6 +1063,15 @@ def run_table_profile(
                 top_coverage = 0
         coverage_pct = (float(top_coverage) / non_nulls * 100.0) if non_nulls else 0.0
 
+        top1_ratio = None
+        top3_ratio = None
+        if top_values and non_nulls:
+            top1_ratio = float(top_values[0].get("count") or 0) / float(non_nulls)
+            top3_ratio = (
+                float(sum((top_values[idx].get("count") or 0) for idx in range(min(3, len(top_values)))))
+                / float(non_nulls)
+            )
+
         column_entry: Dict[str, Any] = {
             "name": name,
             "column_name": name,
@@ -904,6 +1091,29 @@ def run_table_profile(
             "error": None,
         }
 
+        if is_string:
+            column_entry.update(
+                {
+                    "row_cnt": non_nulls,
+                    "distinct_ratio": (float(distincts_int) / float(non_nulls)) if (distincts_int is not None and non_nulls) else None,
+                    "top1_ratio": top1_ratio,
+                    "top3_ratio": top3_ratio,
+                    "len_min": len_min_val,
+                    "len_max": len_max_val,
+                    "numeric_like_ratio": numeric_like_ratio,
+                    "date_pattern_yyyymmdd_ratio": date_pattern_ratios.get("yyyymmdd_ratio"),
+                    "date_pattern_ddmmyyyy_ratio": date_pattern_ratios.get("ddmmyyyy_ratio"),
+                    "date_pattern_iso_ymd_ratio": date_pattern_ratios.get("iso_ymd_ratio"),
+                    "date_parse_ratio_yyyymmdd": date_parse_ratios.get("yyyymmdd"),
+                    "date_parse_ratio_ddmmyyyy": date_parse_ratios.get("ddmmyyyy"),
+                    "date_parse_ratio_iso": date_parse_ratios.get("iso"),
+                    "date_parse_ratio_best": best_date_ratio if best_date_key else None,
+                    "date_parse_best_format": best_date_key,
+                    "parsed_date_min": parsed_date_min,
+                    "parsed_date_max": parsed_date_max,
+                }
+            )
+
         signals: Dict[str, Any] = {
             "null_pct": null_pct,
             "distinct_pct": distinct_pct,
@@ -920,6 +1130,27 @@ def run_table_profile(
             }
             if "whitespace" in char_ratios:
                 signals["whitespace_ratio"] = char_ratios.get("whitespace")
+            signals["string_stats"] = {
+                "row_cnt": non_nulls,
+                "distinct_ratio": column_entry.get("distinct_ratio"),
+                "top1_ratio": top1_ratio,
+                "top3_ratio": top3_ratio,
+                "numeric_like_ratio": numeric_like_ratio,
+            }
+            signals["date_patterns"] = {
+                "yyyymmdd_ratio": date_pattern_ratios.get("yyyymmdd_ratio"),
+                "ddmmyyyy_ratio": date_pattern_ratios.get("ddmmyyyy_ratio"),
+                "iso_ymd_ratio": date_pattern_ratios.get("iso_ymd_ratio"),
+            }
+            signals["date_parse"] = {
+                "yyyymmdd_ratio": date_parse_ratios.get("yyyymmdd"),
+                "ddmmyyyy_ratio": date_parse_ratios.get("ddmmyyyy"),
+                "iso_ratio": date_parse_ratios.get("iso"),
+                "best_ratio": best_date_ratio if best_date_key else None,
+                "best_format": best_date_key,
+                "parsed_min": parsed_date_min,
+                "parsed_max": parsed_date_max,
+            }
         else:
             signals["length"] = {"min": None, "max": None, "avg": None}
 
@@ -935,6 +1166,13 @@ def run_table_profile(
         column_entry["signal_len_avg"] = avg_len if (is_string and avg_len is not None) else None
         for key, value in hints.items():
             column_entry[f"signal_hint_{key}"] = bool(value)
+
+        if is_string:
+            column_entry["signal_numeric_like_ratio"] = numeric_like_ratio
+            column_entry["signal_date_parse_best_ratio"] = best_date_ratio if best_date_key else None
+            column_entry["signal_date_parse_best_format"] = best_date_key
+            column_entry["signal_parsed_date_min"] = parsed_date_min
+            column_entry["signal_parsed_date_max"] = parsed_date_max
 
         column_entry["signals"] = signals
 

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -222,8 +222,9 @@ def _derive_name_hints(column_name: str) -> Dict[str, bool]:
         "amount": {"amount", "amt", "value"},
         "price": {"price", "rate"},
         "quantity": {"qty", "quantity", "volume"},
-        "timestamp": {"timestamp", "datetime", "created", "updated"},
+        "timestamp": {"timestamp", "datetime", "created", "updated", "date"},
         "boolean": {"flag"},
+        "code": {"code", "lookup"},
     }
     hints: Dict[str, bool] = {}
     for key, keywords in tokens.items():
@@ -251,6 +252,8 @@ SEMANTIC_TYPE_CANDIDATES: Tuple[str, ...] = (
     "UUID",
     "URL",
     "PHONE",
+    "REFERENCE_CODE",
+    "DATE_IN_TEXT",
 )
 
 
@@ -270,6 +273,9 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
     references = signals.get("reference_matches", {}) or {}
     hints = signals.get("hints", {}) or {}
     length = signals.get("length", {}) or {}
+    string_stats = signals.get("string_stats", {}) or {}
+    date_patterns = signals.get("date_patterns", {}) or {}
+    date_parse = signals.get("date_parse", {}) or {}
 
     def _as_float(value: Any) -> Optional[float]:
         try:
@@ -282,6 +288,18 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
     length_min = _as_float(length.get("min"))
     length_max = _as_float(length.get("max"))
     length_avg = _as_float(length.get("avg"))
+    distinct_ratio_signal = _as_float(string_stats.get("distinct_ratio"))
+    top1_ratio_signal = _as_float(string_stats.get("top1_ratio"))
+    top3_ratio_signal = _as_float(string_stats.get("top3_ratio"))
+    numeric_like_ratio_signal = _as_float(string_stats.get("numeric_like_ratio"))
+    best_date_ratio = _as_float(date_parse.get("best_ratio"))
+    best_date_format = date_parse.get("best_format")
+    parsed_date_min = date_parse.get("parsed_min")
+    parsed_date_max = date_parse.get("parsed_max")
+    yyyymmdd_pattern_ratio = _as_float(date_patterns.get("yyyymmdd_ratio"))
+    ddmmyyyy_pattern_ratio = _as_float(date_patterns.get("ddmmyyyy_ratio"))
+    iso_pattern_ratio = _as_float(date_patterns.get("iso_ymd_ratio"))
+    column_name_lower = (column_entry.get("column_name") or "").lower()
 
     distinct_pct_raw = column_entry.get("distinct_pct")
     distinct_pct = float(distinct_pct_raw) if distinct_pct_raw is not None else None
@@ -354,6 +372,42 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
         _boost("PHONE", 70.0 * min(phone_ratio, 1.0), f"{phone_ratio:.0%} values match phone pattern")
     if hints.get("phone"):
         _boost("PHONE", 12.0, "column name references phone")
+
+    if best_date_ratio is not None and best_date_ratio >= 0.6:
+        format_labels = {
+            "yyyymmdd": "YYYYMMDD",
+            "ddmmyyyy": "DDMMYYYY",
+            "iso": "YYYY-MM-DD",
+        }
+        label = format_labels.get(str(best_date_format or "").lower(), str(best_date_format or "text date").upper())
+        _boost(
+            "DATE_IN_TEXT",
+            85.0 * min(best_date_ratio, 1.0),
+            f"{best_date_ratio:.0%} of values parse as {label}",
+        )
+        if parsed_date_min or parsed_date_max:
+            _boost(
+                "DATE_IN_TEXT",
+                8.0,
+                "parsed range {start} → {end}".format(
+                    start=parsed_date_min or "?",
+                    end=parsed_date_max or "?",
+                ),
+            )
+    else:
+        pattern_ratio = max(
+            iso_pattern_ratio or 0.0,
+            yyyymmdd_pattern_ratio or 0.0,
+            ddmmyyyy_pattern_ratio or 0.0,
+        )
+        if pattern_ratio >= 0.7:
+            _boost(
+                "DATE_IN_TEXT",
+                40.0 * pattern_ratio,
+                f"{pattern_ratio:.0%} of values resemble date patterns",
+            )
+    if "date" in column_name_lower and not _is_temporal(data_type):
+        _boost("DATE_IN_TEXT", 10.0, "column name references date but stored as string")
 
     currency_ref = _ratio(references, "reference_currency_code")
     if currency_ref > 0:
@@ -450,6 +504,28 @@ def _infer_semantic_type(column_entry: Dict[str, Any]) -> Tuple[str, float, str]
         _boost("ACCOUNT_ID", 8.0, "generic identifier naming")
         _boost("ORDER_ID", 8.0)
         _boost("TRADE_ID", 8.0)
+
+    consistent_length = False
+    if length_min is not None and length_max is not None:
+        consistent_length = math.isclose(length_min, length_max, rel_tol=0.0, abs_tol=1.0)
+
+    if distinct_ratio_signal is not None and distinct_ratio_signal >= 0.25:
+        dominance_ok = (top1_ratio_signal is None or top1_ratio_signal <= 0.2) and (
+            top3_ratio_signal is None or top3_ratio_signal <= 0.45
+        )
+        if dominance_ok:
+            reason = (
+                f"{distinct_ratio_signal:.0%} of values unique with low mode dominance"
+            )
+            _boost("REFERENCE_CODE", 35.0 + min(distinct_ratio_signal, 1.0) * 40.0, reason)
+            if hints.get("code") or "code" in column_name_lower or hints.get("reference"):
+                _boost("REFERENCE_CODE", 12.0, "column name implies reference code")
+            if consistent_length and length_min is not None:
+                _boost("REFERENCE_CODE", 8.0, f"values share consistent length ≈ {length_min:.0f}")
+            if 0.05 <= (numeric_like_ratio_signal or 0.0) <= 0.95:
+                _boost("REFERENCE_CODE", 6.0, "mix of digits suggests coded identifiers")
+            if char_alnum >= 0.6:
+                _boost("REFERENCE_CODE", 4.0, "alphanumeric composition typical of codes")
 
     if distinct_pct is not None and distinct_pct >= 70.0:
         _boost("ACCOUNT_ID", 12.0, "high uniqueness typical for identifiers")
@@ -715,6 +791,12 @@ def run_table_profile(
 
         char_pattern_aliases: Dict[str, str] = {}
         regex_aliases: Dict[str, str] = {}
+        ref_match_aliases: Dict[str, str] = {}
+        date_pattern_aliases: Dict[str, str] = {}
+        date_parse_aliases: Dict[str, str] = {}
+        date_parse_min_aliases: Dict[str, str] = {}
+        date_parse_max_aliases: Dict[str, str] = {}
+        numeric_like_alias: Optional[str] = None
         if is_string:
             metrics_sql.extend(
                 [
@@ -736,8 +818,6 @@ def run_table_profile(
                     f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{pattern_sql}') THEN 1 ELSE 0 END) AS {alias}"
                 )
                 char_pattern_aliases[key] = alias
-
-            ref_match_aliases: Dict[str, str] = {}
             for ref_key, values in (
                 ("country_codes", reference_sets.get("country_codes", set())),
                 ("country_names", reference_sets.get("country_names", set())),
@@ -754,10 +834,57 @@ def run_table_profile(
                 )
                 signal_key = REFERENCE_SIGNAL_NAMES.get(ref_key, ref_key)
                 ref_match_aliases[signal_key] = alias
+
+            numeric_like_alias = "STRING_NUMERIC_LIKE_ROWS"
+            numeric_like_pattern = r"^\d+(\.\d+)?$".replace("\\", "\\\\")
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{numeric_like_pattern}') THEN 1 ELSE 0 END) AS {numeric_like_alias}"
+            )
+
+            date_pattern_aliases = {
+                "yyyymmdd_ratio": "STRING_DATE_YYYYMMDD_MATCHES",
+                "ddmmyyyy_ratio": "STRING_DATE_DDMMYYYY_MATCHES",
+                "iso_ymd_ratio": "STRING_DATE_ISO_YMD_MATCHES",
+            }
+            date_pattern_numeric = r"^\d{8}$".replace("\\", "\\\\")
+            date_pattern_iso = r"^\d{4}-\d{2}-\d{2}$".replace("\\", "\\\\")
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{date_pattern_numeric}') THEN 1 ELSE 0 END) AS {date_pattern_aliases['yyyymmdd_ratio']}"
+            )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{date_pattern_numeric}') THEN 1 ELSE 0 END) AS {date_pattern_aliases['ddmmyyyy_ratio']}"
+            )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '{date_pattern_iso}') THEN 1 ELSE 0 END) AS {date_pattern_aliases['iso_ymd_ratio']}"
+            )
+
+            date_parse_aliases = {
+                "yyyymmdd": "STRING_DATE_PARSE_YYYYMMDD",
+                "ddmmyyyy": "STRING_DATE_PARSE_DDMMYYYY",
+                "iso": "STRING_DATE_PARSE_ISO",
+            }
+            for key, fmt in (("yyyymmdd", "YYYYMMDD"), ("ddmmyyyy", "DDMMYYYY"), ("iso", "YYYY-MM-DD")):
+                alias = date_parse_aliases[key]
+                metrics_sql.append(
+                    f"SUM(CASE WHEN TRY_TO_DATE({qcol}::STRING, '{fmt}') IS NOT NULL THEN 1 ELSE 0 END) AS {alias}"
+                )
+                date_parse_min_aliases[key] = f"STRING_DATE_MIN_{key.upper()}"
+                date_parse_max_aliases[key] = f"STRING_DATE_MAX_{key.upper()}"
+                metrics_sql.append(
+                    f"MIN(TRY_TO_DATE({qcol}::STRING, '{fmt}')) AS {date_parse_min_aliases[key]}"
+                )
+                metrics_sql.append(
+                    f"MAX(TRY_TO_DATE({qcol}::STRING, '{fmt}')) AS {date_parse_max_aliases[key]}"
+                )
         else:
             char_pattern_aliases = {}
             regex_aliases = {}
             ref_match_aliases = {}
+            date_pattern_aliases = {}
+            date_parse_aliases = {}
+            date_parse_min_aliases = {}
+            date_parse_max_aliases = {}
+            numeric_like_alias = None
 
         sql = "SELECT " + ", ".join(metrics_sql) + f" FROM {sampled_ref}"
         try:
@@ -855,6 +982,57 @@ def run_table_profile(
             ratio = (float(matches) / float(non_nulls)) if non_nulls else 0.0
             reference_ratios[key] = ratio
 
+        numeric_like_ratio: Optional[float] = None
+        if numeric_like_alias:
+            matches_raw = _extract_row_value(row, numeric_like_alias, 0)
+            try:
+                matches = int(matches_raw)
+            except Exception:
+                matches = 0
+            numeric_like_ratio = (float(matches) / float(non_nulls)) if non_nulls else 0.0
+
+        date_pattern_ratios: Dict[str, Optional[float]] = {}
+        for key, alias in date_pattern_aliases.items():
+            matches_raw = _extract_row_value(row, alias, 0)
+            try:
+                matches = int(matches_raw)
+            except Exception:
+                matches = 0
+            date_pattern_ratios[key] = (float(matches) / float(non_nulls)) if non_nulls else 0.0
+
+        date_parse_counts: Dict[str, int] = {}
+        date_parse_ratios: Dict[str, Optional[float]] = {}
+        parsed_min_values: Dict[str, Optional[Any]] = {}
+        parsed_max_values: Dict[str, Optional[Any]] = {}
+        for key, alias in date_parse_aliases.items():
+            matches_raw = _extract_row_value(row, alias, 0)
+            try:
+                matches = int(matches_raw)
+            except Exception:
+                matches = 0
+            date_parse_counts[key] = matches
+            date_parse_ratios[key] = (float(matches) / float(non_nulls)) if non_nulls else 0.0
+            parsed_min_values[key] = _extract_row_value(row, date_parse_min_aliases.get(key, ""))
+            parsed_max_values[key] = _extract_row_value(row, date_parse_max_aliases.get(key, ""))
+
+        best_date_key: Optional[str] = None
+        best_date_ratio = 0.0
+        for key, ratio in date_parse_ratios.items():
+            ratio_val = float(ratio or 0.0)
+            if ratio_val >= best_date_ratio and date_parse_counts.get(key, 0) > 0:
+                # prefer earlier key ordering when ratios equal
+                if not math.isclose(ratio_val, best_date_ratio) or best_date_key is None:
+                    best_date_ratio = ratio_val
+                    best_date_key = key
+
+        parsed_date_min: Optional[str] = None
+        parsed_date_max: Optional[str] = None
+        if best_date_key:
+            best_min = parsed_min_values.get(best_date_key)
+            best_max = parsed_max_values.get(best_date_key)
+            parsed_date_min = str(best_min) if best_min is not None else None
+            parsed_date_max = str(best_max) if best_max is not None else None
+
         hints = _derive_name_hints(name)
 
         top_values: List[Dict[str, Any]] = []
@@ -885,6 +1063,15 @@ def run_table_profile(
                 top_coverage = 0
         coverage_pct = (float(top_coverage) / non_nulls * 100.0) if non_nulls else 0.0
 
+        top1_ratio = None
+        top3_ratio = None
+        if top_values and non_nulls:
+            top1_ratio = float(top_values[0].get("count") or 0) / float(non_nulls)
+            top3_ratio = (
+                float(sum((top_values[idx].get("count") or 0) for idx in range(min(3, len(top_values)))))
+                / float(non_nulls)
+            )
+
         column_entry: Dict[str, Any] = {
             "name": name,
             "column_name": name,
@@ -904,6 +1091,29 @@ def run_table_profile(
             "error": None,
         }
 
+        if is_string:
+            column_entry.update(
+                {
+                    "row_cnt": non_nulls,
+                    "distinct_ratio": (float(distincts_int) / float(non_nulls)) if (distincts_int is not None and non_nulls) else None,
+                    "top1_ratio": top1_ratio,
+                    "top3_ratio": top3_ratio,
+                    "len_min": len_min_val,
+                    "len_max": len_max_val,
+                    "numeric_like_ratio": numeric_like_ratio,
+                    "date_pattern_yyyymmdd_ratio": date_pattern_ratios.get("yyyymmdd_ratio"),
+                    "date_pattern_ddmmyyyy_ratio": date_pattern_ratios.get("ddmmyyyy_ratio"),
+                    "date_pattern_iso_ymd_ratio": date_pattern_ratios.get("iso_ymd_ratio"),
+                    "date_parse_ratio_yyyymmdd": date_parse_ratios.get("yyyymmdd"),
+                    "date_parse_ratio_ddmmyyyy": date_parse_ratios.get("ddmmyyyy"),
+                    "date_parse_ratio_iso": date_parse_ratios.get("iso"),
+                    "date_parse_ratio_best": best_date_ratio if best_date_key else None,
+                    "date_parse_best_format": best_date_key,
+                    "parsed_date_min": parsed_date_min,
+                    "parsed_date_max": parsed_date_max,
+                }
+            )
+
         signals: Dict[str, Any] = {
             "null_pct": null_pct,
             "distinct_pct": distinct_pct,
@@ -920,6 +1130,27 @@ def run_table_profile(
             }
             if "whitespace" in char_ratios:
                 signals["whitespace_ratio"] = char_ratios.get("whitespace")
+            signals["string_stats"] = {
+                "row_cnt": non_nulls,
+                "distinct_ratio": column_entry.get("distinct_ratio"),
+                "top1_ratio": top1_ratio,
+                "top3_ratio": top3_ratio,
+                "numeric_like_ratio": numeric_like_ratio,
+            }
+            signals["date_patterns"] = {
+                "yyyymmdd_ratio": date_pattern_ratios.get("yyyymmdd_ratio"),
+                "ddmmyyyy_ratio": date_pattern_ratios.get("ddmmyyyy_ratio"),
+                "iso_ymd_ratio": date_pattern_ratios.get("iso_ymd_ratio"),
+            }
+            signals["date_parse"] = {
+                "yyyymmdd_ratio": date_parse_ratios.get("yyyymmdd"),
+                "ddmmyyyy_ratio": date_parse_ratios.get("ddmmyyyy"),
+                "iso_ratio": date_parse_ratios.get("iso"),
+                "best_ratio": best_date_ratio if best_date_key else None,
+                "best_format": best_date_key,
+                "parsed_min": parsed_date_min,
+                "parsed_max": parsed_date_max,
+            }
         else:
             signals["length"] = {"min": None, "max": None, "avg": None}
 
@@ -935,6 +1166,13 @@ def run_table_profile(
         column_entry["signal_len_avg"] = avg_len if (is_string and avg_len is not None) else None
         for key, value in hints.items():
             column_entry[f"signal_hint_{key}"] = bool(value)
+
+        if is_string:
+            column_entry["signal_numeric_like_ratio"] = numeric_like_ratio
+            column_entry["signal_date_parse_best_ratio"] = best_date_ratio if best_date_key else None
+            column_entry["signal_date_parse_best_format"] = best_date_key
+            column_entry["signal_parsed_date_min"] = parsed_date_min
+            column_entry["signal_parsed_date_max"] = parsed_date_max
 
         column_entry["signals"] = signals
 

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -78,6 +78,23 @@ class ColumnProfile:
     max_val: Optional[Any]
     avg_len: Optional[float]
     whitespace_pct: Optional[float]
+    row_cnt: Optional[int] = None
+    distinct_ratio: Optional[float] = None
+    top1_ratio: Optional[float] = None
+    top3_ratio: Optional[float] = None
+    len_min: Optional[float] = None
+    len_max: Optional[float] = None
+    numeric_like_ratio: Optional[float] = None
+    yyyymmdd_ratio: Optional[float] = None
+    ddmmyyyy_ratio: Optional[float] = None
+    iso_ymd_ratio: Optional[float] = None
+    date_parse_ratio_yyyymmdd: Optional[float] = None
+    date_parse_ratio_ddmmyyyy: Optional[float] = None
+    date_parse_ratio_iso: Optional[float] = None
+    date_parse_ratio_best: Optional[float] = None
+    date_parse_best_format: Optional[str] = None
+    parsed_date_min: Optional[str] = None
+    parsed_date_max: Optional[str] = None
     top_values: List[Dict[str, Any]]
     error: Optional[str] = None
     semantic_type: Optional[str] = None
@@ -92,6 +109,18 @@ def _column_profile_from_payload(column: Dict[str, Any]) -> ColumnProfile:
         top_values_list = [dict(entry) for entry in top_values if isinstance(entry, dict)]
     else:
         top_values_list = []
+    best_format_value = normalized.get("date_parse_best_format")
+    best_format_display: Optional[str]
+    if best_format_value:
+        fmt_key = str(best_format_value).lower()
+        format_map = {
+            "yyyymmdd": "YYYYMMDD",
+            "ddmmyyyy": "DDMMYYYY",
+            "iso": "YYYY-MM-DD",
+        }
+        best_format_display = format_map.get(fmt_key, str(best_format_value))
+    else:
+        best_format_display = None
     return ColumnProfile(
         name=str(normalized.get("column_name") or normalized.get("name") or ""),
         data_type=str(normalized.get("data_type") or ""),
@@ -103,6 +132,23 @@ def _column_profile_from_payload(column: Dict[str, Any]) -> ColumnProfile:
         max_val=normalized.get("max_val"),
         avg_len=_safe_float(normalized.get("avg_len")),
         whitespace_pct=_safe_float(normalized.get("whitespace_pct")),
+        row_cnt=_safe_int(normalized.get("row_cnt")),
+        distinct_ratio=_safe_float(normalized.get("distinct_ratio")),
+        top1_ratio=_safe_float(normalized.get("top1_ratio")),
+        top3_ratio=_safe_float(normalized.get("top3_ratio")),
+        len_min=_safe_float(normalized.get("len_min")),
+        len_max=_safe_float(normalized.get("len_max")),
+        numeric_like_ratio=_safe_float(normalized.get("numeric_like_ratio")),
+        yyyymmdd_ratio=_safe_float(normalized.get("date_pattern_yyyymmdd_ratio")),
+        ddmmyyyy_ratio=_safe_float(normalized.get("date_pattern_ddmmyyyy_ratio")),
+        iso_ymd_ratio=_safe_float(normalized.get("date_pattern_iso_ymd_ratio")),
+        date_parse_ratio_yyyymmdd=_safe_float(normalized.get("date_parse_ratio_yyyymmdd")),
+        date_parse_ratio_ddmmyyyy=_safe_float(normalized.get("date_parse_ratio_ddmmyyyy")),
+        date_parse_ratio_iso=_safe_float(normalized.get("date_parse_ratio_iso")),
+        date_parse_ratio_best=_safe_float(normalized.get("date_parse_ratio_best")),
+        date_parse_best_format=best_format_display,
+        parsed_date_min=str(normalized.get("parsed_date_min")) if normalized.get("parsed_date_min") else None,
+        parsed_date_max=str(normalized.get("parsed_date_max")) if normalized.get("parsed_date_max") else None,
         top_values=top_values_list,
         error=normalized.get("error"),
         semantic_type=normalized.get("semantic_type"),
@@ -178,6 +224,14 @@ def _table_picker(session_obj, preselect_fqn: Optional[str]):
 def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
     records = []
     for profile in profiles:
+        def _pct(value: Optional[float]) -> Optional[float]:
+            if value is None:
+                return None
+            try:
+                return round(float(value) * 100.0, 2)
+            except Exception:
+                return None
+
         records.append(
             {
                 "column_name": profile.name,
@@ -190,6 +244,23 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
                 "max_val": profile.max_val,
                 "avg_len": round(profile.avg_len, 2) if profile.avg_len is not None else None,
                 "whitespace_pct": round(profile.whitespace_pct, 2) if profile.whitespace_pct is not None else None,
+                "row_cnt": profile.row_cnt,
+                "len_min": round(profile.len_min, 2) if profile.len_min is not None else None,
+                "len_max": round(profile.len_max, 2) if profile.len_max is not None else None,
+                "distinct_ratio_pct": _pct(profile.distinct_ratio),
+                "top1_ratio_pct": _pct(profile.top1_ratio),
+                "top3_ratio_pct": _pct(profile.top3_ratio),
+                "numeric_like_pct": _pct(profile.numeric_like_ratio),
+                "date_pattern_yyyymmdd_pct": _pct(profile.yyyymmdd_ratio),
+                "date_pattern_ddmmyyyy_pct": _pct(profile.ddmmyyyy_ratio),
+                "date_pattern_iso_ymd_pct": _pct(profile.iso_ymd_ratio),
+                "date_parse_yyyymmdd_pct": _pct(profile.date_parse_ratio_yyyymmdd),
+                "date_parse_ddmmyyyy_pct": _pct(profile.date_parse_ratio_ddmmyyyy),
+                "date_parse_iso_pct": _pct(profile.date_parse_ratio_iso),
+                "date_parse_best_pct": _pct(profile.date_parse_ratio_best),
+                "date_parse_best_format": profile.date_parse_best_format,
+                "parsed_date_min": profile.parsed_date_min,
+                "parsed_date_max": profile.parsed_date_max,
                 "top_values": profile.top_values,
                 "error": profile.error,
                 "semantic_type": profile.semantic_type,
@@ -538,7 +609,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         filtered_df = filtered_df[(filtered_df["whitespace_pct"].fillna(0) > 5)]
 
     semantic_filter_map = {
-        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN"},
+        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN", "REFERENCE_CODE"},
         "Financial": {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
         "Instrument": {"ISIN", "TICKER/SYMBOL"},
         "Geo": {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
@@ -572,22 +643,58 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         else:
             display_df["Confidence"] = None
             display_df["Confidence Badge"] = "Unknown"
-        display_df = display_df.rename(columns={"semantic_type": "Guessed Type"})
-        if "rationale" in display_df.columns:
-            display_df = display_df.rename(columns={"rationale": "Confidence Rationale"})
+        rename_map = {
+            "semantic_type": "Guessed Type",
+            "rationale": "Confidence Rationale",
+            "row_cnt": "Non-null Rows",
+            "len_min": "Length Min",
+            "len_max": "Length Max",
+            "distinct_ratio_pct": "Distinct Ratio %",
+            "top1_ratio_pct": "Top 1 Ratio %",
+            "top3_ratio_pct": "Top 3 Coverage %",
+            "numeric_like_pct": "Numeric-like %",
+            "date_pattern_yyyymmdd_pct": "YYYYMMDD Pattern %",
+            "date_pattern_ddmmyyyy_pct": "DDMMYYYY Pattern %",
+            "date_pattern_iso_ymd_pct": "ISO Pattern %",
+            "date_parse_yyyymmdd_pct": "YYYYMMDD Parse %",
+            "date_parse_ddmmyyyy_pct": "DDMMYYYY Parse %",
+            "date_parse_iso_pct": "ISO Parse %",
+            "date_parse_best_pct": "Best Parse %",
+            "date_parse_best_format": "Best Parse Format",
+            "parsed_date_min": "Parsed Date Min",
+            "parsed_date_max": "Parsed Date Max",
+        }
+        display_df = display_df.rename(columns={k: v for k, v in rename_map.items() if k in display_df.columns})
         if "Guessed Type" in display_df.columns:
             display_df["Guessed Type"] = display_df["Guessed Type"].fillna("Unknown")
         ordered_columns = [
             "column_name",
             "data_type",
+            "Non-null Rows",
             "nulls",
             "null_pct",
             "distincts",
             "distinct_pct",
+            "Distinct Ratio %",
+            "Top 1 Ratio %",
+            "Top 3 Coverage %",
+            "Numeric-like %",
             "min_val",
             "max_val",
             "avg_len",
+            "Length Min",
+            "Length Max",
             "whitespace_pct",
+            "YYYYMMDD Pattern %",
+            "DDMMYYYY Pattern %",
+            "ISO Pattern %",
+            "YYYYMMDD Parse %",
+            "DDMMYYYY Parse %",
+            "ISO Parse %",
+            "Best Parse %",
+            "Best Parse Format",
+            "Parsed Date Min",
+            "Parsed Date Max",
             "error",
             "Guessed Type",
             "Confidence Badge",
@@ -598,10 +705,26 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             col for col in display_df.columns if col not in ordered_columns
         ]]
         formatters: Dict[str, Any] = {"Confidence": _format_confidence}
-        for count_col in ("nulls", "distincts"):
+        for count_col in ("nulls", "distincts", "Non-null Rows"):
             if count_col in display_df.columns:
                 formatters[count_col] = _format_count
-        for pct_col in ("null_pct", "distinct_pct", "whitespace_pct"):
+        percentage_columns = (
+            "null_pct",
+            "distinct_pct",
+            "whitespace_pct",
+            "Distinct Ratio %",
+            "Top 1 Ratio %",
+            "Top 3 Coverage %",
+            "Numeric-like %",
+            "YYYYMMDD Pattern %",
+            "DDMMYYYY Pattern %",
+            "ISO Pattern %",
+            "YYYYMMDD Parse %",
+            "DDMMYYYY Parse %",
+            "ISO Parse %",
+            "Best Parse %",
+        )
+        for pct_col in percentage_columns:
             if pct_col in display_df.columns:
                 formatters[pct_col] = _format_percentage
         styler = display_df.style.format(formatters)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -78,6 +78,23 @@ class ColumnProfile:
     max_val: Optional[Any]
     avg_len: Optional[float]
     whitespace_pct: Optional[float]
+    row_cnt: Optional[int] = None
+    distinct_ratio: Optional[float] = None
+    top1_ratio: Optional[float] = None
+    top3_ratio: Optional[float] = None
+    len_min: Optional[float] = None
+    len_max: Optional[float] = None
+    numeric_like_ratio: Optional[float] = None
+    yyyymmdd_ratio: Optional[float] = None
+    ddmmyyyy_ratio: Optional[float] = None
+    iso_ymd_ratio: Optional[float] = None
+    date_parse_ratio_yyyymmdd: Optional[float] = None
+    date_parse_ratio_ddmmyyyy: Optional[float] = None
+    date_parse_ratio_iso: Optional[float] = None
+    date_parse_ratio_best: Optional[float] = None
+    date_parse_best_format: Optional[str] = None
+    parsed_date_min: Optional[str] = None
+    parsed_date_max: Optional[str] = None
     top_values: List[Dict[str, Any]]
     error: Optional[str] = None
     semantic_type: Optional[str] = None
@@ -92,6 +109,18 @@ def _column_profile_from_payload(column: Dict[str, Any]) -> ColumnProfile:
         top_values_list = [dict(entry) for entry in top_values if isinstance(entry, dict)]
     else:
         top_values_list = []
+    best_format_value = normalized.get("date_parse_best_format")
+    best_format_display: Optional[str]
+    if best_format_value:
+        fmt_key = str(best_format_value).lower()
+        format_map = {
+            "yyyymmdd": "YYYYMMDD",
+            "ddmmyyyy": "DDMMYYYY",
+            "iso": "YYYY-MM-DD",
+        }
+        best_format_display = format_map.get(fmt_key, str(best_format_value))
+    else:
+        best_format_display = None
     return ColumnProfile(
         name=str(normalized.get("column_name") or normalized.get("name") or ""),
         data_type=str(normalized.get("data_type") or ""),
@@ -103,6 +132,23 @@ def _column_profile_from_payload(column: Dict[str, Any]) -> ColumnProfile:
         max_val=normalized.get("max_val"),
         avg_len=_safe_float(normalized.get("avg_len")),
         whitespace_pct=_safe_float(normalized.get("whitespace_pct")),
+        row_cnt=_safe_int(normalized.get("row_cnt")),
+        distinct_ratio=_safe_float(normalized.get("distinct_ratio")),
+        top1_ratio=_safe_float(normalized.get("top1_ratio")),
+        top3_ratio=_safe_float(normalized.get("top3_ratio")),
+        len_min=_safe_float(normalized.get("len_min")),
+        len_max=_safe_float(normalized.get("len_max")),
+        numeric_like_ratio=_safe_float(normalized.get("numeric_like_ratio")),
+        yyyymmdd_ratio=_safe_float(normalized.get("date_pattern_yyyymmdd_ratio")),
+        ddmmyyyy_ratio=_safe_float(normalized.get("date_pattern_ddmmyyyy_ratio")),
+        iso_ymd_ratio=_safe_float(normalized.get("date_pattern_iso_ymd_ratio")),
+        date_parse_ratio_yyyymmdd=_safe_float(normalized.get("date_parse_ratio_yyyymmdd")),
+        date_parse_ratio_ddmmyyyy=_safe_float(normalized.get("date_parse_ratio_ddmmyyyy")),
+        date_parse_ratio_iso=_safe_float(normalized.get("date_parse_ratio_iso")),
+        date_parse_ratio_best=_safe_float(normalized.get("date_parse_ratio_best")),
+        date_parse_best_format=best_format_display,
+        parsed_date_min=str(normalized.get("parsed_date_min")) if normalized.get("parsed_date_min") else None,
+        parsed_date_max=str(normalized.get("parsed_date_max")) if normalized.get("parsed_date_max") else None,
         top_values=top_values_list,
         error=normalized.get("error"),
         semantic_type=normalized.get("semantic_type"),
@@ -178,6 +224,14 @@ def _table_picker(session_obj, preselect_fqn: Optional[str]):
 def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
     records = []
     for profile in profiles:
+        def _pct(value: Optional[float]) -> Optional[float]:
+            if value is None:
+                return None
+            try:
+                return round(float(value) * 100.0, 2)
+            except Exception:
+                return None
+
         records.append(
             {
                 "column_name": profile.name,
@@ -190,6 +244,23 @@ def _profiles_to_frame(profiles: Iterable[ColumnProfile]) -> pd.DataFrame:
                 "max_val": profile.max_val,
                 "avg_len": round(profile.avg_len, 2) if profile.avg_len is not None else None,
                 "whitespace_pct": round(profile.whitespace_pct, 2) if profile.whitespace_pct is not None else None,
+                "row_cnt": profile.row_cnt,
+                "len_min": round(profile.len_min, 2) if profile.len_min is not None else None,
+                "len_max": round(profile.len_max, 2) if profile.len_max is not None else None,
+                "distinct_ratio_pct": _pct(profile.distinct_ratio),
+                "top1_ratio_pct": _pct(profile.top1_ratio),
+                "top3_ratio_pct": _pct(profile.top3_ratio),
+                "numeric_like_pct": _pct(profile.numeric_like_ratio),
+                "date_pattern_yyyymmdd_pct": _pct(profile.yyyymmdd_ratio),
+                "date_pattern_ddmmyyyy_pct": _pct(profile.ddmmyyyy_ratio),
+                "date_pattern_iso_ymd_pct": _pct(profile.iso_ymd_ratio),
+                "date_parse_yyyymmdd_pct": _pct(profile.date_parse_ratio_yyyymmdd),
+                "date_parse_ddmmyyyy_pct": _pct(profile.date_parse_ratio_ddmmyyyy),
+                "date_parse_iso_pct": _pct(profile.date_parse_ratio_iso),
+                "date_parse_best_pct": _pct(profile.date_parse_ratio_best),
+                "date_parse_best_format": profile.date_parse_best_format,
+                "parsed_date_min": profile.parsed_date_min,
+                "parsed_date_max": profile.parsed_date_max,
                 "top_values": profile.top_values,
                 "error": profile.error,
                 "semantic_type": profile.semantic_type,
@@ -538,7 +609,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         filtered_df = filtered_df[(filtered_df["whitespace_pct"].fillna(0) > 5)]
 
     semantic_filter_map = {
-        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN"},
+        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN", "REFERENCE_CODE"},
         "Financial": {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
         "Instrument": {"ISIN", "TICKER/SYMBOL"},
         "Geo": {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
@@ -572,22 +643,58 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         else:
             display_df["Confidence"] = None
             display_df["Confidence Badge"] = "Unknown"
-        display_df = display_df.rename(columns={"semantic_type": "Guessed Type"})
-        if "rationale" in display_df.columns:
-            display_df = display_df.rename(columns={"rationale": "Confidence Rationale"})
+        rename_map = {
+            "semantic_type": "Guessed Type",
+            "rationale": "Confidence Rationale",
+            "row_cnt": "Non-null Rows",
+            "len_min": "Length Min",
+            "len_max": "Length Max",
+            "distinct_ratio_pct": "Distinct Ratio %",
+            "top1_ratio_pct": "Top 1 Ratio %",
+            "top3_ratio_pct": "Top 3 Coverage %",
+            "numeric_like_pct": "Numeric-like %",
+            "date_pattern_yyyymmdd_pct": "YYYYMMDD Pattern %",
+            "date_pattern_ddmmyyyy_pct": "DDMMYYYY Pattern %",
+            "date_pattern_iso_ymd_pct": "ISO Pattern %",
+            "date_parse_yyyymmdd_pct": "YYYYMMDD Parse %",
+            "date_parse_ddmmyyyy_pct": "DDMMYYYY Parse %",
+            "date_parse_iso_pct": "ISO Parse %",
+            "date_parse_best_pct": "Best Parse %",
+            "date_parse_best_format": "Best Parse Format",
+            "parsed_date_min": "Parsed Date Min",
+            "parsed_date_max": "Parsed Date Max",
+        }
+        display_df = display_df.rename(columns={k: v for k, v in rename_map.items() if k in display_df.columns})
         if "Guessed Type" in display_df.columns:
             display_df["Guessed Type"] = display_df["Guessed Type"].fillna("Unknown")
         ordered_columns = [
             "column_name",
             "data_type",
+            "Non-null Rows",
             "nulls",
             "null_pct",
             "distincts",
             "distinct_pct",
+            "Distinct Ratio %",
+            "Top 1 Ratio %",
+            "Top 3 Coverage %",
+            "Numeric-like %",
             "min_val",
             "max_val",
             "avg_len",
+            "Length Min",
+            "Length Max",
             "whitespace_pct",
+            "YYYYMMDD Pattern %",
+            "DDMMYYYY Pattern %",
+            "ISO Pattern %",
+            "YYYYMMDD Parse %",
+            "DDMMYYYY Parse %",
+            "ISO Parse %",
+            "Best Parse %",
+            "Best Parse Format",
+            "Parsed Date Min",
+            "Parsed Date Max",
             "error",
             "Guessed Type",
             "Confidence Badge",
@@ -598,10 +705,26 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             col for col in display_df.columns if col not in ordered_columns
         ]]
         formatters: Dict[str, Any] = {"Confidence": _format_confidence}
-        for count_col in ("nulls", "distincts"):
+        for count_col in ("nulls", "distincts", "Non-null Rows"):
             if count_col in display_df.columns:
                 formatters[count_col] = _format_count
-        for pct_col in ("null_pct", "distinct_pct", "whitespace_pct"):
+        percentage_columns = (
+            "null_pct",
+            "distinct_pct",
+            "whitespace_pct",
+            "Distinct Ratio %",
+            "Top 1 Ratio %",
+            "Top 3 Coverage %",
+            "Numeric-like %",
+            "YYYYMMDD Pattern %",
+            "DDMMYYYY Pattern %",
+            "ISO Pattern %",
+            "YYYYMMDD Parse %",
+            "DDMMYYYY Parse %",
+            "ISO Parse %",
+            "Best Parse %",
+        )
+        for pct_col in percentage_columns:
             if pct_col in display_df.columns:
                 formatters[pct_col] = _format_percentage
         styler = display_df.style.format(formatters)


### PR DESCRIPTION
- extend profiling to compute numeric-like and date parsing metrics for string columns and expose parsed date ranges
- enhance semantic inference with REFERENCE_CODE and DATE_IN_TEXT heuristics that leverage the new signals
- surface the new ratios, parsed date bounds, and reference code tag in the profiling UI

------
https://chatgpt.com/codex/tasks/task_e_68f77b1325988324a7fefe82a16ae623