### PR TITLE
feat: load saved profiling runs

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -17,6 +17,8 @@ from utils.meta import _q
 
 __all__ = [
     "list_columns",
+    "list_saved_profiles",
+    "load_profile_run",
     "run_table_profile",
     "suggest_checks_from_profile",
     "save_profile_results",
@@ -1518,6 +1520,49 @@ def _extract_row_value(row, key: str, default=None):
         return default
 
 
+def _coerce_variant_map(value: Any) -> Dict[str, Any]:
+    """Best-effort conversion of a Snowflake VARIANT payload into a dict."""
+
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "asDict"):
+        try:
+            data = value.asDict()
+        except Exception:  # pragma: no cover - defensive fallback
+            data = None
+        if isinstance(data, dict):
+            return dict(data)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+        return {}
+    return {}
+
+
+def _coerce_variant_value(value: Any) -> Any:
+    """Return a Python value from a Snowflake VARIANT payload when possible."""
+
+    if value is None:
+        return None
+    if hasattr(value, "asDict"):
+        try:
+            return value.asDict()
+        except Exception:  # pragma: no cover - defensive fallback
+            return None
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+    return value
+
+
 def run_table_profile(
     session,
     fqn: str,
@@ -3000,3 +3045,192 @@ def save_profile_results(
         ).collect()
 
     return str(run_id)
+
+
+def list_saved_profiles(session, meta_db: str, meta_schema: str) -> List[Dict[str, Any]]:
+    """Return recent saved profile runs from the metadata tables."""
+
+    if not session or not (meta_db and meta_schema):
+        return []
+
+    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
+    sql = (
+        f"SELECT RUN_ID, RUN_AT, SUMMARY FROM {runs_tbl} "
+        "ORDER BY RUN_AT DESC LIMIT 25"
+    )
+
+    try:
+        rows = session.sql(sql).collect()
+    except Exception:  # pragma: no cover - Snowflake specific
+        logger.debug("Unable to list saved profile runs", exc_info=True)
+        return []
+
+    results: List[Dict[str, Any]] = []
+    for row in rows:
+        if hasattr(row, "asDict"):
+            data = row.asDict()
+        else:
+            data = {}
+            try:
+                data["RUN_ID"] = row[0]
+                data["RUN_AT"] = row[1] if len(row) > 1 else None
+                data["SUMMARY"] = row[2] if len(row) > 2 else None
+            except Exception:
+                data = {}
+
+        run_id_value = data.get("RUN_ID") or data.get("run_id")
+        if not run_id_value:
+            continue
+
+        summary_payload = _coerce_variant_map(data.get("SUMMARY") or data.get("summary"))
+        results.append(
+            {
+                "run_id": str(run_id_value),
+                "run_at": data.get("RUN_AT") or data.get("run_at"),
+                "summary": summary_payload,
+            }
+        )
+
+    return results
+
+
+def load_profile_run(
+    session,
+    meta_db: str,
+    meta_schema: str,
+    run_id: str,
+) -> Dict[str, Any]:
+    """Reconstruct a saved profile run from metadata tables."""
+
+    if not session or not (meta_db and meta_schema) or not run_id:
+        return {}
+
+    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
+    cols_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_COLUMN"
+
+    try:
+        run_rows = session.sql(
+            f"SELECT RUN_ID, SUMMARY FROM {runs_tbl} WHERE RUN_ID = ?",
+            params=[run_id],
+        ).collect()
+    except Exception:  # pragma: no cover - Snowflake specific
+        logger.debug("Unable to load saved profile run %s", run_id, exc_info=True)
+        return {}
+
+    if not run_rows:
+        return {}
+
+    summary_payload = _coerce_variant_map(
+        _extract_row_value(run_rows[0], "SUMMARY")
+    )
+
+    target_table = summary_payload.get("target_table") or summary_payload.get("table")
+
+    def _coerce_int(value: Any) -> Optional[int]:
+        try:
+            return int(value)
+        except Exception:
+            return None
+
+    def _coerce_float(value: Any) -> Optional[float]:
+        try:
+            return float(value)
+        except Exception:
+            return None
+
+    top_n: Optional[int]
+    top_n = _coerce_int(summary_payload.get("top_n"))
+
+    columns: List[Dict[str, Any]] = []
+    try:
+        column_rows = session.sql(
+            f"""
+            SELECT COLUMN_NAME, PROFILE, SEMANTIC_TYPE, CONFIDENCE, RATIONALE, SIGNALS, SUGGESTED_CHECKS
+            FROM {cols_tbl}
+            WHERE RUN_ID = ?
+            ORDER BY COLUMN_NAME
+            """,
+            params=[run_id],
+        ).collect()
+    except Exception:  # pragma: no cover - Snowflake specific
+        logger.debug("Unable to load saved profile columns for %s", run_id, exc_info=True)
+        column_rows = []
+
+    for row in column_rows:
+        if hasattr(row, "asDict"):
+            data = row.asDict()
+        else:
+            try:
+                data = {
+                    "COLUMN_NAME": row[0],
+                    "PROFILE": row[1] if len(row) > 1 else None,
+                    "SEMANTIC_TYPE": row[2] if len(row) > 2 else None,
+                    "CONFIDENCE": row[3] if len(row) > 3 else None,
+                    "RATIONALE": row[4] if len(row) > 4 else None,
+                    "SIGNALS": row[5] if len(row) > 5 else None,
+                    "SUGGESTED_CHECKS": row[6] if len(row) > 6 else None,
+                }
+            except Exception:
+                data = {}
+
+        profile_payload = _coerce_variant_map(data.get("PROFILE") or data.get("profile"))
+        if not profile_payload:
+            profile_payload = {}
+
+        merged = dict(profile_payload)
+
+        for key in ("semantic_type", "confidence", "rationale"):
+            upper = key.upper()
+            value = data.get(upper) if upper in data else data.get(key)
+            if value is not None:
+                merged[key] = value
+
+        signals_value = data.get("SIGNALS") or data.get("signals")
+        if signals_value is not None:
+            merged["signals"] = _coerce_variant_value(signals_value)
+
+        suggested_value = data.get("SUGGESTED_CHECKS") or data.get("suggested_checks")
+        if suggested_value is not None:
+            merged["suggested_checks"] = _coerce_variant_value(suggested_value)
+
+        merged.setdefault("column_name", data.get("COLUMN_NAME") or data.get("column_name") or "")
+
+        normalized = normalize_profile_row(merged)
+        columns.append(normalized)
+
+    rows_profiled_value = _coerce_int(summary_payload.get("rows_profiled"))
+    if rows_profiled_value is None:
+        rows_profiled_value = 0
+
+    sample_pct_raw = summary_payload.get("sample_pct")
+    if sample_pct_raw is None:
+        sample_pct_value: Optional[float] = None
+    else:
+        sample_pct_value = _coerce_float(sample_pct_raw)
+        if sample_pct_value is None:
+            try:
+                sample_pct_value = float(sample_pct_raw)
+            except Exception:
+                sample_pct_value = None
+
+    duration_value = _coerce_float(summary_payload.get("duration_sec"))
+    if duration_value is None:
+        duration_value = 0.0
+
+    columns_count = len(columns) if columns else _coerce_int(summary_payload.get("columns"))
+    if columns_count is None:
+        columns_count = len(columns)
+
+    summary_out = {
+        "rows_profiled": rows_profiled_value,
+        "sample_pct": sample_pct_value,
+        "duration_sec": duration_value,
+        "columns": columns_count,
+    }
+
+    return {
+        "target_table": target_table,
+        "summary": summary_out,
+        "columns": columns,
+        "top_n": top_n,
+    }

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -17,6 +17,8 @@ from utils.meta import _q
 
 __all__ = [
     "list_columns",
+    "list_saved_profiles",
+    "load_profile_run",
     "run_table_profile",
     "suggest_checks_from_profile",
     "save_profile_results",
@@ -1518,6 +1520,49 @@ def _extract_row_value(row, key: str, default=None):
         return default
 
 
+def _coerce_variant_map(value: Any) -> Dict[str, Any]:
+    """Best-effort conversion of a Snowflake VARIANT payload into a dict."""
+
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "asDict"):
+        try:
+            data = value.asDict()
+        except Exception:  # pragma: no cover - defensive fallback
+            data = None
+        if isinstance(data, dict):
+            return dict(data)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+        return {}
+    return {}
+
+
+def _coerce_variant_value(value: Any) -> Any:
+    """Return a Python value from a Snowflake VARIANT payload when possible."""
+
+    if value is None:
+        return None
+    if hasattr(value, "asDict"):
+        try:
+            return value.asDict()
+        except Exception:  # pragma: no cover - defensive fallback
+            return None
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+    return value
+
+
 def run_table_profile(
     session,
     fqn: str,
@@ -3000,3 +3045,192 @@ def save_profile_results(
         ).collect()
 
     return str(run_id)
+
+
+def list_saved_profiles(session, meta_db: str, meta_schema: str) -> List[Dict[str, Any]]:
+    """Return recent saved profile runs from the metadata tables."""
+
+    if not session or not (meta_db and meta_schema):
+        return []
+
+    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
+    sql = (
+        f"SELECT RUN_ID, RUN_AT, SUMMARY FROM {runs_tbl} "
+        "ORDER BY RUN_AT DESC LIMIT 25"
+    )
+
+    try:
+        rows = session.sql(sql).collect()
+    except Exception:  # pragma: no cover - Snowflake specific
+        logger.debug("Unable to list saved profile runs", exc_info=True)
+        return []
+
+    results: List[Dict[str, Any]] = []
+    for row in rows:
+        if hasattr(row, "asDict"):
+            data = row.asDict()
+        else:
+            data = {}
+            try:
+                data["RUN_ID"] = row[0]
+                data["RUN_AT"] = row[1] if len(row) > 1 else None
+                data["SUMMARY"] = row[2] if len(row) > 2 else None
+            except Exception:
+                data = {}
+
+        run_id_value = data.get("RUN_ID") or data.get("run_id")
+        if not run_id_value:
+            continue
+
+        summary_payload = _coerce_variant_map(data.get("SUMMARY") or data.get("summary"))
+        results.append(
+            {
+                "run_id": str(run_id_value),
+                "run_at": data.get("RUN_AT") or data.get("run_at"),
+                "summary": summary_payload,
+            }
+        )
+
+    return results
+
+
+def load_profile_run(
+    session,
+    meta_db: str,
+    meta_schema: str,
+    run_id: str,
+) -> Dict[str, Any]:
+    """Reconstruct a saved profile run from metadata tables."""
+
+    if not session or not (meta_db and meta_schema) or not run_id:
+        return {}
+
+    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
+    cols_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_COLUMN"
+
+    try:
+        run_rows = session.sql(
+            f"SELECT RUN_ID, SUMMARY FROM {runs_tbl} WHERE RUN_ID = ?",
+            params=[run_id],
+        ).collect()
+    except Exception:  # pragma: no cover - Snowflake specific
+        logger.debug("Unable to load saved profile run %s", run_id, exc_info=True)
+        return {}
+
+    if not run_rows:
+        return {}
+
+    summary_payload = _coerce_variant_map(
+        _extract_row_value(run_rows[0], "SUMMARY")
+    )
+
+    target_table = summary_payload.get("target_table") or summary_payload.get("table")
+
+    def _coerce_int(value: Any) -> Optional[int]:
+        try:
+            return int(value)
+        except Exception:
+            return None
+
+    def _coerce_float(value: Any) -> Optional[float]:
+        try:
+            return float(value)
+        except Exception:
+            return None
+
+    top_n: Optional[int]
+    top_n = _coerce_int(summary_payload.get("top_n"))
+
+    columns: List[Dict[str, Any]] = []
+    try:
+        column_rows = session.sql(
+            f"""
+            SELECT COLUMN_NAME, PROFILE, SEMANTIC_TYPE, CONFIDENCE, RATIONALE, SIGNALS, SUGGESTED_CHECKS
+            FROM {cols_tbl}
+            WHERE RUN_ID = ?
+            ORDER BY COLUMN_NAME
+            """,
+            params=[run_id],
+        ).collect()
+    except Exception:  # pragma: no cover - Snowflake specific
+        logger.debug("Unable to load saved profile columns for %s", run_id, exc_info=True)
+        column_rows = []
+
+    for row in column_rows:
+        if hasattr(row, "asDict"):
+            data = row.asDict()
+        else:
+            try:
+                data = {
+                    "COLUMN_NAME": row[0],
+                    "PROFILE": row[1] if len(row) > 1 else None,
+                    "SEMANTIC_TYPE": row[2] if len(row) > 2 else None,
+                    "CONFIDENCE": row[3] if len(row) > 3 else None,
+                    "RATIONALE": row[4] if len(row) > 4 else None,
+                    "SIGNALS": row[5] if len(row) > 5 else None,
+                    "SUGGESTED_CHECKS": row[6] if len(row) > 6 else None,
+                }
+            except Exception:
+                data = {}
+
+        profile_payload = _coerce_variant_map(data.get("PROFILE") or data.get("profile"))
+        if not profile_payload:
+            profile_payload = {}
+
+        merged = dict(profile_payload)
+
+        for key in ("semantic_type", "confidence", "rationale"):
+            upper = key.upper()
+            value = data.get(upper) if upper in data else data.get(key)
+            if value is not None:
+                merged[key] = value
+
+        signals_value = data.get("SIGNALS") or data.get("signals")
+        if signals_value is not None:
+            merged["signals"] = _coerce_variant_value(signals_value)
+
+        suggested_value = data.get("SUGGESTED_CHECKS") or data.get("suggested_checks")
+        if suggested_value is not None:
+            merged["suggested_checks"] = _coerce_variant_value(suggested_value)
+
+        merged.setdefault("column_name", data.get("COLUMN_NAME") or data.get("column_name") or "")
+
+        normalized = normalize_profile_row(merged)
+        columns.append(normalized)
+
+    rows_profiled_value = _coerce_int(summary_payload.get("rows_profiled"))
+    if rows_profiled_value is None:
+        rows_profiled_value = 0
+
+    sample_pct_raw = summary_payload.get("sample_pct")
+    if sample_pct_raw is None:
+        sample_pct_value: Optional[float] = None
+    else:
+        sample_pct_value = _coerce_float(sample_pct_raw)
+        if sample_pct_value is None:
+            try:
+                sample_pct_value = float(sample_pct_raw)
+            except Exception:
+                sample_pct_value = None
+
+    duration_value = _coerce_float(summary_payload.get("duration_sec"))
+    if duration_value is None:
+        duration_value = 0.0
+
+    columns_count = len(columns) if columns else _coerce_int(summary_payload.get("columns"))
+    if columns_count is None:
+        columns_count = len(columns)
+
+    summary_out = {
+        "rows_profiled": rows_profiled_value,
+        "sample_pct": sample_pct_value,
+        "duration_sec": duration_value,
+        "columns": columns_count,
+    }
+
+    return {
+        "target_table": target_table,
+        "summary": summary_out,
+        "columns": columns,
+        "top_n": top_n,
+    }

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -13,7 +13,13 @@ import pandas as pd
 import streamlit as st
 
 from services.profile import build_profile_suggestion
-from services.profiling import normalize_profile_row, run_table_profile, save_profile_results
+from services.profiling import (
+    list_saved_profiles,
+    load_profile_run,
+    normalize_profile_row,
+    run_table_profile,
+    save_profile_results,
+)
 from utils.meta import get_table_row_count
 from views.table_picker import session_cache_token, stateless_table_picker
 
@@ -568,6 +574,46 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         st.session_state["profile_target_fqn"] = selected_fqn
 
     st.divider()
+
+    def _format_saved_run_label(run: Dict[str, Any]) -> str:
+        run_at = run.get("run_at")
+        if isinstance(run_at, datetime):
+            run_at_display = run_at.strftime("%Y-%m-%d %H:%M")
+        else:
+            run_at_display = str(run_at) if run_at else "Unknown time"
+        summary_payload = run.get("summary") or {}
+        if isinstance(summary_payload, dict):
+            target_table = summary_payload.get("target_table") or summary_payload.get("table")
+            top_n_raw = summary_payload.get("top_n")
+            try:
+                top_n = int(float(top_n_raw)) if top_n_raw is not None else None
+            except Exception:
+                top_n = None
+        else:
+            target_table = None
+            top_n = None
+        table_display = str(target_table or "Unknown table")
+        run_id_value = str(run.get("run_id") or "")
+        short_id = run_id_value[:8] if run_id_value else "—"
+        top_n_suffix = f" (Top {top_n})" if isinstance(top_n, (int, float)) else ""
+        return f"{run_at_display} — {table_display}{top_n_suffix} — {short_id}"
+
+    saved_profiles_enabled = bool(session and meta_db and meta_schema)
+    saved_profile_runs: List[Dict[str, Any]] = []
+    if saved_profiles_enabled:
+        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema)
+
+    saved_run_lookup: Dict[str, str] = {}
+    saved_run_labels: List[str] = []
+    for run in saved_profile_runs:
+        run_id_value = run.get("run_id")
+        if not run_id_value:
+            continue
+        run_id_str = str(run_id_value)
+        label = _format_saved_run_label(run)
+        saved_run_lookup[label] = run_id_str
+        saved_run_labels.append(label)
+
     controls = st.columns(3)
     suggested_pct = 10.0
     row_count: Optional[int] = None
@@ -620,12 +666,70 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             step=1,
             help=f"Collect up to {MAX_TOP_N} of the most common values per column.",
         )
+    load_selected_run_id: Optional[str] = None
+    load_button_clicked = False
     with controls[2]:
-        save_profile = st.button("💾 Save Profile", disabled=True, help="Coming soon")
-        if save_profile:
-            st.info("Saving profiles is not yet supported.")
+        if saved_run_labels:
+            load_options = ["— Select a saved run —"] + saved_run_labels
+            selected_option = st.selectbox(
+                "Load saved profile",
+                options=load_options,
+                key="profile_load_select",
+                disabled=not saved_profiles_enabled,
+            )
+            if selected_option in saved_run_lookup:
+                load_selected_run_id = saved_run_lookup[selected_option]
+        else:
+            st.selectbox(
+                "Load saved profile",
+                options=["— No saved profiles —"],
+                key="profile_load_select",
+                disabled=True,
+            )
+        load_button_clicked = st.button(
+            "Load",
+            key="profile_load_button",
+            disabled=not (saved_profiles_enabled and load_selected_run_id),
+        )
+        if not saved_profiles_enabled:
+            st.caption(
+                "Connect to Snowflake and configure metadata targets to enable loading saved profiles."
+            )
+        elif not saved_run_labels:
+            st.caption("No saved profiles found in metadata tables yet.")
+
+    if load_button_clicked:
+        if not saved_profiles_enabled:
+            st.warning("Loading profiles requires a Snowflake connection and metadata configuration.")
+        elif not load_selected_run_id:
+            st.warning("Select a saved run to load.")
+        else:
+            try:
+                loaded_profile = load_profile_run(
+                    session=session,
+                    meta_db=meta_db,
+                    meta_schema=meta_schema,
+                    run_id=load_selected_run_id,
+                )
+            except Exception as exc:  # pragma: no cover - Snowflake specific
+                st.error(f"Failed to load saved profile: {exc}")
+            else:
+                if not loaded_profile:
+                    st.warning("Saved profile was not found or is empty.")
+                else:
+                    st.session_state["profile_results"] = loaded_profile
+                    st.session_state["profile_loaded_run_id"] = load_selected_run_id
+                    target_table = loaded_profile.get("target_table")
+                    if target_table:
+                        st.session_state["profile_target_fqn"] = target_table
+                    st.success(f"Loaded saved profile {load_selected_run_id}.")
+                    st.rerun()
 
     stored_profile_result = st.session_state.get("profile_results")
+    loaded_run_id = st.session_state.get("profile_loaded_run_id")
+    if loaded_run_id and not stored_profile_result:
+        st.session_state.pop("profile_loaded_run_id", None)
+        loaded_run_id = None
     selection_state_raw = st.session_state.get("profile_select")
     if isinstance(selection_state_raw, dict):
         selection_state: Dict[str, bool] = dict(selection_state_raw)
@@ -683,8 +787,9 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     )
 
     button_cols = st.columns([1, 1, 2])
+    run_disabled = bool(loaded_run_id)
     with button_cols[0]:
-        run_profile = st.button("▶️ Run Profile", type="primary")
+        run_profile = st.button("▶️ Run Profile", type="primary", disabled=run_disabled)
     with button_cols[1]:
         suggest_cfg = st.button(
             "✨ Suggest DQ Config",
@@ -692,9 +797,24 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             disabled=not stored_profile_result,
         )
 
+    clear_loaded = False
+    if loaded_run_id:
+        with button_cols[2]:
+            st.info("Viewing a saved profile.")
+            clear_loaded = st.button("Clear loaded profile", key="profile_clear_loaded")
+    else:
+        button_cols[2].empty()
+
+    if clear_loaded:
+        st.session_state.pop("profile_loaded_run_id", None)
+        loaded_run_id = None
+        st.rerun()
+
     profile_result = stored_profile_result
 
     if run_profile:
+        st.session_state.pop("profile_loaded_run_id", None)
+        loaded_run_id = None
         if not session:
             st.error("No active Snowpark session — unable to profile tables.")
         elif not selected_fqn:

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -13,7 +13,13 @@ import pandas as pd
 import streamlit as st
 
 from services.profile import build_profile_suggestion
-from services.profiling import normalize_profile_row, run_table_profile, save_profile_results
+from services.profiling import (
+    list_saved_profiles,
+    load_profile_run,
+    normalize_profile_row,
+    run_table_profile,
+    save_profile_results,
+)
 from utils.meta import get_table_row_count
 from views.table_picker import session_cache_token, stateless_table_picker
 
@@ -568,6 +574,46 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         st.session_state["profile_target_fqn"] = selected_fqn
 
     st.divider()
+
+    def _format_saved_run_label(run: Dict[str, Any]) -> str:
+        run_at = run.get("run_at")
+        if isinstance(run_at, datetime):
+            run_at_display = run_at.strftime("%Y-%m-%d %H:%M")
+        else:
+            run_at_display = str(run_at) if run_at else "Unknown time"
+        summary_payload = run.get("summary") or {}
+        if isinstance(summary_payload, dict):
+            target_table = summary_payload.get("target_table") or summary_payload.get("table")
+            top_n_raw = summary_payload.get("top_n")
+            try:
+                top_n = int(float(top_n_raw)) if top_n_raw is not None else None
+            except Exception:
+                top_n = None
+        else:
+            target_table = None
+            top_n = None
+        table_display = str(target_table or "Unknown table")
+        run_id_value = str(run.get("run_id") or "")
+        short_id = run_id_value[:8] if run_id_value else "—"
+        top_n_suffix = f" (Top {top_n})" if isinstance(top_n, (int, float)) else ""
+        return f"{run_at_display} — {table_display}{top_n_suffix} — {short_id}"
+
+    saved_profiles_enabled = bool(session and meta_db and meta_schema)
+    saved_profile_runs: List[Dict[str, Any]] = []
+    if saved_profiles_enabled:
+        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema)
+
+    saved_run_lookup: Dict[str, str] = {}
+    saved_run_labels: List[str] = []
+    for run in saved_profile_runs:
+        run_id_value = run.get("run_id")
+        if not run_id_value:
+            continue
+        run_id_str = str(run_id_value)
+        label = _format_saved_run_label(run)
+        saved_run_lookup[label] = run_id_str
+        saved_run_labels.append(label)
+
     controls = st.columns(3)
     suggested_pct = 10.0
     row_count: Optional[int] = None
@@ -620,12 +666,70 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             step=1,
             help=f"Collect up to {MAX_TOP_N} of the most common values per column.",
         )
+    load_selected_run_id: Optional[str] = None
+    load_button_clicked = False
     with controls[2]:
-        save_profile = st.button("💾 Save Profile", disabled=True, help="Coming soon")
-        if save_profile:
-            st.info("Saving profiles is not yet supported.")
+        if saved_run_labels:
+            load_options = ["— Select a saved run —"] + saved_run_labels
+            selected_option = st.selectbox(
+                "Load saved profile",
+                options=load_options,
+                key="profile_load_select",
+                disabled=not saved_profiles_enabled,
+            )
+            if selected_option in saved_run_lookup:
+                load_selected_run_id = saved_run_lookup[selected_option]
+        else:
+            st.selectbox(
+                "Load saved profile",
+                options=["— No saved profiles —"],
+                key="profile_load_select",
+                disabled=True,
+            )
+        load_button_clicked = st.button(
+            "Load",
+            key="profile_load_button",
+            disabled=not (saved_profiles_enabled and load_selected_run_id),
+        )
+        if not saved_profiles_enabled:
+            st.caption(
+                "Connect to Snowflake and configure metadata targets to enable loading saved profiles."
+            )
+        elif not saved_run_labels:
+            st.caption("No saved profiles found in metadata tables yet.")
+
+    if load_button_clicked:
+        if not saved_profiles_enabled:
+            st.warning("Loading profiles requires a Snowflake connection and metadata configuration.")
+        elif not load_selected_run_id:
+            st.warning("Select a saved run to load.")
+        else:
+            try:
+                loaded_profile = load_profile_run(
+                    session=session,
+                    meta_db=meta_db,
+                    meta_schema=meta_schema,
+                    run_id=load_selected_run_id,
+                )
+            except Exception as exc:  # pragma: no cover - Snowflake specific
+                st.error(f"Failed to load saved profile: {exc}")
+            else:
+                if not loaded_profile:
+                    st.warning("Saved profile was not found or is empty.")
+                else:
+                    st.session_state["profile_results"] = loaded_profile
+                    st.session_state["profile_loaded_run_id"] = load_selected_run_id
+                    target_table = loaded_profile.get("target_table")
+                    if target_table:
+                        st.session_state["profile_target_fqn"] = target_table
+                    st.success(f"Loaded saved profile {load_selected_run_id}.")
+                    st.rerun()
 
     stored_profile_result = st.session_state.get("profile_results")
+    loaded_run_id = st.session_state.get("profile_loaded_run_id")
+    if loaded_run_id and not stored_profile_result:
+        st.session_state.pop("profile_loaded_run_id", None)
+        loaded_run_id = None
     selection_state_raw = st.session_state.get("profile_select")
     if isinstance(selection_state_raw, dict):
         selection_state: Dict[str, bool] = dict(selection_state_raw)
@@ -683,8 +787,9 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     )
 
     button_cols = st.columns([1, 1, 2])
+    run_disabled = bool(loaded_run_id)
     with button_cols[0]:
-        run_profile = st.button("▶️ Run Profile", type="primary")
+        run_profile = st.button("▶️ Run Profile", type="primary", disabled=run_disabled)
     with button_cols[1]:
         suggest_cfg = st.button(
             "✨ Suggest DQ Config",
@@ -692,9 +797,24 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             disabled=not stored_profile_result,
         )
 
+    clear_loaded = False
+    if loaded_run_id:
+        with button_cols[2]:
+            st.info("Viewing a saved profile.")
+            clear_loaded = st.button("Clear loaded profile", key="profile_clear_loaded")
+    else:
+        button_cols[2].empty()
+
+    if clear_loaded:
+        st.session_state.pop("profile_loaded_run_id", None)
+        loaded_run_id = None
+        st.rerun()
+
     profile_result = stored_profile_result
 
     if run_profile:
+        st.session_state.pop("profile_loaded_run_id", None)
+        loaded_run_id = None
         if not session:
             st.error("No active Snowpark session — unable to profile tables.")
         elif not selected_fqn:


### PR DESCRIPTION
* add metadata helpers to list and load saved profile runs
* update the profiling view to load saved results and disable the run action while viewing them
* remove the unused placeholder save button and keep the existing save toggle

------
https://chatgpt.com/codex/tasks/task_e_6903776a00cc8324ba7f89e4284d6602