### PR TITLE
Restore profiling grid color styling

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1117,14 +1117,14 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             "Min Value": st.column_config.Column("Min Value", disabled=True),
             "Max Value": st.column_config.Column("Max Value", disabled=True),
             "Whitespace %": _column_config_with_optional_style(
-                st.column_config.Column,
+                st.column_config.TextColumn,
                 "Whitespace %",
                 disabled=True,
                 cell_style=_whitespace_cell_style,
             ),
             "Guessed Type": st.column_config.Column("Guessed Type", disabled=True),
             "Confidence": _column_config_with_optional_style(
-                st.column_config.Column,
+                st.column_config.TextColumn,
                 "Confidence",
                 disabled=True,
                 cell_style=_confidence_style,

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1117,14 +1117,14 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             "Min Value": st.column_config.Column("Min Value", disabled=True),
             "Max Value": st.column_config.Column("Max Value", disabled=True),
             "Whitespace %": _column_config_with_optional_style(
-                st.column_config.Column,
+                st.column_config.TextColumn,
                 "Whitespace %",
                 disabled=True,
                 cell_style=_whitespace_cell_style,
             ),
             "Guessed Type": st.column_config.Column("Guessed Type", disabled=True),
             "Confidence": _column_config_with_optional_style(
-                st.column_config.Column,
+                st.column_config.TextColumn,
                 "Confidence",
                 disabled=True,
                 cell_style=_confidence_style,


### PR DESCRIPTION
Restore profiling grid color styling
- Switch the profiling data editor whitespace and confidence columns to TextColumn so cell styles are honored
- Mirror updated snapshot artifacts

------
https://chatgpt.com/codex/tasks/task_e_68fcb0a3f8208324a936d79117c9ad2b