### PR TITLE
Backend (services/profiling.py): strengthen whitespace + selection logic

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -169,6 +169,11 @@ DATE_PARSE_LABELS: Dict[str, str] = {
 }
 
 
+DATE_PARSE_CONFIG_MAP: Dict[str, Dict[str, str]] = {
+    config["key"]: config for config in DATE_PARSE_CONFIGS
+}
+
+
 FALLBACK_COUNTRY_CODES: Set[str] = {
     "US",
     "DE",
@@ -1349,8 +1354,16 @@ def run_table_profile(
             metrics_sql.append(
                 f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\s|\\s$|\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
             )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND {qcol}::STRING != TRIM({qcol}::STRING) THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
+            )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND TRIM({qcol}::STRING) = '' THEN 1 ELSE 0 END) AS ONLY_WS_ROWS"
+            )
         else:
             metrics_sql.append("0 AS WHITESPACE_ROWS")
+            metrics_sql.append("0 AS LEAD_TRAIL_WS_ROWS")
+            metrics_sql.append("0 AS ONLY_WS_ROWS")
         length_expr: Optional[str]
         if is_string:
             length_expr = f"LENGTH({qcol}::STRING)"
@@ -1629,6 +1642,24 @@ def run_table_profile(
             except Exception:
                 whitespace_rows_int = 0
 
+        lead_trail_ws_rows = _extract_row_value(row, "LEAD_TRAIL_WS_ROWS", 0)
+        try:
+            lead_trail_ws_rows_int = int(lead_trail_ws_rows)
+        except Exception:
+            try:
+                lead_trail_ws_rows_int = int(float(lead_trail_ws_rows))
+            except Exception:
+                lead_trail_ws_rows_int = 0
+
+        only_ws_rows = _extract_row_value(row, "ONLY_WS_ROWS", 0)
+        try:
+            only_ws_rows_int = int(only_ws_rows)
+        except Exception:
+            try:
+                only_ws_rows_int = int(float(only_ws_rows))
+            except Exception:
+                only_ws_rows_int = 0
+
         avg_len_raw = _extract_row_value(row, "AVG_LEN")
         try:
             avg_len_value = float(avg_len_raw) if avg_len_raw is not None else None
@@ -1641,7 +1672,10 @@ def run_table_profile(
             distinct_pct = float(distincts_int) / float(non_nulls)
         else:
             distinct_pct = None
-        whitespace_pct = (float(whitespace_rows_int) / float(row_cnt) * 100.0) if row_cnt else 0.0
+        whitespace_ratio = (float(whitespace_rows_int) / float(non_nulls)) if non_nulls else 0.0
+        lead_trail_ws_ratio = (float(lead_trail_ws_rows_int) / float(non_nulls)) if non_nulls else 0.0
+        only_ws_ratio = (float(only_ws_rows_int) / float(non_nulls)) if non_nulls else 0.0
+        whitespace_pct = whitespace_ratio * 100.0
 
         avg_len_debug_note: Optional[str] = None
         if is_string:
@@ -1859,6 +1893,7 @@ def run_table_profile(
             "max_val": max_val,
             "avg_len": avg_len_final if supports_length_stats else None,
             "whitespace_pct": whitespace_pct,
+            "whitespace_only_pct": only_ws_ratio * 100.0,
             "top_values": top_values,
             "top_coverage_pct": coverage_pct,
             "rows_profiled": row_cnt,
@@ -1937,6 +1972,9 @@ def run_table_profile(
                 "sentinel_count": sentinel_count,
                 "len_spread": column_entry.get("len_spread"),
                 "avg_len": avg_len_final,
+                "whitespace_ratio": whitespace_ratio,
+                "lead_trail_ws_ratio": lead_trail_ws_ratio,
+                "only_ws_ratio": only_ws_ratio,
             }
             signals["date_patterns"] = {str(key): date_pattern_ratios.get(key) for key in date_pattern_ratios}
             signals["date_parse"] = {
@@ -2012,6 +2050,93 @@ def run_table_profile(
                 column_entry["numeric_max"] = str(numeric_max_raw)
                 if column_entry.get("profile_max") is None:
                     column_entry["profile_max"] = str(numeric_max_raw)
+
+        dq_checks: Dict[str, Dict[str, Any]] = {}
+        dq_selected = False
+        dq_reason = ""
+
+        distinct_ratio_value = float(distinct_pct) if distinct_pct is not None else None
+        null_pct_value = float(null_pct)
+
+        if (
+            distinct_ratio_value is not None
+            and distinct_ratio_value >= 0.60
+            and nulls_int == 0
+        ):
+            dq_selected = True
+            dq_reason = f"near-unique; {int(round(null_pct_value * 100))}% nulls"
+            dq_checks["UNIQUE"] = {"params": {"ignore_nulls": True}}
+        elif (
+            distincts_int is not None
+            and distincts_int <= 50
+            and (top3_ratio or 0.0) >= 0.80
+        ):
+            dq_selected = True
+            coverage_pct_val = int(round((top3_ratio or 0.0) * 100))
+            dq_reason = f"low-cardinality; top3 cover {coverage_pct_val}%"
+            allowed_values: List[str] = []
+            for entry in top_values:
+                value = entry.get("value")
+                if value is None:
+                    continue
+                allowed_values.append(_stringify(value))
+                if len(allowed_values) >= 20:
+                    break
+            dq_checks["VALUE_DISTRIBUTION"] = {
+                "params": {
+                    "allowed_values_csv": ", ".join(allowed_values),
+                    "min_match_ratio": 0.9,
+                }
+            }
+        elif is_numeric and min_val is not None and max_val is not None:
+            dq_selected = True
+            dq_reason = f"numeric range {min_val}–{max_val}"
+            dq_checks["MIN_MAX"] = {
+                "params": {
+                    "min": _stringify(min_val) if min_val is not None else None,
+                    "max": _stringify(max_val) if max_val is not None else None,
+                }
+            }
+        elif _is_temporal(dtype):
+            dq_selected = True
+            dq_reason = "temporal range profiling"
+            dq_checks["MIN_MAX"] = {
+                "params": {
+                    "min": _stringify(min_val) if min_val is not None else None,
+                    "max": _stringify(max_val) if max_val is not None else None,
+                }
+            }
+        elif (
+            semantic_type == "DATE_IN_TEXT"
+            and (any_parse_ratio or 0.0) >= 0.6
+        ):
+            dq_selected = True
+            success_pct = int(round((any_parse_ratio or 0.0) * 100))
+            dq_reason = f"dates in text; {success_pct}% parse success"
+            best_format_key = best_date_key
+            if best_format_key:
+                config = DATE_PARSE_CONFIG_MAP.get(best_format_key, {})
+                format_label = DATE_PARSE_LABELS.get(best_format_key, best_format_key)
+                regex_value = config.get("regex") or ""
+                dq_checks["FORMAT_DISTRIBUTION"] = {
+                    "params": {"label": format_label, "regex": regex_value}
+                }
+            dq_checks["MIN_MAX"] = {
+                "params": {"min": parsed_date_min, "max": parsed_date_max}
+            }
+
+        if dq_selected and is_string and (
+            whitespace_ratio >= 0.05 or only_ws_ratio > 0.0
+        ):
+            dq_checks["WHITESPACE"] = {"params": {"mode": "NO_LEADING_TRAILING"}}
+
+        if dq_selected and null_pct_value > 0.0:
+            max_nulls_allowed = int(math.ceil(float(row_cnt) * null_pct_value))
+            dq_checks["NULL_COUNT"] = {"params": {"max_nulls": max_nulls_allowed}}
+
+        column_entry["dq_selected"] = dq_selected
+        column_entry["dq_reason"] = dq_reason
+        column_entry["dq_checks"] = dq_checks
 
         per_column.append(column_entry)
 

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -169,6 +169,11 @@ DATE_PARSE_LABELS: Dict[str, str] = {
 }
 
 
+DATE_PARSE_CONFIG_MAP: Dict[str, Dict[str, str]] = {
+    config["key"]: config for config in DATE_PARSE_CONFIGS
+}
+
+
 FALLBACK_COUNTRY_CODES: Set[str] = {
     "US",
     "DE",
@@ -1349,8 +1354,16 @@ def run_table_profile(
             metrics_sql.append(
                 f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\s|\\s$|\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
             )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND {qcol}::STRING != TRIM({qcol}::STRING) THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
+            )
+            metrics_sql.append(
+                f"SUM(CASE WHEN {qcol} IS NOT NULL AND TRIM({qcol}::STRING) = '' THEN 1 ELSE 0 END) AS ONLY_WS_ROWS"
+            )
         else:
             metrics_sql.append("0 AS WHITESPACE_ROWS")
+            metrics_sql.append("0 AS LEAD_TRAIL_WS_ROWS")
+            metrics_sql.append("0 AS ONLY_WS_ROWS")
         length_expr: Optional[str]
         if is_string:
             length_expr = f"LENGTH({qcol}::STRING)"
@@ -1629,6 +1642,24 @@ def run_table_profile(
             except Exception:
                 whitespace_rows_int = 0
 
+        lead_trail_ws_rows = _extract_row_value(row, "LEAD_TRAIL_WS_ROWS", 0)
+        try:
+            lead_trail_ws_rows_int = int(lead_trail_ws_rows)
+        except Exception:
+            try:
+                lead_trail_ws_rows_int = int(float(lead_trail_ws_rows))
+            except Exception:
+                lead_trail_ws_rows_int = 0
+
+        only_ws_rows = _extract_row_value(row, "ONLY_WS_ROWS", 0)
+        try:
+            only_ws_rows_int = int(only_ws_rows)
+        except Exception:
+            try:
+                only_ws_rows_int = int(float(only_ws_rows))
+            except Exception:
+                only_ws_rows_int = 0
+
         avg_len_raw = _extract_row_value(row, "AVG_LEN")
         try:
             avg_len_value = float(avg_len_raw) if avg_len_raw is not None else None
@@ -1641,7 +1672,10 @@ def run_table_profile(
             distinct_pct = float(distincts_int) / float(non_nulls)
         else:
             distinct_pct = None
-        whitespace_pct = (float(whitespace_rows_int) / float(row_cnt) * 100.0) if row_cnt else 0.0
+        whitespace_ratio = (float(whitespace_rows_int) / float(non_nulls)) if non_nulls else 0.0
+        lead_trail_ws_ratio = (float(lead_trail_ws_rows_int) / float(non_nulls)) if non_nulls else 0.0
+        only_ws_ratio = (float(only_ws_rows_int) / float(non_nulls)) if non_nulls else 0.0
+        whitespace_pct = whitespace_ratio * 100.0
 
         avg_len_debug_note: Optional[str] = None
         if is_string:
@@ -1859,6 +1893,7 @@ def run_table_profile(
             "max_val": max_val,
             "avg_len": avg_len_final if supports_length_stats else None,
             "whitespace_pct": whitespace_pct,
+            "whitespace_only_pct": only_ws_ratio * 100.0,
             "top_values": top_values,
             "top_coverage_pct": coverage_pct,
             "rows_profiled": row_cnt,
@@ -1937,6 +1972,9 @@ def run_table_profile(
                 "sentinel_count": sentinel_count,
                 "len_spread": column_entry.get("len_spread"),
                 "avg_len": avg_len_final,
+                "whitespace_ratio": whitespace_ratio,
+                "lead_trail_ws_ratio": lead_trail_ws_ratio,
+                "only_ws_ratio": only_ws_ratio,
             }
             signals["date_patterns"] = {str(key): date_pattern_ratios.get(key) for key in date_pattern_ratios}
             signals["date_parse"] = {
@@ -2012,6 +2050,93 @@ def run_table_profile(
                 column_entry["numeric_max"] = str(numeric_max_raw)
                 if column_entry.get("profile_max") is None:
                     column_entry["profile_max"] = str(numeric_max_raw)
+
+        dq_checks: Dict[str, Dict[str, Any]] = {}
+        dq_selected = False
+        dq_reason = ""
+
+        distinct_ratio_value = float(distinct_pct) if distinct_pct is not None else None
+        null_pct_value = float(null_pct)
+
+        if (
+            distinct_ratio_value is not None
+            and distinct_ratio_value >= 0.60
+            and nulls_int == 0
+        ):
+            dq_selected = True
+            dq_reason = f"near-unique; {int(round(null_pct_value * 100))}% nulls"
+            dq_checks["UNIQUE"] = {"params": {"ignore_nulls": True}}
+        elif (
+            distincts_int is not None
+            and distincts_int <= 50
+            and (top3_ratio or 0.0) >= 0.80
+        ):
+            dq_selected = True
+            coverage_pct_val = int(round((top3_ratio or 0.0) * 100))
+            dq_reason = f"low-cardinality; top3 cover {coverage_pct_val}%"
+            allowed_values: List[str] = []
+            for entry in top_values:
+                value = entry.get("value")
+                if value is None:
+                    continue
+                allowed_values.append(_stringify(value))
+                if len(allowed_values) >= 20:
+                    break
+            dq_checks["VALUE_DISTRIBUTION"] = {
+                "params": {
+                    "allowed_values_csv": ", ".join(allowed_values),
+                    "min_match_ratio": 0.9,
+                }
+            }
+        elif is_numeric and min_val is not None and max_val is not None:
+            dq_selected = True
+            dq_reason = f"numeric range {min_val}–{max_val}"
+            dq_checks["MIN_MAX"] = {
+                "params": {
+                    "min": _stringify(min_val) if min_val is not None else None,
+                    "max": _stringify(max_val) if max_val is not None else None,
+                }
+            }
+        elif _is_temporal(dtype):
+            dq_selected = True
+            dq_reason = "temporal range profiling"
+            dq_checks["MIN_MAX"] = {
+                "params": {
+                    "min": _stringify(min_val) if min_val is not None else None,
+                    "max": _stringify(max_val) if max_val is not None else None,
+                }
+            }
+        elif (
+            semantic_type == "DATE_IN_TEXT"
+            and (any_parse_ratio or 0.0) >= 0.6
+        ):
+            dq_selected = True
+            success_pct = int(round((any_parse_ratio or 0.0) * 100))
+            dq_reason = f"dates in text; {success_pct}% parse success"
+            best_format_key = best_date_key
+            if best_format_key:
+                config = DATE_PARSE_CONFIG_MAP.get(best_format_key, {})
+                format_label = DATE_PARSE_LABELS.get(best_format_key, best_format_key)
+                regex_value = config.get("regex") or ""
+                dq_checks["FORMAT_DISTRIBUTION"] = {
+                    "params": {"label": format_label, "regex": regex_value}
+                }
+            dq_checks["MIN_MAX"] = {
+                "params": {"min": parsed_date_min, "max": parsed_date_max}
+            }
+
+        if dq_selected and is_string and (
+            whitespace_ratio >= 0.05 or only_ws_ratio > 0.0
+        ):
+            dq_checks["WHITESPACE"] = {"params": {"mode": "NO_LEADING_TRAILING"}}
+
+        if dq_selected and null_pct_value > 0.0:
+            max_nulls_allowed = int(math.ceil(float(row_cnt) * null_pct_value))
+            dq_checks["NULL_COUNT"] = {"params": {"max_nulls": max_nulls_allowed}}
+
+        column_entry["dq_selected"] = dq_selected
+        column_entry["dq_reason"] = dq_reason
+        column_entry["dq_checks"] = dq_checks
 
         per_column.append(column_entry)
 


### PR DESCRIPTION
- enhance string profiling metrics to count leading/trailing and whitespace-only values and compute derived ratios
- surface whitespace ratios and new percentage fields in column profile payloads
- implement heuristic dq selection with reasons and suggested checks, including whitespace and null follow-ups
- refresh profiling snapshot mirror

------
https://chatgpt.com/codex/tasks/task_e_68fc7063016483248d80175ccfc709eb