### PR TITLE
fix: remove unsupported progress column flag

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1155,7 +1155,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         format="%.1f%%",
                         min_value=0.0,
                         max_value=100.0,
-                        disabled=True,
                     ),
                     "Note": st.column_config.Column("Note", disabled=True),
                 },

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1155,7 +1155,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         format="%.1f%%",
                         min_value=0.0,
                         max_value=100.0,
-                        disabled=True,
                     ),
                     "Note": st.column_config.Column("Note", disabled=True),
                 },


### PR DESCRIPTION
- remove the unsupported `disabled` argument from the profile confidence progress column
- refresh the mirrored profile_view snapshot

------
https://chatgpt.com/codex/tasks/task_e_6903764ce5f883249fdb1689b5a3a876