### PR TITLE
Add pytest snapshot tests for UI data models

### DIFF
--- a/snapshots/tests/conftest.p
+++ b/snapshots/tests/conftest.p
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class Snapshotter:
+    """Simple snapshot helper with opt-in updates via UPDATE_SNAPSHOTS."""
+
+    def __init__(self, request: pytest.FixtureRequest) -> None:
+        self._request = request
+        self._dir = Path(__file__).parent / "__snapshots__"
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    def assert_match(self, data: Any, name: str = "snapshot") -> None:
+        path = self._dir / f"{self._request.node.name}__{name}.json"
+        serialized = json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        if os.getenv("UPDATE_SNAPSHOTS"):
+            path.write_text(serialized, encoding="utf-8")
+            return
+        if not path.exists():
+            pytest.fail(
+                "Snapshot does not exist. Run with UPDATE_SNAPSHOTS=1 to create it."
+            )
+        existing = path.read_text(encoding="utf-8")
+        assert (
+            existing == serialized
+        ), "Snapshot mismatch. Run with UPDATE_SNAPSHOTS=1 to update intentionally."
+
+
+@pytest.fixture
+def snapshot(request: pytest.FixtureRequest) -> Snapshotter:
+    return Snapshotter(request)

--- a/snapshots/tests/test_cfg_view_snapshot.p
+++ b/snapshots/tests/test_cfg_view_snapshot.p
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _unique(values: List[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+class _ConfigContractCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.headers: List[str] = []
+        self.subheaders: List[str] = []
+        self.buttons: List[str] = []
+        self.form_buttons: List[str] = []
+        self.multiselects: List[str] = []
+        self.checkbox_labels: List[str] = []
+        self.include_mentions: List[str] = []
+
+    def _strings_from_node(self, node: ast.AST | None) -> List[str]:
+        if node is None:
+            return []
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return [node.value]
+        if isinstance(node, ast.IfExp):
+            values: List[str] = []
+            values.extend(self._strings_from_node(node.body))
+            values.extend(self._strings_from_node(node.orelse))
+            return values
+        return []
+
+    def visit_Call(self, node: ast.Call) -> Any:  # type: ignore[override]
+        func = node.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id == "st":
+            labels: List[str] = []
+            if node.args:
+                labels = self._strings_from_node(node.args[0])
+            for label in labels:
+                if func.attr == "header":
+                    self.headers.append(label)
+                elif func.attr == "subheader":
+                    self.subheaders.append(label)
+                elif func.attr == "button":
+                    self.buttons.append(label)
+                elif func.attr == "form_submit_button":
+                    self.form_buttons.append(label)
+                elif func.attr == "multiselect":
+                    self.multiselects.append(label)
+                elif func.attr == "checkbox":
+                    self.checkbox_labels.append(label)
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> Any:  # type: ignore[override]
+        if isinstance(node.value, str) and "include" in node.value.lower():
+            self.include_mentions.append(node.value)
+        self.generic_visit(node)
+
+
+def _collect_config_contract() -> Dict[str, Any]:
+    module_path = Path(__file__).resolve().parents[1] / "streamlit_app.py"
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    render_node = None
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "render_config_editor":
+            render_node = node
+            break
+    if render_node is None:
+        raise AssertionError("render_config_editor not found in streamlit_app")
+
+    collector = _ConfigContractCollector()
+    collector.visit(render_node)
+
+    return {
+        "headers": _unique(collector.headers),
+        "subheaders": _unique(collector.subheaders),
+        "buttons": _unique(collector.buttons),
+        "form_buttons": _unique(collector.form_buttons),
+        "multiselects": _unique(collector.multiselects),
+        "checkboxes": _unique(collector.checkbox_labels),
+        "include_mentions": _unique(collector.include_mentions),
+    }
+
+
+def test_config_editor_contract(snapshot) -> None:
+    contract = _collect_config_contract()
+    snapshot.assert_match(contract, "config_editor_contract")

--- a/snapshots/tests/test_profile_view_snapshot.p
+++ b/snapshots/tests/test_profile_view_snapshot.p
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _unique(values: List[str]) -> List[str]:
+    seen = set()
+    result: List[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+class _ProfileContractCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.headers: List[str] = []
+        self.captions: List[str] = []
+        self.buttons: List[str] = []
+        self.grid_columns: List[str] | None = None
+
+    def _strings_from_node(self, node: ast.AST | None) -> List[str]:
+        if node is None:
+            return []
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return [node.value]
+        if isinstance(node, ast.IfExp):
+            values: List[str] = []
+            values.extend(self._strings_from_node(node.body))
+            values.extend(self._strings_from_node(node.orelse))
+            return values
+        return []
+
+    def visit_Call(self, node: ast.Call) -> Any:  # type: ignore[override]
+        func = node.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id == "st":
+            labels: List[str] = []
+            if node.args:
+                labels = self._strings_from_node(node.args[0])
+            for label in labels:
+                if func.attr == "header":
+                    self.headers.append(label)
+                elif func.attr == "caption":
+                    self.captions.append(label)
+                elif func.attr == "button":
+                    self.buttons.append(label)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> Any:  # type: ignore[override]
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "grid_columns":
+                try:
+                    value = ast.literal_eval(node.value)
+                except Exception:
+                    value = None
+                if isinstance(value, list) and all(isinstance(item, str) for item in value):
+                    self.grid_columns = value
+        self.generic_visit(node)
+
+
+def _collect_profile_contract() -> Dict[str, Any]:
+    module_path = Path(__file__).resolve().parents[1] / "views" / "profile_view.py"
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    render_node = None
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "render_profile":
+            render_node = node
+            break
+    if render_node is None:
+        raise AssertionError("render_profile not found in views.profile_view")
+
+    collector = _ProfileContractCollector()
+    collector.visit(render_node)
+
+    buttons = _unique(collector.buttons)
+    return {
+        "headers": _unique(collector.headers),
+        "captions": _unique(collector.captions),
+        "buttons": buttons,
+        "grid_columns": collector.grid_columns,
+        "include_column_alias": "Select" if collector.grid_columns and "Select" in collector.grid_columns else None,
+    }
+
+
+def test_profile_view_contract(snapshot) -> None:
+    contract = _collect_profile_contract()
+    snapshot.assert_match(contract, "profile_view_contract")

--- a/tests/__snapshots__/test_config_editor_contract__config_editor_contract.json
+++ b/tests/__snapshots__/test_config_editor_contract__config_editor_contract.json
@@ -1,0 +1,37 @@
+{
+  "buttons": [
+    "⬅ Back"
+  ],
+  "checkboxes": [
+    "UNIQUE",
+    "Ignore NULLs",
+    "NULL_COUNT",
+    "MIN_MAX",
+    "WHITESPACE",
+    "FORMAT_DISTRIBUTION",
+    "VALUE_DISTRIBUTION",
+    "Enable daily task"
+  ],
+  "form_buttons": [
+    "Preview last 60 days row counts",
+    "Save & Apply",
+    "Save as Draft",
+    "Run Now",
+    "Delete"
+  ],
+  "headers": [
+    "Edit Configuration",
+    "Create Configuration"
+  ],
+  "include_mentions": [
+    "Table-level checks **FRESHNESS** and **ROW_COUNT_ANOMALY** are automatically included.",
+    "### Table-level checks (always included)"
+  ],
+  "multiselects": [
+    "Columns to check"
+  ],
+  "subheaders": [
+    "Target",
+    "Configuration"
+  ]
+}

--- a/tests/__snapshots__/test_profile_view_contract__profile_view_contract.json
+++ b/tests/__snapshots__/test_profile_view_contract__profile_view_contract.json
@@ -1,0 +1,31 @@
+{
+  "buttons": [
+    "Load",
+    "▶️ Run Profile",
+    "✨ Suggest DQ Config",
+    "Clear loaded profile"
+  ],
+  "captions": [
+    "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks.",
+    "Connect to Snowflake and configure metadata targets to enable loading saved profiles.",
+    "No saved profiles found in metadata tables yet."
+  ],
+  "grid_columns": [
+    "Select",
+    "Column",
+    "Physical Type",
+    "Nulls",
+    "Distinct",
+    "Avg Length",
+    "Min Value",
+    "Max Value",
+    "Whitespace %",
+    "Guessed Type",
+    "Confidence",
+    "Note"
+  ],
+  "headers": [
+    "🧪 Profile Table"
+  ],
+  "include_column_alias": "Select"
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class Snapshotter:
+    """Simple snapshot helper with opt-in updates via UPDATE_SNAPSHOTS."""
+
+    def __init__(self, request: pytest.FixtureRequest) -> None:
+        self._request = request
+        self._dir = Path(__file__).parent / "__snapshots__"
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    def assert_match(self, data: Any, name: str = "snapshot") -> None:
+        path = self._dir / f"{self._request.node.name}__{name}.json"
+        serialized = json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        if os.getenv("UPDATE_SNAPSHOTS"):
+            path.write_text(serialized, encoding="utf-8")
+            return
+        if not path.exists():
+            pytest.fail(
+                "Snapshot does not exist. Run with UPDATE_SNAPSHOTS=1 to create it."
+            )
+        existing = path.read_text(encoding="utf-8")
+        assert (
+            existing == serialized
+        ), "Snapshot mismatch. Run with UPDATE_SNAPSHOTS=1 to update intentionally."
+
+
+@pytest.fixture
+def snapshot(request: pytest.FixtureRequest) -> Snapshotter:
+    return Snapshotter(request)

--- a/tests/test_cfg_view_snapshot.py
+++ b/tests/test_cfg_view_snapshot.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _unique(values: List[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+class _ConfigContractCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.headers: List[str] = []
+        self.subheaders: List[str] = []
+        self.buttons: List[str] = []
+        self.form_buttons: List[str] = []
+        self.multiselects: List[str] = []
+        self.checkbox_labels: List[str] = []
+        self.include_mentions: List[str] = []
+
+    def _strings_from_node(self, node: ast.AST | None) -> List[str]:
+        if node is None:
+            return []
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return [node.value]
+        if isinstance(node, ast.IfExp):
+            values: List[str] = []
+            values.extend(self._strings_from_node(node.body))
+            values.extend(self._strings_from_node(node.orelse))
+            return values
+        return []
+
+    def visit_Call(self, node: ast.Call) -> Any:  # type: ignore[override]
+        func = node.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id == "st":
+            labels: List[str] = []
+            if node.args:
+                labels = self._strings_from_node(node.args[0])
+            for label in labels:
+                if func.attr == "header":
+                    self.headers.append(label)
+                elif func.attr == "subheader":
+                    self.subheaders.append(label)
+                elif func.attr == "button":
+                    self.buttons.append(label)
+                elif func.attr == "form_submit_button":
+                    self.form_buttons.append(label)
+                elif func.attr == "multiselect":
+                    self.multiselects.append(label)
+                elif func.attr == "checkbox":
+                    self.checkbox_labels.append(label)
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> Any:  # type: ignore[override]
+        if isinstance(node.value, str) and "include" in node.value.lower():
+            self.include_mentions.append(node.value)
+        self.generic_visit(node)
+
+
+def _collect_config_contract() -> Dict[str, Any]:
+    module_path = Path(__file__).resolve().parents[1] / "streamlit_app.py"
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    render_node = None
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "render_config_editor":
+            render_node = node
+            break
+    if render_node is None:
+        raise AssertionError("render_config_editor not found in streamlit_app")
+
+    collector = _ConfigContractCollector()
+    collector.visit(render_node)
+
+    return {
+        "headers": _unique(collector.headers),
+        "subheaders": _unique(collector.subheaders),
+        "buttons": _unique(collector.buttons),
+        "form_buttons": _unique(collector.form_buttons),
+        "multiselects": _unique(collector.multiselects),
+        "checkboxes": _unique(collector.checkbox_labels),
+        "include_mentions": _unique(collector.include_mentions),
+    }
+
+
+def test_config_editor_contract(snapshot) -> None:
+    contract = _collect_config_contract()
+    snapshot.assert_match(contract, "config_editor_contract")

--- a/tests/test_profile_view_snapshot.py
+++ b/tests/test_profile_view_snapshot.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _unique(values: List[str]) -> List[str]:
+    seen = set()
+    result: List[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+class _ProfileContractCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.headers: List[str] = []
+        self.captions: List[str] = []
+        self.buttons: List[str] = []
+        self.grid_columns: List[str] | None = None
+
+    def _strings_from_node(self, node: ast.AST | None) -> List[str]:
+        if node is None:
+            return []
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return [node.value]
+        if isinstance(node, ast.IfExp):
+            values: List[str] = []
+            values.extend(self._strings_from_node(node.body))
+            values.extend(self._strings_from_node(node.orelse))
+            return values
+        return []
+
+    def visit_Call(self, node: ast.Call) -> Any:  # type: ignore[override]
+        func = node.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id == "st":
+            labels: List[str] = []
+            if node.args:
+                labels = self._strings_from_node(node.args[0])
+            for label in labels:
+                if func.attr == "header":
+                    self.headers.append(label)
+                elif func.attr == "caption":
+                    self.captions.append(label)
+                elif func.attr == "button":
+                    self.buttons.append(label)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> Any:  # type: ignore[override]
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "grid_columns":
+                try:
+                    value = ast.literal_eval(node.value)
+                except Exception:
+                    value = None
+                if isinstance(value, list) and all(isinstance(item, str) for item in value):
+                    self.grid_columns = value
+        self.generic_visit(node)
+
+
+def _collect_profile_contract() -> Dict[str, Any]:
+    module_path = Path(__file__).resolve().parents[1] / "views" / "profile_view.py"
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    render_node = None
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "render_profile":
+            render_node = node
+            break
+    if render_node is None:
+        raise AssertionError("render_profile not found in views.profile_view")
+
+    collector = _ProfileContractCollector()
+    collector.visit(render_node)
+
+    buttons = _unique(collector.buttons)
+    return {
+        "headers": _unique(collector.headers),
+        "captions": _unique(collector.captions),
+        "buttons": buttons,
+        "grid_columns": collector.grid_columns,
+        "include_column_alias": "Select" if collector.grid_columns and "Select" in collector.grid_columns else None,
+    }
+
+
+def test_profile_view_contract(snapshot) -> None:
+    contract = _collect_profile_contract()
+    snapshot.assert_match(contract, "profile_view_contract")


### PR DESCRIPTION
Add pytest snapshot tests for UI data models

- add snapshot fixture and AST-based inspections to capture profile view contract details
- add config editor snapshot coverage and store snapshots under tests/__snapshots__
- mirror updated tests into /snapshots for the automated workflow

------
https://chatgpt.com/codex/tasks/task_e_6904788867448324aa44c96057b2f3e7