### PR TITLE
Create UI contract files for key screens

### DIFF
--- a/docs/ui_contract_cfg.md
+++ b/docs/ui_contract_cfg.md
@@ -1,0 +1,31 @@
+UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Controls (top to bottom):
+1. Header row with two columns sized `[1, 8]`.  Left column must contain the "⬅ Back" button wired to return to the list view.  Right column must render the header "Edit Configuration" when editing or "Create Configuration" when creating.
+2. When profile suggestions are applied, show a single success alert summarising rows profiled and sample percentage exactly as implemented; no additional banners precede the Target section.
+3. Subheader "Target" with the stateless table picker (database, schema, table) capturing the selected fully qualified name into `editor_target_fqn`.  Immediately below, display the caption `Target Table: <value>` where `<value>` resolves to the selected table or "— not selected —".
+4. Heading "### Columns" followed by a multiselect labelled "Columns to check" listing available table columns.  The informational message "Table-level checks **FRESHNESS** and **ROW_COUNT_ANOMALY** are automatically included." must follow directly beneath the multiselect.
+5. Configuration form `cfg_form` containing elements in this fixed order:
+   a. Subheader "Configuration".
+   b. Disabled text input "Name" with automatic derivation help text.  No manual name entry control may be added.
+   c. Text area "Description" allowing optional free-form notes.
+   d. For each selected column, render an expander titled `Column: <column>` (collapsed by default).  Inside each expander, controls must appear exactly as follows:
+      • Number input "Sample failing rows for <column>" (0–1000, default 10).
+      • Checkbox "UNIQUE".  When checked, show the `Ignore NULLs` checkbox (defaults True) followed by the selectbox `Severity (UNIQUE)` with options `ERROR`, `WARN` in that order.
+      • Checkbox "NULL_COUNT".  When checked, show number input `Max NULL rows` (minimum 0) then selectbox `Severity (NULL_COUNT)` with options `ERROR`, `WARN`.
+      • Checkbox "MIN_MAX".  When checked, show text inputs `Min (inclusive)` and `Max (inclusive)` (both default empty strings) followed by selectbox `Severity (MIN_MAX)` with options `ERROR`, `WARN`.
+      • Checkbox "WHITESPACE".  When checked, show selectbox `Mode` with the three options `NO_LEADING_TRAILING`, `NO_INTERNAL_ONLY_WHITESPACE`, `NON_EMPTY_TRIMMED` in that exact order, followed by selectbox `Severity (WHITESPACE)` with options `ERROR`, `WARN`.
+      • Checkbox "FORMAT_DISTRIBUTION".  When checked, show text input `Regex (Snowflake RLIKE)`, number input `Min match ratio (0-1)` (range 0.0–1.0, step 0.01), then selectbox `Severity (FORMAT_DISTRIBUTION)` with options `ERROR`, `WARN`.
+      • Checkbox "VALUE_DISTRIBUTION".  When checked, show text input `Allowed values (CSV)`, number input `Min in-set ratio (0-1)` (range 0.0–1.0, step 0.01), then selectbox `Severity (VALUE_DISTRIBUTION)` with options `ERROR`, `WARN`.
+   e. Heading "### Table-level checks (always included)" with the text input `Timestamp column for table checks`, caption explaining failure behaviour, and number input `Freshness max age (minutes)` (range 1–10080, step 30).  The values must synchronise with session state as in code.
+   f. `st.form_submit_button` labelled "Preview last 60 days row counts" of type `secondary`.
+   g. Heading "### Schedule" followed by checkbox `Enable daily task` (with explanatory help text), text input `Cron expression`, and text input `Timezone`.  The cron and timezone inputs are disabled when scheduling is unchecked.
+   h. Final row of four submit buttons laid out in columns `[1,1,1,1]`: `Save & Apply` (primary by default), `Save as Draft`, `Run Now`, and `Delete` (secondary styling).
+6. When preview is requested and prerequisites are satisfied, render a dataframe showing the columns `day` and `cnt` in that order with `use_container_width=True`, `hide_index=True`, and `height=320`.  No charts or alternative layouts are permitted.
+7. Post-submit handling must reuse the existing success, warning, and info messaging pattern; no extra notifications precede or replace them.
+
+Forbidden patterns:
+• Do not reorder sections or controls listed above.
+• Do not introduce additional check types, severity dropdowns, or per-column widgets beyond those specified.
+• Do not add new scheduling controls, task toggles, or preview visualisations.
+• Do not allow manual editing of the configuration name or target caption formatting.

--- a/docs/ui_contract_docs.md
+++ b/docs/ui_contract_docs.md
@@ -1,0 +1,18 @@
+UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Layout requirements:
+1. Page header "Zeus Data Quality documentation" appears once at the top.
+2. A fixed `st.tabs` call defines six tabs in this exact order: "User Guide", "Profiling", "DQ Framework", "Technical Overview", "Data Governance", "Version History".  Tab labels and count must not change.
+3. Tab content expectations:
+   • "User Guide" tab renders the subheader "User Guide" followed by the existing markdown sections (What the app delivers, Create a configuration, Checks in plain language, Run and monitor results, Troubleshooting essentials).  No interactive widgets belong in this tab.
+   • "Profiling" tab renders the subheader "Profiling" and the markdown sections covering why to profile, metrics, semantic insights, filters, performance notes, and persistence guidance exactly as shipped.  This tab remains markdown-only.
+   • "DQ Framework" tab renders the subheader "Snowflake-native data quality framework" with descriptive markdown, then a divider, then subheader "Entity Diagram" with a Graphviz diagram (rendered via `st.graphviz_chart`) describing metadata objects, followed by subheader "Workflow Diagram" with its Graphviz diagram.  Chart ordering and titles must remain unchanged.
+   • "Technical Overview" tab renders the subheader "Technical Overview", markdown with runtime/metadata/procedure details, then a `st.markdown` heading "#### Required privileges for the caller role" and a single `st.code` block listing privilege statements.  No additional controls may be added.
+   • "Data Governance" tab renders the subheader "Data Governance and Security" plus the markdown sections on roles, traceability, access, and sensitive data handling.
+   • "Version History" tab renders the subheader "Version History" followed by the info message "Version history will be documented here once releases are tracked."  No other content is permitted.
+
+Forbidden patterns:
+• Do not change the tab order, labels, or count.
+• Do not replace markdown content with inputs, tables, or dataframes.
+• Do not remove or reposition the Graphviz charts within the "DQ Framework" tab.
+• Do not add new alerts, buttons, or accordions to any tab without explicit approval.

--- a/docs/ui_contract_profile.md
+++ b/docs/ui_contract_profile.md
@@ -1,0 +1,28 @@
+UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Controls (top to bottom):
+1. Page header labelled "🧪 Profile Table" immediately followed by the caption "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks."  The header and caption must remain paired with no intervening widgets.
+2. Stateless table picker with three selectors (database, schema, table) sourced from `stateless_table_picker`.  It must appear directly under the caption and persist the selected fully qualified name in `st.session_state["profile_target_fqn"]`.
+3. A horizontal divider separating the picker from the run controls.
+4. Control row rendered as three equally spaced columns:
+   • Column 1 contains the number input labelled "Sample %" (range 0–100, step 1).  Help text must include the metadata rationale and the instruction "Enter 0 for a full table scan."  The widget key stays `profile_sample_pct`.
+   • Column 2 contains the number input labelled "Top N values" (range 1–10, default 10, step 1) with helper text "Collect up to 10 of the most common values per column."  No additional controls share this column.
+   • Column 3 contains a selectbox labelled "Load saved profile" followed by a "Load" button.  The selectbox must always render, using "— Select a saved run —" when runs exist or the disabled option "— No saved profiles —" otherwise.  The Load button lives directly under the selectbox and is disabled unless a run is chosen and metadata targets are configured.  Caption messaging under the button must cover the Snowflake connection requirement or the "No saved profiles" notice as in code.
+5. Caption `Suggested: X of Y columns selected` sourced from `selection_counts` showing immediately below the control row.
+6. Action row with three columns sized `[1, 1, 2]`:
+   • Column 1 hosts the primary button "▶️ Run Profile" (disabled when a saved run is loaded).
+   • Column 2 hosts the secondary button "✨ Suggest DQ Config" (disabled until profile results exist).
+   • Column 3 shows an info box `Viewing a saved profile.` plus a "Clear loaded profile" button only when `profile_loaded_run_id` is set; otherwise it must remain empty.
+7. Metrics row of three `st.metric` widgets labelled "Rows profiled", "Sampling", and "Duration".  These appear once results exist and must remain in this order.
+8. Optional warning banner firing for full scans over the threshold with the message "Full table scan processed {rows} rows. Consider sampling to improve performance."  The icon stays `⚠️`.
+9. Filters container that starts with subheader "Filters" then four toggles: "High null % (>20%)", "Unique candidates", "Low cardinality", "Whitespace risk".  Immediately afterwards render the bold label "Semantic tags" and a single row of checkboxes: "Identifiers", "Financial", "Instrument", "Geo", "Contact", "Date (Text)", "Reference Codes"—all defaulting to `False`.
+10. Toggle "💾 Save Profile" (key `profile_save_toggle`) with dynamic help text explaining persistence.  This control is always rendered; it is disabled rather than hidden when metadata prerequisites fail.
+11. Selection editor grid created with `st.data_editor` that exposes only two columns: `Select` (checkbox) and `Column` (read-only).  The editor must precede the main dataframe and use key `profile_results_selection`.
+12. Main profile dataframe displayed with `st.dataframe` using the styled `grid_df`.  Required columns in order: `Select`, `Column`, `Physical Type`, `Nulls`, `Distinct`, `Avg Length`, `Min Value`, `Max Value`, `Whitespace %`, `Guessed Type`, `Confidence`, `Note`.  Confidence styling and legend text (green ≥90%, amber 75–89, grey otherwise) must remain untouched.
+13. Subheader "Top values by column" followed by one expander per column in the filtered results.  Each expander title follows the pattern `<column> (<N values>)`.  Inside, render exactly one `st.table` using the processed `tv_df` (columns "Value", "Count", and any metadata-supplied percentage columns).  When the table is empty, show the existing informational messages instead of alternative layouts.
+
+Forbidden patterns:
+• Do not add, remove, or reorder the control groups above.
+• Do not introduce extra tabs, accordions, or secondary grids beyond the selection editor, main dataframe, and per-column tables described.
+• Do not alter widget labels, keys, or default states except through existing logic.
+• Do not surface additional persistence toggles or sampling controls; `💾 Save Profile` and `Sample %` are the sole persistence and sampling mechanisms.

--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1,3 +1,36 @@
+"""UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Controls (top to bottom):
+1. Header row with two columns sized `[1, 8]`.  Left column must contain the "⬅ Back" button wired to return to the list view.  Right column must render the header "Edit Configuration" when editing or "Create Configuration" when creating.
+2. When profile suggestions are applied, show a single success alert summarising rows profiled and sample percentage exactly as implemented; no additional banners precede the Target section.
+3. Subheader "Target" with the stateless table picker (database, schema, table) capturing the selected fully qualified name into `editor_target_fqn`.  Immediately below, display the caption `Target Table: <value>` where `<value>` resolves to the selected table or "— not selected —".
+4. Heading "### Columns" followed by a multiselect labelled "Columns to check" listing available table columns.  The informational message "Table-level checks **FRESHNESS** and **ROW_COUNT_ANOMALY** are automatically included." must follow directly beneath the multiselect.
+5. Configuration form `cfg_form` containing elements in this fixed order:
+   a. Subheader "Configuration".
+   b. Disabled text input "Name" with automatic derivation help text.  No manual name entry control may be added.
+   c. Text area "Description" allowing optional free-form notes.
+   d. For each selected column, render an expander titled `Column: <column>` (collapsed by default).  Inside each expander, controls must appear exactly as follows:
+      • Number input "Sample failing rows for <column>" (0–1000, default 10).
+      • Checkbox "UNIQUE".  When checked, show the `Ignore NULLs` checkbox (defaults True) followed by the selectbox `Severity (UNIQUE)` with options `ERROR`, `WARN` in that order.
+      • Checkbox "NULL_COUNT".  When checked, show number input `Max NULL rows` (minimum 0) then selectbox `Severity (NULL_COUNT)` with options `ERROR`, `WARN`.
+      • Checkbox "MIN_MAX".  When checked, show text inputs `Min (inclusive)` and `Max (inclusive)` (both default empty strings) followed by selectbox `Severity (MIN_MAX)` with options `ERROR`, `WARN`.
+      • Checkbox "WHITESPACE".  When checked, show selectbox `Mode` with the three options `NO_LEADING_TRAILING`, `NO_INTERNAL_ONLY_WHITESPACE`, `NON_EMPTY_TRIMMED` in that exact order, followed by selectbox `Severity (WHITESPACE)` with options `ERROR`, `WARN`.
+      • Checkbox "FORMAT_DISTRIBUTION".  When checked, show text input `Regex (Snowflake RLIKE)`, number input `Min match ratio (0-1)` (range 0.0–1.0, step 0.01), then selectbox `Severity (FORMAT_DISTRIBUTION)` with options `ERROR`, `WARN`.
+      • Checkbox "VALUE_DISTRIBUTION".  When checked, show text input `Allowed values (CSV)`, number input `Min in-set ratio (0-1)` (range 0.0–1.0, step 0.01), then selectbox `Severity (VALUE_DISTRIBUTION)` with options `ERROR`, `WARN`.
+   e. Heading "### Table-level checks (always included)" with the text input `Timestamp column for table checks`, caption explaining failure behaviour, and number input `Freshness max age (minutes)` (range 1–10080, step 30).  The values must synchronise with session state as in code.
+   f. `st.form_submit_button` labelled "Preview last 60 days row counts" of type `secondary`.
+   g. Heading "### Schedule" followed by checkbox `Enable daily task` (with explanatory help text), text input `Cron expression`, and text input `Timezone`.  The cron and timezone inputs are disabled when scheduling is unchecked.
+   h. Final row of four submit buttons laid out in columns `[1,1,1,1]`: `Save & Apply` (primary by default), `Save as Draft`, `Run Now`, and `Delete` (secondary styling).
+6. When preview is requested and prerequisites are satisfied, render a dataframe showing the columns `day` and `cnt` in that order with `use_container_width=True`, `hide_index=True`, and `height=320`.  No charts or alternative layouts are permitted.
+7. Post-submit handling must reuse the existing success, warning, and info messaging pattern; no extra notifications precede or replace them.
+
+Forbidden patterns:
+• Do not reorder sections or controls listed above.
+• Do not introduce additional check types, severity dropdowns, or per-column widgets beyond those specified.
+• Do not add new scheduling controls, task toggles, or preview visualisations.
+• Do not allow manual editing of the configuration name or target caption formatting.
+"""
+
 import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple

--- a/snapshots/views/docs_view.p
+++ b/snapshots/views/docs_view.p
@@ -1,3 +1,23 @@
+"""UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Layout requirements:
+1. Page header "Zeus Data Quality documentation" appears once at the top.
+2. A fixed `st.tabs` call defines six tabs in this exact order: "User Guide", "Profiling", "DQ Framework", "Technical Overview", "Data Governance", "Version History".  Tab labels and count must not change.
+3. Tab content expectations:
+   • "User Guide" tab renders the subheader "User Guide" followed by the existing markdown sections (What the app delivers, Create a configuration, Checks in plain language, Run and monitor results, Troubleshooting essentials).  No interactive widgets belong in this tab.
+   • "Profiling" tab renders the subheader "Profiling" and the markdown sections covering why to profile, metrics, semantic insights, filters, performance notes, and persistence guidance exactly as shipped.  This tab remains markdown-only.
+   • "DQ Framework" tab renders the subheader "Snowflake-native data quality framework" with descriptive markdown, then a divider, then subheader "Entity Diagram" with a Graphviz diagram (rendered via `st.graphviz_chart`) describing metadata objects, followed by subheader "Workflow Diagram" with its Graphviz diagram.  Chart ordering and titles must remain unchanged.
+   • "Technical Overview" tab renders the subheader "Technical Overview", markdown with runtime/metadata/procedure details, then a `st.markdown` heading "#### Required privileges for the caller role" and a single `st.code` block listing privilege statements.  No additional controls may be added.
+   • "Data Governance" tab renders the subheader "Data Governance and Security" plus the markdown sections on roles, traceability, access, and sensitive data handling.
+   • "Version History" tab renders the subheader "Version History" followed by the info message "Version history will be documented here once releases are tracked."  No other content is permitted.
+
+Forbidden patterns:
+• Do not change the tab order, labels, or count.
+• Do not replace markdown content with inputs, tables, or dataframes.
+• Do not remove or reposition the Graphviz charts within the "DQ Framework" tab.
+• Do not add new alerts, buttons, or accordions to any tab without explicit approval.
+"""
+
 """Documentation view rendering helpers."""
 
 from __future__ import annotations

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1,3 +1,33 @@
+"""UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Controls (top to bottom):
+1. Page header labelled "🧪 Profile Table" immediately followed by the caption "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks."  The header and caption must remain paired with no intervening widgets.
+2. Stateless table picker with three selectors (database, schema, table) sourced from `stateless_table_picker`.  It must appear directly under the caption and persist the selected fully qualified name in `st.session_state["profile_target_fqn"]`.
+3. A horizontal divider separating the picker from the run controls.
+4. Control row rendered as three equally spaced columns:
+   • Column 1 contains the number input labelled "Sample %" (range 0–100, step 1).  Help text must include the metadata rationale and the instruction "Enter 0 for a full table scan."  The widget key stays `profile_sample_pct`.
+   • Column 2 contains the number input labelled "Top N values" (range 1–10, default 10, step 1) with helper text "Collect up to 10 of the most common values per column."  No additional controls share this column.
+   • Column 3 contains a selectbox labelled "Load saved profile" followed by a "Load" button.  The selectbox must always render, using "— Select a saved run —" when runs exist or the disabled option "— No saved profiles —" otherwise.  The Load button lives directly under the selectbox and is disabled unless a run is chosen and metadata targets are configured.  Caption messaging under the button must cover the Snowflake connection requirement or the "No saved profiles" notice as in code.
+5. Caption `Suggested: X of Y columns selected` sourced from `selection_counts` showing immediately below the control row.
+6. Action row with three columns sized `[1, 1, 2]`:
+   • Column 1 hosts the primary button "▶️ Run Profile" (disabled when a saved run is loaded).
+   • Column 2 hosts the secondary button "✨ Suggest DQ Config" (disabled until profile results exist).
+   • Column 3 shows an info box `Viewing a saved profile.` plus a "Clear loaded profile" button only when `profile_loaded_run_id` is set; otherwise it must remain empty.
+7. Metrics row of three `st.metric` widgets labelled "Rows profiled", "Sampling", and "Duration".  These appear once results exist and must remain in this order.
+8. Optional warning banner firing for full scans over the threshold with the message "Full table scan processed {rows} rows. Consider sampling to improve performance."  The icon stays `⚠️`.
+9. Filters container that starts with subheader "Filters" then four toggles: "High null % (>20%)", "Unique candidates", "Low cardinality", "Whitespace risk".  Immediately afterwards render the bold label "Semantic tags" and a single row of checkboxes: "Identifiers", "Financial", "Instrument", "Geo", "Contact", "Date (Text)", "Reference Codes"—all defaulting to `False`.
+10. Toggle "💾 Save Profile" (key `profile_save_toggle`) with dynamic help text explaining persistence.  This control is always rendered; it is disabled rather than hidden when metadata prerequisites fail.
+11. Selection editor grid created with `st.data_editor` that exposes only two columns: `Select` (checkbox) and `Column` (read-only).  The editor must precede the main dataframe and use key `profile_results_selection`.
+12. Main profile dataframe displayed with `st.dataframe` using the styled `grid_df`.  Required columns in order: `Select`, `Column`, `Physical Type`, `Nulls`, `Distinct`, `Avg Length`, `Min Value`, `Max Value`, `Whitespace %`, `Guessed Type`, `Confidence`, `Note`.  Confidence styling and legend text (green ≥90%, amber 75–89, grey otherwise) must remain untouched.
+13. Subheader "Top values by column" followed by one expander per column in the filtered results.  Each expander title follows the pattern `<column> (<N values>)`.  Inside, render exactly one `st.table` using the processed `tv_df` (columns "Value", "Count", and any metadata-supplied percentage columns).  When the table is empty, show the existing informational messages instead of alternative layouts.
+
+Forbidden patterns:
+• Do not add, remove, or reorder the control groups above.
+• Do not introduce extra tabs, accordions, or secondary grids beyond the selection editor, main dataframe, and per-column tables described.
+• Do not alter widget labels, keys, or default states except through existing logic.
+• Do not surface additional persistence toggles or sampling controls; `💾 Save Profile` and `Sample %` are the sole persistence and sampling mechanisms.
+"""
+
 from __future__ import annotations
 import html
 import json

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,3 +1,36 @@
+"""UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Controls (top to bottom):
+1. Header row with two columns sized `[1, 8]`.  Left column must contain the "⬅ Back" button wired to return to the list view.  Right column must render the header "Edit Configuration" when editing or "Create Configuration" when creating.
+2. When profile suggestions are applied, show a single success alert summarising rows profiled and sample percentage exactly as implemented; no additional banners precede the Target section.
+3. Subheader "Target" with the stateless table picker (database, schema, table) capturing the selected fully qualified name into `editor_target_fqn`.  Immediately below, display the caption `Target Table: <value>` where `<value>` resolves to the selected table or "— not selected —".
+4. Heading "### Columns" followed by a multiselect labelled "Columns to check" listing available table columns.  The informational message "Table-level checks **FRESHNESS** and **ROW_COUNT_ANOMALY** are automatically included." must follow directly beneath the multiselect.
+5. Configuration form `cfg_form` containing elements in this fixed order:
+   a. Subheader "Configuration".
+   b. Disabled text input "Name" with automatic derivation help text.  No manual name entry control may be added.
+   c. Text area "Description" allowing optional free-form notes.
+   d. For each selected column, render an expander titled `Column: <column>` (collapsed by default).  Inside each expander, controls must appear exactly as follows:
+      • Number input "Sample failing rows for <column>" (0–1000, default 10).
+      • Checkbox "UNIQUE".  When checked, show the `Ignore NULLs` checkbox (defaults True) followed by the selectbox `Severity (UNIQUE)` with options `ERROR`, `WARN` in that order.
+      • Checkbox "NULL_COUNT".  When checked, show number input `Max NULL rows` (minimum 0) then selectbox `Severity (NULL_COUNT)` with options `ERROR`, `WARN`.
+      • Checkbox "MIN_MAX".  When checked, show text inputs `Min (inclusive)` and `Max (inclusive)` (both default empty strings) followed by selectbox `Severity (MIN_MAX)` with options `ERROR`, `WARN`.
+      • Checkbox "WHITESPACE".  When checked, show selectbox `Mode` with the three options `NO_LEADING_TRAILING`, `NO_INTERNAL_ONLY_WHITESPACE`, `NON_EMPTY_TRIMMED` in that exact order, followed by selectbox `Severity (WHITESPACE)` with options `ERROR`, `WARN`.
+      • Checkbox "FORMAT_DISTRIBUTION".  When checked, show text input `Regex (Snowflake RLIKE)`, number input `Min match ratio (0-1)` (range 0.0–1.0, step 0.01), then selectbox `Severity (FORMAT_DISTRIBUTION)` with options `ERROR`, `WARN`.
+      • Checkbox "VALUE_DISTRIBUTION".  When checked, show text input `Allowed values (CSV)`, number input `Min in-set ratio (0-1)` (range 0.0–1.0, step 0.01), then selectbox `Severity (VALUE_DISTRIBUTION)` with options `ERROR`, `WARN`.
+   e. Heading "### Table-level checks (always included)" with the text input `Timestamp column for table checks`, caption explaining failure behaviour, and number input `Freshness max age (minutes)` (range 1–10080, step 30).  The values must synchronise with session state as in code.
+   f. `st.form_submit_button` labelled "Preview last 60 days row counts" of type `secondary`.
+   g. Heading "### Schedule" followed by checkbox `Enable daily task` (with explanatory help text), text input `Cron expression`, and text input `Timezone`.  The cron and timezone inputs are disabled when scheduling is unchecked.
+   h. Final row of four submit buttons laid out in columns `[1,1,1,1]`: `Save & Apply` (primary by default), `Save as Draft`, `Run Now`, and `Delete` (secondary styling).
+6. When preview is requested and prerequisites are satisfied, render a dataframe showing the columns `day` and `cnt` in that order with `use_container_width=True`, `hide_index=True`, and `height=320`.  No charts or alternative layouts are permitted.
+7. Post-submit handling must reuse the existing success, warning, and info messaging pattern; no extra notifications precede or replace them.
+
+Forbidden patterns:
+• Do not reorder sections or controls listed above.
+• Do not introduce additional check types, severity dropdowns, or per-column widgets beyond those specified.
+• Do not add new scheduling controls, task toggles, or preview visualisations.
+• Do not allow manual editing of the configuration name or target caption formatting.
+"""
+
 import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple

--- a/views/docs_view.py
+++ b/views/docs_view.py
@@ -1,3 +1,23 @@
+"""UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Layout requirements:
+1. Page header "Zeus Data Quality documentation" appears once at the top.
+2. A fixed `st.tabs` call defines six tabs in this exact order: "User Guide", "Profiling", "DQ Framework", "Technical Overview", "Data Governance", "Version History".  Tab labels and count must not change.
+3. Tab content expectations:
+   • "User Guide" tab renders the subheader "User Guide" followed by the existing markdown sections (What the app delivers, Create a configuration, Checks in plain language, Run and monitor results, Troubleshooting essentials).  No interactive widgets belong in this tab.
+   • "Profiling" tab renders the subheader "Profiling" and the markdown sections covering why to profile, metrics, semantic insights, filters, performance notes, and persistence guidance exactly as shipped.  This tab remains markdown-only.
+   • "DQ Framework" tab renders the subheader "Snowflake-native data quality framework" with descriptive markdown, then a divider, then subheader "Entity Diagram" with a Graphviz diagram (rendered via `st.graphviz_chart`) describing metadata objects, followed by subheader "Workflow Diagram" with its Graphviz diagram.  Chart ordering and titles must remain unchanged.
+   • "Technical Overview" tab renders the subheader "Technical Overview", markdown with runtime/metadata/procedure details, then a `st.markdown` heading "#### Required privileges for the caller role" and a single `st.code` block listing privilege statements.  No additional controls may be added.
+   • "Data Governance" tab renders the subheader "Data Governance and Security" plus the markdown sections on roles, traceability, access, and sensitive data handling.
+   • "Version History" tab renders the subheader "Version History" followed by the info message "Version history will be documented here once releases are tracked."  No other content is permitted.
+
+Forbidden patterns:
+• Do not change the tab order, labels, or count.
+• Do not replace markdown content with inputs, tables, or dataframes.
+• Do not remove or reposition the Graphviz charts within the "DQ Framework" tab.
+• Do not add new alerts, buttons, or accordions to any tab without explicit approval.
+"""
+
 """Documentation view rendering helpers."""
 
 from __future__ import annotations

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1,3 +1,33 @@
+"""UI CONTRACT – DO NOT CHANGE WITHOUT EXPLICIT INSTRUCTION
+
+Controls (top to bottom):
+1. Page header labelled "🧪 Profile Table" immediately followed by the caption "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks."  The header and caption must remain paired with no intervening widgets.
+2. Stateless table picker with three selectors (database, schema, table) sourced from `stateless_table_picker`.  It must appear directly under the caption and persist the selected fully qualified name in `st.session_state["profile_target_fqn"]`.
+3. A horizontal divider separating the picker from the run controls.
+4. Control row rendered as three equally spaced columns:
+   • Column 1 contains the number input labelled "Sample %" (range 0–100, step 1).  Help text must include the metadata rationale and the instruction "Enter 0 for a full table scan."  The widget key stays `profile_sample_pct`.
+   • Column 2 contains the number input labelled "Top N values" (range 1–10, default 10, step 1) with helper text "Collect up to 10 of the most common values per column."  No additional controls share this column.
+   • Column 3 contains a selectbox labelled "Load saved profile" followed by a "Load" button.  The selectbox must always render, using "— Select a saved run —" when runs exist or the disabled option "— No saved profiles —" otherwise.  The Load button lives directly under the selectbox and is disabled unless a run is chosen and metadata targets are configured.  Caption messaging under the button must cover the Snowflake connection requirement or the "No saved profiles" notice as in code.
+5. Caption `Suggested: X of Y columns selected` sourced from `selection_counts` showing immediately below the control row.
+6. Action row with three columns sized `[1, 1, 2]`:
+   • Column 1 hosts the primary button "▶️ Run Profile" (disabled when a saved run is loaded).
+   • Column 2 hosts the secondary button "✨ Suggest DQ Config" (disabled until profile results exist).
+   • Column 3 shows an info box `Viewing a saved profile.` plus a "Clear loaded profile" button only when `profile_loaded_run_id` is set; otherwise it must remain empty.
+7. Metrics row of three `st.metric` widgets labelled "Rows profiled", "Sampling", and "Duration".  These appear once results exist and must remain in this order.
+8. Optional warning banner firing for full scans over the threshold with the message "Full table scan processed {rows} rows. Consider sampling to improve performance."  The icon stays `⚠️`.
+9. Filters container that starts with subheader "Filters" then four toggles: "High null % (>20%)", "Unique candidates", "Low cardinality", "Whitespace risk".  Immediately afterwards render the bold label "Semantic tags" and a single row of checkboxes: "Identifiers", "Financial", "Instrument", "Geo", "Contact", "Date (Text)", "Reference Codes"—all defaulting to `False`.
+10. Toggle "💾 Save Profile" (key `profile_save_toggle`) with dynamic help text explaining persistence.  This control is always rendered; it is disabled rather than hidden when metadata prerequisites fail.
+11. Selection editor grid created with `st.data_editor` that exposes only two columns: `Select` (checkbox) and `Column` (read-only).  The editor must precede the main dataframe and use key `profile_results_selection`.
+12. Main profile dataframe displayed with `st.dataframe` using the styled `grid_df`.  Required columns in order: `Select`, `Column`, `Physical Type`, `Nulls`, `Distinct`, `Avg Length`, `Min Value`, `Max Value`, `Whitespace %`, `Guessed Type`, `Confidence`, `Note`.  Confidence styling and legend text (green ≥90%, amber 75–89, grey otherwise) must remain untouched.
+13. Subheader "Top values by column" followed by one expander per column in the filtered results.  Each expander title follows the pattern `<column> (<N values>)`.  Inside, render exactly one `st.table` using the processed `tv_df` (columns "Value", "Count", and any metadata-supplied percentage columns).  When the table is empty, show the existing informational messages instead of alternative layouts.
+
+Forbidden patterns:
+• Do not add, remove, or reorder the control groups above.
+• Do not introduce extra tabs, accordions, or secondary grids beyond the selection editor, main dataframe, and per-column tables described.
+• Do not alter widget labels, keys, or default states except through existing logic.
+• Do not surface additional persistence toggles or sampling controls; `💾 Save Profile` and `Sample %` are the sole persistence and sampling mechanisms.
+"""
+
 from __future__ import annotations
 import html
 import json


### PR DESCRIPTION
* Document UI contracts for the profiling, configuration editor, and documentation views.
* Embed mirrored UI contract headers in the associated Streamlit view modules.
* Refresh snapshot mirrors to capture the new documentation blocks.

------
https://chatgpt.com/codex/tasks/task_e_69046a98730c8324ac22bb7b0ff44a5b