### PR TITLE
Fix dataclass default ordering in ColumnProfile

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -2,7 +2,7 @@ from __future__ import annotations
 import html
 import math
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from numbers import Integral, Real
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
@@ -98,7 +98,7 @@ class ColumnProfile:
     parsed_date_max: Optional[str] = None
     numeric_min: Optional[Any] = None
     numeric_max: Optional[Any] = None
-    top_values: List[Dict[str, Any]]
+    top_values: List[Dict[str, Any]] = field(default_factory=list)
     error: Optional[str] = None
     semantic_type: Optional[str] = None
     confidence: Optional[float] = None

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import html
 import math
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from numbers import Integral, Real
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
@@ -98,7 +98,7 @@ class ColumnProfile:
     parsed_date_max: Optional[str] = None
     numeric_min: Optional[Any] = None
     numeric_max: Optional[Any] = None
-    top_values: List[Dict[str, Any]]
+    top_values: List[Dict[str, Any]] = field(default_factory=list)
     error: Optional[str] = None
     semantic_type: Optional[str] = None
     confidence: Optional[float] = None


### PR DESCRIPTION
- ensure `ColumnProfile.top_values` uses a default factory so dataclass generation succeeds
- mirror the updated `views/profile_view.py` snapshot

------
https://chatgpt.com/codex/tasks/task_e_68f78c8707b88324803434d5aa9e1458