### PR TITLE
Add lightweight runtime guards to views

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -82,6 +82,7 @@ from utils.configs import get_metadata_namespace, get_proc_name
 from views.profile_view import render_profile
 from views.table_picker import stateless_table_picker, session_cache_token
 from views.docs_view import render_docs as render_docs_view
+from views.config_editor import render_row_count_preview
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs"}
 
@@ -1036,7 +1037,7 @@ def render_config_editor():
         except Exception as exc:
             st.error(f"Failed to preview row counts: {exc}")
         else:
-            st.dataframe(df, use_container_width=True, hide_index=True, height=320)
+            render_row_count_preview(df)
 
     # After submit
     if apply_now or save_draft or run_now_btn or delete_btn:

--- a/snapshots/views/config_editor.p
+++ b/snapshots/views/config_editor.p
@@ -1,0 +1,43 @@
+"""Runtime guards for configuration editor views."""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+import pandas as pd
+import streamlit as st
+
+_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
+_EXPECTED_PREVIEW_COLUMNS: Sequence[str] = ("day", "cnt")
+
+
+def _contract_message(message: str) -> None:
+    """Display a contract warning or elevate to an error when strict."""
+
+    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    if strict:
+        st.error(message)
+    else:
+        st.warning(message)
+
+
+def render_row_count_preview(df: pd.DataFrame) -> None:
+    """Render the row-count preview grid with UI contract validation."""
+
+    if not isinstance(df, pd.DataFrame):
+        _contract_message(
+            "UI contract violation in config preview: expected a pandas DataFrame."
+        )
+        return
+
+    actual_columns = list(df.columns)
+    expected_columns = list(_EXPECTED_PREVIEW_COLUMNS)
+    if actual_columns != expected_columns:
+        _contract_message(
+            "UI contract violation in config preview: expected columns "
+            f"{expected_columns} but found {actual_columns}."
+        )
+        return
+
+    st.dataframe(df, use_container_width=True, hide_index=True, height=320)

--- a/snapshots/views/docs_view.p
+++ b/snapshots/views/docs_view.p
@@ -23,10 +23,23 @@ Forbidden patterns:
 from __future__ import annotations
 
 from typing import Tuple
+import os
 
 import streamlit as st
 
 from utils.meta import _q
+
+_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
+
+
+def _contract_message(message: str) -> None:
+    """Display contract feedback as warning or error based on strict mode."""
+
+    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    if strict:
+        st.error(message)
+    else:
+        st.warning(message)
 
 
 def _safe_quote(identifier: str) -> str:
@@ -67,6 +80,12 @@ def render_docs(
             "Version History",
         ]
     )
+
+    if len(tabs) != 6:
+        _contract_message(
+            "UI contract violation in documentation view: expected 6 tabs."
+        )
+        return
 
     cfg_tbl_display = _safe_quote(configs_table)
     chk_tbl_display = _safe_quote(checks_table)

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -32,12 +32,13 @@ from __future__ import annotations
 import html
 import json
 import math
+import os
 import textwrap
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from numbers import Integral, Real
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import pandas as pd
 import streamlit as st
@@ -56,6 +57,8 @@ from views.table_picker import session_cache_token, stateless_table_picker
 
 FULL_SCAN_WARNING_THRESHOLD = 1_000_000
 MAX_TOP_N = 10
+
+_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
 
 
 def _safe_int(value: Any) -> Optional[int]:
@@ -131,6 +134,47 @@ def _selection_key(table_fqn: str, column_name: str) -> str:
     if table_str:
         return f"{table_str}::{column_str}"
     return column_str
+
+
+def _contract_message(message: str) -> None:
+    """Emit a contract warning or error depending on env configuration."""
+
+    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    if strict:
+        st.error(message)
+    else:
+        st.warning(message)
+
+
+def _validate_grid_columns(
+    actual: Sequence[str], expected: Sequence[str], grid_name: str
+) -> bool:
+    """Ensure a rendered grid exposes the expected columns and ordering."""
+
+    actual_list = list(actual)
+    expected_list = list(expected)
+    if actual_list != expected_list:
+        _contract_message(
+            "UI contract violation in "
+            f"{grid_name}: expected columns {expected_list} but found {actual_list}."
+        )
+        return False
+    return True
+
+
+def _detect_secondary_selector_keys(base_key: str) -> List[str]:
+    """Return suspicious session-state keys that hint at duplicate selectors."""
+
+    suspicious: List[str] = []
+    for key in list(st.session_state.keys()):
+        if not isinstance(key, str) or key == base_key:
+            continue
+        if not key.startswith(base_key):
+            continue
+        remainder = key[len(base_key) :]
+        if remainder and remainder[0] in {"_", "-", ":", "."}:
+            suspicious.append(key)
+    return suspicious
 
 
 @dataclass
@@ -1308,34 +1352,57 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             )
 
         grid_df = pd.DataFrame(formatted_rows, columns=grid_columns)
-        grid_df["Select"] = grid_df["Select"].fillna(False).astype(bool)
-        grid_df["Confidence"] = grid_df["Confidence"].apply(_safe_float)
+        grid_render_allowed = _validate_grid_columns(
+            grid_df.columns, grid_columns, "profile results grid"
+        )
+        if grid_render_allowed:
+            grid_df["Select"] = grid_df["Select"].fillna(False).astype(bool)
+            grid_df["Confidence"] = grid_df["Confidence"].apply(_safe_float)
 
         with grid_container:
             st.markdown(confidence_legend_html, unsafe_allow_html=True)
             include_map: Dict[str, bool] = {}
             selection_editor: Optional[pd.DataFrame] = None
-            if not grid_df.empty:
+            if grid_render_allowed and not grid_df.empty:
                 selection_editor_df = grid_df[["Select", "Column"]].copy()
-                selection_editor_df["Select"] = (
-                    selection_editor_df["Select"].fillna(False).astype(bool)
+                selection_render_allowed = _validate_grid_columns(
+                    selection_editor_df.columns,
+                    ["Select", "Column"],
+                    "profile selection editor",
                 )
-                selection_editor = st.data_editor(
-                    selection_editor_df,
-                    use_container_width=True,
-                    hide_index=True,
-                    column_config={
-                        "Select": st.column_config.CheckboxColumn(
-                            "Select",
-                            help="Toggle to include the column in downstream DQ suggestions.",
-                        ),
-                        "Column": st.column_config.Column("Column", disabled=True),
-                    },
-                    disabled=["Column"],
-                    key="profile_results_selection",
-                )
+                if selection_render_allowed:
+                    selection_editor_df["Select"] = (
+                        selection_editor_df["Select"].fillna(False).astype(bool)
+                    )
+                    suspicious_keys = _detect_secondary_selector_keys(
+                        "profile_results_selection"
+                    )
+                    if suspicious_keys:
+                        _contract_message(
+                            "UI contract violation: secondary selector state detected "
+                            f"({', '.join(sorted(suspicious_keys))}). Skipping selector."
+                        )
+                    else:
+                        selection_editor = st.data_editor(
+                            selection_editor_df,
+                            use_container_width=True,
+                            hide_index=True,
+                            column_config={
+                                "Select": st.column_config.CheckboxColumn(
+                                    "Select",
+                                    help="Toggle to include the column in downstream DQ suggestions.",
+                                ),
+                                "Column": st.column_config.Column("Column", disabled=True),
+                            },
+                            disabled=["Column"],
+                            key="profile_results_selection",
+                        )
 
-            if isinstance(selection_editor, pd.DataFrame) and not selection_editor.empty:
+            if (
+                grid_render_allowed
+                and isinstance(selection_editor, pd.DataFrame)
+                and not selection_editor.empty
+            ):
                 select_series = selection_editor.get("Select")
                 column_series = selection_editor.get("Column")
                 if select_series is not None and column_series is not None:
@@ -1345,15 +1412,16 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         for idx in range(len(select_flags))
                     }
 
-            if include_map:
+            if grid_render_allowed and include_map:
                 for column_name, selected_flag in include_map.items():
                     key = _selection_key(target_table, column_name)
                     selection_state[key] = selected_flag
                     grid_df.loc[grid_df["Column"] == column_name, "Select"] = selected_flag
 
-            styler = grid_df.style.format({"Confidence": _format_confidence_display})
-            styler = styler.applymap(_confidence_style, subset=["Confidence"])
-            st.dataframe(styler, hide_index=True, use_container_width=True)
+            if grid_render_allowed:
+                styler = grid_df.style.format({"Confidence": _format_confidence_display})
+                styler = styler.applymap(_confidence_style, subset=["Confidence"])
+                st.dataframe(styler, hide_index=True, use_container_width=True)
 
         selection_counts = _apply_selection_state(
             profile_result,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -82,6 +82,7 @@ from utils.configs import get_metadata_namespace, get_proc_name
 from views.profile_view import render_profile
 from views.table_picker import stateless_table_picker, session_cache_token
 from views.docs_view import render_docs as render_docs_view
+from views.config_editor import render_row_count_preview
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs"}
 
@@ -1036,7 +1037,7 @@ def render_config_editor():
         except Exception as exc:
             st.error(f"Failed to preview row counts: {exc}")
         else:
-            st.dataframe(df, use_container_width=True, hide_index=True, height=320)
+            render_row_count_preview(df)
 
     # After submit
     if apply_now or save_draft or run_now_btn or delete_btn:

--- a/views/config_editor.py
+++ b/views/config_editor.py
@@ -1,0 +1,43 @@
+"""Runtime guards for configuration editor views."""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+import pandas as pd
+import streamlit as st
+
+_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
+_EXPECTED_PREVIEW_COLUMNS: Sequence[str] = ("day", "cnt")
+
+
+def _contract_message(message: str) -> None:
+    """Display a contract warning or elevate to an error when strict."""
+
+    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    if strict:
+        st.error(message)
+    else:
+        st.warning(message)
+
+
+def render_row_count_preview(df: pd.DataFrame) -> None:
+    """Render the row-count preview grid with UI contract validation."""
+
+    if not isinstance(df, pd.DataFrame):
+        _contract_message(
+            "UI contract violation in config preview: expected a pandas DataFrame."
+        )
+        return
+
+    actual_columns = list(df.columns)
+    expected_columns = list(_EXPECTED_PREVIEW_COLUMNS)
+    if actual_columns != expected_columns:
+        _contract_message(
+            "UI contract violation in config preview: expected columns "
+            f"{expected_columns} but found {actual_columns}."
+        )
+        return
+
+    st.dataframe(df, use_container_width=True, hide_index=True, height=320)

--- a/views/docs_view.py
+++ b/views/docs_view.py
@@ -23,10 +23,23 @@ Forbidden patterns:
 from __future__ import annotations
 
 from typing import Tuple
+import os
 
 import streamlit as st
 
 from utils.meta import _q
+
+_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
+
+
+def _contract_message(message: str) -> None:
+    """Display contract feedback as warning or error based on strict mode."""
+
+    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    if strict:
+        st.error(message)
+    else:
+        st.warning(message)
 
 
 def _safe_quote(identifier: str) -> str:
@@ -67,6 +80,12 @@ def render_docs(
             "Version History",
         ]
     )
+
+    if len(tabs) != 6:
+        _contract_message(
+            "UI contract violation in documentation view: expected 6 tabs."
+        )
+        return
 
     cfg_tbl_display = _safe_quote(configs_table)
     chk_tbl_display = _safe_quote(checks_table)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -32,12 +32,13 @@ from __future__ import annotations
 import html
 import json
 import math
+import os
 import textwrap
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from numbers import Integral, Real
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import pandas as pd
 import streamlit as st
@@ -56,6 +57,8 @@ from views.table_picker import session_cache_token, stateless_table_picker
 
 FULL_SCAN_WARNING_THRESHOLD = 1_000_000
 MAX_TOP_N = 10
+
+_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
 
 
 def _safe_int(value: Any) -> Optional[int]:
@@ -131,6 +134,47 @@ def _selection_key(table_fqn: str, column_name: str) -> str:
     if table_str:
         return f"{table_str}::{column_str}"
     return column_str
+
+
+def _contract_message(message: str) -> None:
+    """Emit a contract warning or error depending on env configuration."""
+
+    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    if strict:
+        st.error(message)
+    else:
+        st.warning(message)
+
+
+def _validate_grid_columns(
+    actual: Sequence[str], expected: Sequence[str], grid_name: str
+) -> bool:
+    """Ensure a rendered grid exposes the expected columns and ordering."""
+
+    actual_list = list(actual)
+    expected_list = list(expected)
+    if actual_list != expected_list:
+        _contract_message(
+            "UI contract violation in "
+            f"{grid_name}: expected columns {expected_list} but found {actual_list}."
+        )
+        return False
+    return True
+
+
+def _detect_secondary_selector_keys(base_key: str) -> List[str]:
+    """Return suspicious session-state keys that hint at duplicate selectors."""
+
+    suspicious: List[str] = []
+    for key in list(st.session_state.keys()):
+        if not isinstance(key, str) or key == base_key:
+            continue
+        if not key.startswith(base_key):
+            continue
+        remainder = key[len(base_key) :]
+        if remainder and remainder[0] in {"_", "-", ":", "."}:
+            suspicious.append(key)
+    return suspicious
 
 
 @dataclass
@@ -1308,34 +1352,57 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             )
 
         grid_df = pd.DataFrame(formatted_rows, columns=grid_columns)
-        grid_df["Select"] = grid_df["Select"].fillna(False).astype(bool)
-        grid_df["Confidence"] = grid_df["Confidence"].apply(_safe_float)
+        grid_render_allowed = _validate_grid_columns(
+            grid_df.columns, grid_columns, "profile results grid"
+        )
+        if grid_render_allowed:
+            grid_df["Select"] = grid_df["Select"].fillna(False).astype(bool)
+            grid_df["Confidence"] = grid_df["Confidence"].apply(_safe_float)
 
         with grid_container:
             st.markdown(confidence_legend_html, unsafe_allow_html=True)
             include_map: Dict[str, bool] = {}
             selection_editor: Optional[pd.DataFrame] = None
-            if not grid_df.empty:
+            if grid_render_allowed and not grid_df.empty:
                 selection_editor_df = grid_df[["Select", "Column"]].copy()
-                selection_editor_df["Select"] = (
-                    selection_editor_df["Select"].fillna(False).astype(bool)
+                selection_render_allowed = _validate_grid_columns(
+                    selection_editor_df.columns,
+                    ["Select", "Column"],
+                    "profile selection editor",
                 )
-                selection_editor = st.data_editor(
-                    selection_editor_df,
-                    use_container_width=True,
-                    hide_index=True,
-                    column_config={
-                        "Select": st.column_config.CheckboxColumn(
-                            "Select",
-                            help="Toggle to include the column in downstream DQ suggestions.",
-                        ),
-                        "Column": st.column_config.Column("Column", disabled=True),
-                    },
-                    disabled=["Column"],
-                    key="profile_results_selection",
-                )
+                if selection_render_allowed:
+                    selection_editor_df["Select"] = (
+                        selection_editor_df["Select"].fillna(False).astype(bool)
+                    )
+                    suspicious_keys = _detect_secondary_selector_keys(
+                        "profile_results_selection"
+                    )
+                    if suspicious_keys:
+                        _contract_message(
+                            "UI contract violation: secondary selector state detected "
+                            f"({', '.join(sorted(suspicious_keys))}). Skipping selector."
+                        )
+                    else:
+                        selection_editor = st.data_editor(
+                            selection_editor_df,
+                            use_container_width=True,
+                            hide_index=True,
+                            column_config={
+                                "Select": st.column_config.CheckboxColumn(
+                                    "Select",
+                                    help="Toggle to include the column in downstream DQ suggestions.",
+                                ),
+                                "Column": st.column_config.Column("Column", disabled=True),
+                            },
+                            disabled=["Column"],
+                            key="profile_results_selection",
+                        )
 
-            if isinstance(selection_editor, pd.DataFrame) and not selection_editor.empty:
+            if (
+                grid_render_allowed
+                and isinstance(selection_editor, pd.DataFrame)
+                and not selection_editor.empty
+            ):
                 select_series = selection_editor.get("Select")
                 column_series = selection_editor.get("Column")
                 if select_series is not None and column_series is not None:
@@ -1345,15 +1412,16 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         for idx in range(len(select_flags))
                     }
 
-            if include_map:
+            if grid_render_allowed and include_map:
                 for column_name, selected_flag in include_map.items():
                     key = _selection_key(target_table, column_name)
                     selection_state[key] = selected_flag
                     grid_df.loc[grid_df["Column"] == column_name, "Select"] = selected_flag
 
-            styler = grid_df.style.format({"Confidence": _format_confidence_display})
-            styler = styler.applymap(_confidence_style, subset=["Confidence"])
-            st.dataframe(styler, hide_index=True, use_container_width=True)
+            if grid_render_allowed:
+                styler = grid_df.style.format({"Confidence": _format_confidence_display})
+                styler = styler.applymap(_confidence_style, subset=["Confidence"])
+                st.dataframe(styler, hide_index=True, use_container_width=True)
 
         selection_counts = _apply_selection_state(
             profile_result,


### PR DESCRIPTION
- add ui contract helpers to profile view to validate grid columns, watch for duplicate selector state, and respect the UI_CONTRACT_STRICT flag
- guard the configuration editor preview grid via a new views.config_editor helper and invoke it from the Streamlit app
- enforce the documentation tab contract by warning or erroring when the tab count drifts and mirror updated snapshots

------
https://chatgpt.com/codex/tasks/task_e_69046fe05d988324b4bb9aa04d8f7743