### PR TITLE
Fix min/max assessment card layout

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import html
 import math
+import textwrap
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -473,12 +474,14 @@ def _render_metric_card(
         else:
             value_block = f"<div class=\"metric-value\">{value_html}</div>"
         metric_html.append(
-            """
-            <div class="metric">
-                <div class="metric-label">{label}</div>
-                {value_block}
-            </div>
-            """.format(label=label_html, value_block=value_block)
+            textwrap.dedent(
+                """
+                <div class="metric">
+                    <div class="metric-label">{label}</div>
+                    {value_block}
+                </div>
+                """
+            ).format(label=label_html, value_block=value_block).strip()
         )
 
     subtitle_html = (
@@ -486,17 +489,19 @@ def _render_metric_card(
         if subtitle
         else ""
     )
-    card_html = """
-    <div class="card">
-        <div class="kv">{title}</div>
-        {subtitle}
-        <div class="metrics-grid">
-            {metrics}
+    card_html = textwrap.dedent(
+        """
+        <div class="card">
+            <div class="kv">{title}</div>
+            {subtitle}
+            <div class="metrics-grid">
+                {metrics}
+            </div>
         </div>
-    </div>
-    """.format(
+        """
+    ).format(
         title=html.escape(title), subtitle=subtitle_html, metrics="".join(metric_html)
-    )
+    ).strip()
     st.markdown(card_html, unsafe_allow_html=True)
 
 

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import html
 import math
+import textwrap
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -473,12 +474,14 @@ def _render_metric_card(
         else:
             value_block = f"<div class=\"metric-value\">{value_html}</div>"
         metric_html.append(
-            """
-            <div class="metric">
-                <div class="metric-label">{label}</div>
-                {value_block}
-            </div>
-            """.format(label=label_html, value_block=value_block)
+            textwrap.dedent(
+                """
+                <div class="metric">
+                    <div class="metric-label">{label}</div>
+                    {value_block}
+                </div>
+                """
+            ).format(label=label_html, value_block=value_block).strip()
         )
 
     subtitle_html = (
@@ -486,17 +489,19 @@ def _render_metric_card(
         if subtitle
         else ""
     )
-    card_html = """
-    <div class="card">
-        <div class="kv">{title}</div>
-        {subtitle}
-        <div class="metrics-grid">
-            {metrics}
+    card_html = textwrap.dedent(
+        """
+        <div class="card">
+            <div class="kv">{title}</div>
+            {subtitle}
+            <div class="metrics-grid">
+                {metrics}
+            </div>
         </div>
-    </div>
-    """.format(
+        """
+    ).format(
         title=html.escape(title), subtitle=subtitle_html, metrics="".join(metric_html)
-    )
+    ).strip()
     st.markdown(card_html, unsafe_allow_html=True)
 
 


### PR DESCRIPTION
Fix min/max assessment card layout

- remove leading indentation from generated metric card HTML to prevent markdown code block rendering
- refresh mirrored snapshot for profile view

------
https://chatgpt.com/codex/tasks/task_e_68f78f0bbe3c83248fc15f362a5f588b