### PR TITLE
Normalize profiling top value buckets

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -2221,29 +2221,23 @@ def run_table_profile(
 
         top_values: List[Dict[str, Any]] = []
         top_coverage = 0
-        if top_n_clamped > 0 and rows_profiled:
-            if is_string:
-                val_norm_expr = (
-                    "CASE WHEN {col} IS NULL THEN NULL "
-                    "WHEN REGEXP_REPLACE({col}::STRING, '\\s+', '') = '' THEN '' "
-                    "ELSE {col}::STRING END AS VAL_NORM"
-                ).format(col=qcol)
-            else:
-                val_norm_expr = (
-                    "CASE WHEN {col} IS NULL THEN NULL ELSE {col}::STRING END AS VAL_NORM"
-                ).format(col=qcol)
+        denom_non_nulls = max(1, int(non_nulls or 0))
+        if top_n_clamped > 0 and rows_profiled and non_nulls:
             top_sql = (
                 "WITH base AS (\n"
-                f"    SELECT {val_norm_expr}\n"
+                f"    SELECT {qcol}::STRING AS s\n"
                 f"    FROM {sampled_ref}\n"
-                "), agg AS (\n"
-                "    SELECT VAL_NORM, COUNT(*) AS CNT\n"
+                "), bucketed AS (\n"
+                "    SELECT CASE\n"
+                "        WHEN s IS NULL THEN '__NULL__'\n"
+                "        WHEN REGEXP_LIKE(s, '^\\s*$') THEN '__EMPTY__'\n"
+                "        ELSE s\n"
+                "    END AS BUCKET\n"
                 "    FROM base\n"
-                "    WHERE VAL_NORM IS NOT NULL\n"
-                "    GROUP BY VAL_NORM\n"
                 ")\n"
-                "SELECT VAL_NORM AS VALUE, CNT\n"
-                "FROM agg\n"
+                "SELECT BUCKET AS VALUE, COUNT(*) AS CNT\n"
+                "FROM bucketed\n"
+                "GROUP BY 1\n"
                 "ORDER BY CNT DESC\n"
                 f"LIMIT {top_n_clamped}"
             )
@@ -2263,8 +2257,10 @@ def run_table_profile(
                             count_int = int(float(count_raw))
                         except Exception:
                             count_int = 0
+                    if value == "__NULL__":
+                        continue
                     top_coverage += count_int
-                    pct = (float(count_int) / float(non_nulls) * 100.0) if non_nulls else 0.0
+                    pct = (float(count_int) / float(denom_non_nulls) * 100.0)
                     top_values.append({"value": value, "count": count_int, "pct": pct})
             except Exception:
                 top_values = []
@@ -2308,12 +2304,8 @@ def run_table_profile(
 
         if is_string and whitespace_length_counts and non_nulls:
             for length_int, count_int in whitespace_length_counts:
-                pct = (float(count_int) / float(non_nulls) * 100.0) if non_nulls else 0.0
+                pct = (float(count_int) / float(denom_non_nulls) * 100.0)
                 top_values.append({"value": f"__WS_LEN__:{length_int}", "count": count_int, "pct": pct})
-
-        if nulls_int > 0:
-            pct = (float(nulls_int) / float(row_cnt) * 100.0) if row_cnt else 0.0
-            top_values.append({"value": None, "count": nulls_int, "pct": pct})
 
         coverage_pct = (float(top_coverage) / non_nulls * 100.0) if non_nulls else 0.0
 

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -2221,29 +2221,23 @@ def run_table_profile(
 
         top_values: List[Dict[str, Any]] = []
         top_coverage = 0
-        if top_n_clamped > 0 and rows_profiled:
-            if is_string:
-                val_norm_expr = (
-                    "CASE WHEN {col} IS NULL THEN NULL "
-                    "WHEN REGEXP_REPLACE({col}::STRING, '\\s+', '') = '' THEN '' "
-                    "ELSE {col}::STRING END AS VAL_NORM"
-                ).format(col=qcol)
-            else:
-                val_norm_expr = (
-                    "CASE WHEN {col} IS NULL THEN NULL ELSE {col}::STRING END AS VAL_NORM"
-                ).format(col=qcol)
+        denom_non_nulls = max(1, int(non_nulls or 0))
+        if top_n_clamped > 0 and rows_profiled and non_nulls:
             top_sql = (
                 "WITH base AS (\n"
-                f"    SELECT {val_norm_expr}\n"
+                f"    SELECT {qcol}::STRING AS s\n"
                 f"    FROM {sampled_ref}\n"
-                "), agg AS (\n"
-                "    SELECT VAL_NORM, COUNT(*) AS CNT\n"
+                "), bucketed AS (\n"
+                "    SELECT CASE\n"
+                "        WHEN s IS NULL THEN '__NULL__'\n"
+                "        WHEN REGEXP_LIKE(s, '^\\s*$') THEN '__EMPTY__'\n"
+                "        ELSE s\n"
+                "    END AS BUCKET\n"
                 "    FROM base\n"
-                "    WHERE VAL_NORM IS NOT NULL\n"
-                "    GROUP BY VAL_NORM\n"
                 ")\n"
-                "SELECT VAL_NORM AS VALUE, CNT\n"
-                "FROM agg\n"
+                "SELECT BUCKET AS VALUE, COUNT(*) AS CNT\n"
+                "FROM bucketed\n"
+                "GROUP BY 1\n"
                 "ORDER BY CNT DESC\n"
                 f"LIMIT {top_n_clamped}"
             )
@@ -2263,8 +2257,10 @@ def run_table_profile(
                             count_int = int(float(count_raw))
                         except Exception:
                             count_int = 0
+                    if value == "__NULL__":
+                        continue
                     top_coverage += count_int
-                    pct = (float(count_int) / float(non_nulls) * 100.0) if non_nulls else 0.0
+                    pct = (float(count_int) / float(denom_non_nulls) * 100.0)
                     top_values.append({"value": value, "count": count_int, "pct": pct})
             except Exception:
                 top_values = []
@@ -2308,12 +2304,8 @@ def run_table_profile(
 
         if is_string and whitespace_length_counts and non_nulls:
             for length_int, count_int in whitespace_length_counts:
-                pct = (float(count_int) / float(non_nulls) * 100.0) if non_nulls else 0.0
+                pct = (float(count_int) / float(denom_non_nulls) * 100.0)
                 top_values.append({"value": f"__WS_LEN__:{length_int}", "count": count_int, "pct": pct})
-
-        if nulls_int > 0:
-            pct = (float(nulls_int) / float(row_cnt) * 100.0) if row_cnt else 0.0
-            top_values.append({"value": None, "count": nulls_int, "pct": pct})
 
         coverage_pct = (float(top_coverage) / non_nulls * 100.0) if non_nulls else 0.0
 

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1219,35 +1219,85 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     st.subheader("Top values by column", anchor=False)
     for _, row in filtered_df.iterrows():
         values = row.get("top_values", [])
-        if not values:
-            continue
-        with st.expander(f"{row['column_name']} ({len(values)} values)"):
+        non_nulls_value = _safe_int(row.get("non_nulls"))
+        label_suffix = f"{len(values)} values"
+        with st.expander(f"{row['column_name']} ({label_suffix})"):
+            if not values:
+                if non_nulls_value is not None and non_nulls_value <= 0:
+                    st.info("No non-null values to display.")
+                else:
+                    st.info("No top values available.")
+                continue
+
             tv_df = pd.DataFrame(values)
             if tv_df.empty:
                 st.table(tv_df)
                 continue
 
             # Normalize common column names when present; otherwise fall back gracefully
-            rename_map = {}
+            rename_map: Dict[Any, str] = {}
             value_column_name: Optional[str] = None
+            count_column_name: Optional[str] = None
             for candidate in tv_df.columns:
-                if str(candidate).lower() in {"value", "val", "values"}:
+                lowered = str(candidate).lower()
+                if lowered in {"value", "val", "values"} and value_column_name is None:
                     value_column_name = candidate
-                    break
-            if "value" in tv_df.columns:
-                rename_map["value"] = "Value"
-            if "count" in tv_df.columns:
-                rename_map["count"] = "Count"
+                if lowered in {"count", "cnt"} and count_column_name is None:
+                    count_column_name = candidate
+            if value_column_name is not None:
+                rename_map[value_column_name] = "Value"
+            if count_column_name is not None:
+                rename_map[count_column_name] = "Count"
             if rename_map:
                 tv_df = tv_df.rename(columns=rename_map)
-                if value_column_name in rename_map:
-                    value_column_name = rename_map[value_column_name]
+                if value_column_name is not None:
+                    value_column_name = "Value"
+                if count_column_name is not None:
+                    count_column_name = "Count"
             elif tv_df.shape[1] == 2:
                 tv_df.columns = ["Value", "Count"]
                 value_column_name = "Value"
+                count_column_name = "Count"
 
             if value_column_name is None and len(tv_df.columns) > 0:
                 value_column_name = tv_df.columns[0]
+            if count_column_name is None and "Count" in tv_df.columns:
+                count_column_name = "Count"
+
+            pct_columns = [col for col in tv_df.columns if "pct" in str(col).lower()]
+
+            if value_column_name and count_column_name:
+                empty_mask = tv_df[value_column_name] == "__EMPTY__"
+                if empty_mask.any():
+                    total_empty = (
+                        tv_df.loc[empty_mask, count_column_name]
+                        .apply(lambda x: _safe_int(x) or 0)
+                        .sum()
+                    )
+                    tv_df = tv_df.loc[~empty_mask].copy()
+                    new_row = {col: None for col in tv_df.columns}
+                    new_row[value_column_name] = "__EMPTY__"
+                    new_row[count_column_name] = total_empty
+                    if pct_columns:
+                        denom_raw = non_nulls_value
+                        if denom_raw is None or denom_raw <= 0:
+                            pct_value = 0.0
+                        else:
+                            pct_value = (float(total_empty) / float(denom_raw)) * 100.0
+                        for pct_col in pct_columns:
+                            new_row[pct_col] = pct_value
+                    tv_df = pd.concat([tv_df, pd.DataFrame([new_row])], ignore_index=True)
+
+            if value_column_name and value_column_name in tv_df.columns:
+                tv_df[value_column_name] = tv_df[value_column_name].replace(
+                    {"__EMPTY__": '"" (empty/whitespace)'}
+                )
+
+            for pct_col in pct_columns:
+                tv_df[pct_col] = tv_df[pct_col].apply(_safe_float)
+                tv_df[pct_col] = tv_df[pct_col].apply(
+                    lambda x: None if x is None else min(100.0, max(0.0, x))
+                )
 
             nulls = _safe_int(row.get("nulls"))
             row_cnt = _safe_int(row.get("row_cnt"))
@@ -1269,10 +1319,10 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 else:
                     tv_df = tv_df.head(1).copy()
 
-            if "Count" in tv_df.columns:
-                tv_df["Count"] = tv_df["Count"].apply(_format_count)
+            if count_column_name and count_column_name in tv_df.columns:
+                tv_df[count_column_name] = tv_df[count_column_name].apply(_format_count)
             for col in tv_df.columns:
-                if col == "Count":
+                if count_column_name and col == count_column_name:
                     continue
                 if value_column_name and col == value_column_name:
                     tv_df[col] = tv_df[col].apply(_format_top_value_cell)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1219,35 +1219,85 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     st.subheader("Top values by column", anchor=False)
     for _, row in filtered_df.iterrows():
         values = row.get("top_values", [])
-        if not values:
-            continue
-        with st.expander(f"{row['column_name']} ({len(values)} values)"):
+        non_nulls_value = _safe_int(row.get("non_nulls"))
+        label_suffix = f"{len(values)} values"
+        with st.expander(f"{row['column_name']} ({label_suffix})"):
+            if not values:
+                if non_nulls_value is not None and non_nulls_value <= 0:
+                    st.info("No non-null values to display.")
+                else:
+                    st.info("No top values available.")
+                continue
+
             tv_df = pd.DataFrame(values)
             if tv_df.empty:
                 st.table(tv_df)
                 continue
 
             # Normalize common column names when present; otherwise fall back gracefully
-            rename_map = {}
+            rename_map: Dict[Any, str] = {}
             value_column_name: Optional[str] = None
+            count_column_name: Optional[str] = None
             for candidate in tv_df.columns:
-                if str(candidate).lower() in {"value", "val", "values"}:
+                lowered = str(candidate).lower()
+                if lowered in {"value", "val", "values"} and value_column_name is None:
                     value_column_name = candidate
-                    break
-            if "value" in tv_df.columns:
-                rename_map["value"] = "Value"
-            if "count" in tv_df.columns:
-                rename_map["count"] = "Count"
+                if lowered in {"count", "cnt"} and count_column_name is None:
+                    count_column_name = candidate
+            if value_column_name is not None:
+                rename_map[value_column_name] = "Value"
+            if count_column_name is not None:
+                rename_map[count_column_name] = "Count"
             if rename_map:
                 tv_df = tv_df.rename(columns=rename_map)
-                if value_column_name in rename_map:
-                    value_column_name = rename_map[value_column_name]
+                if value_column_name is not None:
+                    value_column_name = "Value"
+                if count_column_name is not None:
+                    count_column_name = "Count"
             elif tv_df.shape[1] == 2:
                 tv_df.columns = ["Value", "Count"]
                 value_column_name = "Value"
+                count_column_name = "Count"
 
             if value_column_name is None and len(tv_df.columns) > 0:
                 value_column_name = tv_df.columns[0]
+            if count_column_name is None and "Count" in tv_df.columns:
+                count_column_name = "Count"
+
+            pct_columns = [col for col in tv_df.columns if "pct" in str(col).lower()]
+
+            if value_column_name and count_column_name:
+                empty_mask = tv_df[value_column_name] == "__EMPTY__"
+                if empty_mask.any():
+                    total_empty = (
+                        tv_df.loc[empty_mask, count_column_name]
+                        .apply(lambda x: _safe_int(x) or 0)
+                        .sum()
+                    )
+                    tv_df = tv_df.loc[~empty_mask].copy()
+                    new_row = {col: None for col in tv_df.columns}
+                    new_row[value_column_name] = "__EMPTY__"
+                    new_row[count_column_name] = total_empty
+                    if pct_columns:
+                        denom_raw = non_nulls_value
+                        if denom_raw is None or denom_raw <= 0:
+                            pct_value = 0.0
+                        else:
+                            pct_value = (float(total_empty) / float(denom_raw)) * 100.0
+                        for pct_col in pct_columns:
+                            new_row[pct_col] = pct_value
+                    tv_df = pd.concat([tv_df, pd.DataFrame([new_row])], ignore_index=True)
+
+            if value_column_name and value_column_name in tv_df.columns:
+                tv_df[value_column_name] = tv_df[value_column_name].replace(
+                    {"__EMPTY__": '"" (empty/whitespace)'}
+                )
+
+            for pct_col in pct_columns:
+                tv_df[pct_col] = tv_df[pct_col].apply(_safe_float)
+                tv_df[pct_col] = tv_df[pct_col].apply(
+                    lambda x: None if x is None else min(100.0, max(0.0, x))
+                )
 
             nulls = _safe_int(row.get("nulls"))
             row_cnt = _safe_int(row.get("row_cnt"))
@@ -1269,10 +1319,10 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 else:
                     tv_df = tv_df.head(1).copy()
 
-            if "Count" in tv_df.columns:
-                tv_df["Count"] = tv_df["Count"].apply(_format_count)
+            if count_column_name and count_column_name in tv_df.columns:
+                tv_df[count_column_name] = tv_df[count_column_name].apply(_format_count)
             for col in tv_df.columns:
-                if col == "Count":
+                if count_column_name and col == count_column_name:
                     continue
                 if value_column_name and col == value_column_name:
                     tv_df[col] = tv_df[col].apply(_format_top_value_cell)


### PR DESCRIPTION
Normalize profiling top value buckets
- Bucket top value profiling SQL to isolate NULL and empty buckets while using non-null counts for percentages.
- Update the top values UI to merge empty buckets, show friendly labels, clamp percentages, and surface a message when no non-null values exist.
- Mirror updated Python snapshots.

------
https://chatgpt.com/codex/tasks/task_e_6903662d3ea883248d69109aa5349dc8