### PR TITLE
Lock SQL builder outputs and lint

### DIFF
--- a/.github/workflows/sqlfluff.yml
+++ b/.github/workflows/sqlfluff.yml
@@ -1,0 +1,20 @@
+name: SQLFluff
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install sqlfluff==2.3.5
+      - name: Run sqlfluff
+        run: sqlfluff lint

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,8 @@
+[sqlfluff]
+dialect = snowflake
+exclude_rules = L031,L032
+max_line_length = 120
+
+[lint]
+ignore =
+    templates/

--- a/services/profiling.py
+++ b/services/profiling.py
@@ -7,6 +7,7 @@ import logging
 import math
 import os
 import random
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import uuid4
@@ -27,6 +28,67 @@ __all__ = [
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _StringColumnSqlFragments:
+    """Precomputed SQL snippets used when profiling string columns."""
+
+    empty_expr: str
+    whitespace_only_expr: str
+    whitespace_expr: str
+    lead_trail_expr: str
+    numeric_guard_expr: str
+    numeric_date_expr: str
+
+
+def _string_column_sql_fragments(qcol: str) -> _StringColumnSqlFragments:
+    """Return reusable SQL fragments for profiling a string column."""
+
+    digits_expr = "REGEXP_REPLACE({col}::STRING, '[^0-9]', '')".format(col=qcol)
+    numeric_guard_expr = (
+        "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
+        "THEN {digits} ELSE NULL END"
+    ).format(digits=digits_expr)
+    numeric_date_expr = (
+        "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
+        "THEN TRY_TO_DATE({digits}, 'YYYYMMDD') ELSE NULL END"
+    ).format(digits=digits_expr)
+    return _StringColumnSqlFragments(
+        empty_expr=f"SUM(CASE WHEN {qcol}::STRING = '' THEN 1 ELSE 0 END) AS EMPTY_STR_ROWS",
+        whitespace_only_expr=(
+            f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\\\s+$') "
+            "THEN 1 ELSE 0 END) AS WS_ONLY_ROWS"
+        ),
+        whitespace_expr=(
+            f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, "
+            "'^\\\\s|\\\\s$|\\\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
+        ),
+        lead_trail_expr=(
+            f"SUM(CASE WHEN {qcol} IS NOT NULL AND {qcol}::STRING != TRIM({qcol}::STRING) "
+            "THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
+        ),
+        numeric_guard_expr=numeric_guard_expr,
+        numeric_date_expr=numeric_date_expr,
+    )
+
+
+def _column_length_expression(
+    qcol: str, *, is_string: bool, is_numeric: bool
+) -> Optional[str]:
+    """Return the expression used to compute column value lengths."""
+
+    if is_string:
+        return f"LENGTH({qcol}::STRING)"
+    if is_numeric:
+        return f"LENGTH(TO_VARCHAR({qcol}))"
+    return None
+
+
+def _avg_length_metric(qcol: str, length_expr: str) -> str:
+    """Return the AVG length metric for the provided column expression."""
+
+    return f"AVG(CASE WHEN {qcol} IS NOT NULL THEN {length_expr} END) AS AVG_LEN"
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -1675,27 +1737,17 @@ def run_table_profile(
         if is_string:
             trimmed_expr = f"TRIM({qcol}::STRING)"
             sentinel_values = ("'0'", "'00000000'", "'0000-00-00'", "'0000/00/00'")
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol}::STRING = '' THEN 1 ELSE 0 END) AS EMPTY_STR_ROWS"
+            fragments = _string_column_sql_fragments(qcol)
+            metrics_sql.extend(
+                [
+                    fragments.empty_expr,
+                    fragments.whitespace_only_expr,
+                    fragments.whitespace_expr,
+                    fragments.lead_trail_expr,
+                ]
             )
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\s+$') THEN 1 ELSE 0 END) AS WS_ONLY_ROWS"
-            )
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\s|\\s$|\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
-            )
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol} IS NOT NULL AND {qcol}::STRING != TRIM({qcol}::STRING) THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
-            )
-            digits_expr = "REGEXP_REPLACE({col}::STRING, '[^0-9]', '')".format(col=qcol)
-            guarded_numeric_expr = (
-                "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
-                "THEN {digits} ELSE NULL END"
-            ).format(digits=digits_expr)
-            num_date_expr_sql = (
-                "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
-                "THEN TRY_TO_DATE({digits}, 'YYYYMMDD') ELSE NULL END"
-            ).format(digits=digits_expr)
+            guarded_numeric_expr = fragments.numeric_guard_expr
+            num_date_expr_sql = fragments.numeric_date_expr
         else:
             metrics_sql.append("0 AS EMPTY_STR_ROWS")
             metrics_sql.append("0 AS WS_ONLY_ROWS")
@@ -1722,17 +1774,9 @@ def run_table_profile(
             metrics_sql.append(
                 f"NULL AS {num_date_max_alias or 'NUMDATE_MAX'}"
             )
-        length_expr: Optional[str]
-        if is_string:
-            length_expr = f"LENGTH({qcol}::STRING)"
-        elif is_numeric:
-            length_expr = f"LENGTH(TO_VARCHAR({qcol}))"
-        else:
-            length_expr = None
+        length_expr = _column_length_expression(qcol, is_string=is_string, is_numeric=is_numeric)
         if length_expr:
-            metrics_sql.append(
-                f"AVG(CASE WHEN {qcol} IS NOT NULL THEN {length_expr} END) AS AVG_LEN"
-            )
+            metrics_sql.append(_avg_length_metric(qcol, length_expr))
         else:
             metrics_sql.append("NULL AS AVG_LEN")
 

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -7,6 +7,7 @@ import logging
 import math
 import os
 import random
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import uuid4
@@ -27,6 +28,67 @@ __all__ = [
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _StringColumnSqlFragments:
+    """Precomputed SQL snippets used when profiling string columns."""
+
+    empty_expr: str
+    whitespace_only_expr: str
+    whitespace_expr: str
+    lead_trail_expr: str
+    numeric_guard_expr: str
+    numeric_date_expr: str
+
+
+def _string_column_sql_fragments(qcol: str) -> _StringColumnSqlFragments:
+    """Return reusable SQL fragments for profiling a string column."""
+
+    digits_expr = "REGEXP_REPLACE({col}::STRING, '[^0-9]', '')".format(col=qcol)
+    numeric_guard_expr = (
+        "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
+        "THEN {digits} ELSE NULL END"
+    ).format(digits=digits_expr)
+    numeric_date_expr = (
+        "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
+        "THEN TRY_TO_DATE({digits}, 'YYYYMMDD') ELSE NULL END"
+    ).format(digits=digits_expr)
+    return _StringColumnSqlFragments(
+        empty_expr=f"SUM(CASE WHEN {qcol}::STRING = '' THEN 1 ELSE 0 END) AS EMPTY_STR_ROWS",
+        whitespace_only_expr=(
+            f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\\\s+$') "
+            "THEN 1 ELSE 0 END) AS WS_ONLY_ROWS"
+        ),
+        whitespace_expr=(
+            f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, "
+            "'^\\\\s|\\\\s$|\\\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
+        ),
+        lead_trail_expr=(
+            f"SUM(CASE WHEN {qcol} IS NOT NULL AND {qcol}::STRING != TRIM({qcol}::STRING) "
+            "THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
+        ),
+        numeric_guard_expr=numeric_guard_expr,
+        numeric_date_expr=numeric_date_expr,
+    )
+
+
+def _column_length_expression(
+    qcol: str, *, is_string: bool, is_numeric: bool
+) -> Optional[str]:
+    """Return the expression used to compute column value lengths."""
+
+    if is_string:
+        return f"LENGTH({qcol}::STRING)"
+    if is_numeric:
+        return f"LENGTH(TO_VARCHAR({qcol}))"
+    return None
+
+
+def _avg_length_metric(qcol: str, length_expr: str) -> str:
+    """Return the AVG length metric for the provided column expression."""
+
+    return f"AVG(CASE WHEN {qcol} IS NOT NULL THEN {length_expr} END) AS AVG_LEN"
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -1675,27 +1737,17 @@ def run_table_profile(
         if is_string:
             trimmed_expr = f"TRIM({qcol}::STRING)"
             sentinel_values = ("'0'", "'00000000'", "'0000-00-00'", "'0000/00/00'")
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol}::STRING = '' THEN 1 ELSE 0 END) AS EMPTY_STR_ROWS"
+            fragments = _string_column_sql_fragments(qcol)
+            metrics_sql.extend(
+                [
+                    fragments.empty_expr,
+                    fragments.whitespace_only_expr,
+                    fragments.whitespace_expr,
+                    fragments.lead_trail_expr,
+                ]
             )
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\s+$') THEN 1 ELSE 0 END) AS WS_ONLY_ROWS"
-            )
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol} IS NOT NULL AND REGEXP_LIKE({qcol}::STRING, '^\\s|\\s$|\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
-            )
-            metrics_sql.append(
-                f"SUM(CASE WHEN {qcol} IS NOT NULL AND {qcol}::STRING != TRIM({qcol}::STRING) THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
-            )
-            digits_expr = "REGEXP_REPLACE({col}::STRING, '[^0-9]', '')".format(col=qcol)
-            guarded_numeric_expr = (
-                "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
-                "THEN {digits} ELSE NULL END"
-            ).format(digits=digits_expr)
-            num_date_expr_sql = (
-                "CASE WHEN LENGTH({digits}) = 8 AND {digits} NOT IN ('00000000') "
-                "THEN TRY_TO_DATE({digits}, 'YYYYMMDD') ELSE NULL END"
-            ).format(digits=digits_expr)
+            guarded_numeric_expr = fragments.numeric_guard_expr
+            num_date_expr_sql = fragments.numeric_date_expr
         else:
             metrics_sql.append("0 AS EMPTY_STR_ROWS")
             metrics_sql.append("0 AS WS_ONLY_ROWS")
@@ -1722,17 +1774,9 @@ def run_table_profile(
             metrics_sql.append(
                 f"NULL AS {num_date_max_alias or 'NUMDATE_MAX'}"
             )
-        length_expr: Optional[str]
-        if is_string:
-            length_expr = f"LENGTH({qcol}::STRING)"
-        elif is_numeric:
-            length_expr = f"LENGTH(TO_VARCHAR({qcol}))"
-        else:
-            length_expr = None
+        length_expr = _column_length_expression(qcol, is_string=is_string, is_numeric=is_numeric)
         if length_expr:
-            metrics_sql.append(
-                f"AVG(CASE WHEN {qcol} IS NOT NULL THEN {length_expr} END) AS AVG_LEN"
-            )
+            metrics_sql.append(_avg_length_metric(qcol, length_expr))
         else:
             metrics_sql.append("NULL AS AVG_LEN")
 

--- a/snapshots/tests/test_sql_golden.p
+++ b/snapshots/tests/test_sql_golden.p
@@ -1,0 +1,64 @@
+from services.profiling import (
+    _avg_length_metric,
+    _column_length_expression,
+    _string_column_sql_fragments,
+)
+from utils.checkdefs import build_rule_for_column_check
+
+
+def test_string_whitespace_fragments_are_stable():
+    qcol = '"CUSTOMER_NAME"'
+    fragments = _string_column_sql_fragments(qcol)
+
+    assert (
+        fragments.empty_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\"::STRING = '' THEN 1 ELSE 0 END) AS EMPTY_STR_ROWS"
+    )
+    assert (
+        fragments.whitespace_only_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL AND REGEXP_LIKE(\"CUSTOMER_NAME\"::STRING, '^\\\\s+$') THEN 1 ELSE 0 END) AS WS_ONLY_ROWS"
+    )
+    assert (
+        fragments.whitespace_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL AND REGEXP_LIKE(\"CUSTOMER_NAME\"::STRING, '^\\\\s|\\\\s$|\\\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
+    )
+    assert (
+        fragments.lead_trail_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL AND \"CUSTOMER_NAME\"::STRING != TRIM(\"CUSTOMER_NAME\"::STRING) THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
+    )
+
+
+def test_string_numeric_date_fragment_is_stable():
+    qcol = '"CUSTOMER_NAME"'
+    fragments = _string_column_sql_fragments(qcol)
+    expected = (
+        "CASE WHEN LENGTH(REGEXP_REPLACE(\"CUSTOMER_NAME\"::STRING, '[^0-9]', '')) = 8 "
+        "AND REGEXP_REPLACE(\"CUSTOMER_NAME\"::STRING, '[^0-9]', '') NOT IN ('00000000') "
+        "THEN TRY_TO_DATE(REGEXP_REPLACE(\"CUSTOMER_NAME\"::STRING, '[^0-9]', ''), 'YYYYMMDD') ELSE NULL END"
+    )
+    assert fragments.numeric_date_expr == expected
+
+
+def test_avg_length_metric_uses_case_guard():
+    qcol = '"CUSTOMER_NAME"'
+    length_expr = _column_length_expression(qcol, is_string=True, is_numeric=False)
+    assert length_expr == "LENGTH(\"CUSTOMER_NAME\"::STRING)"
+    metric = _avg_length_metric(qcol, length_expr)
+    assert (
+        metric
+        == "AVG(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL THEN LENGTH(\"CUSTOMER_NAME\"::STRING) END) AS AVG_LEN"
+    )
+
+
+def test_checkdef_whitespace_internal_only_pattern():
+    sql, is_agg = build_rule_for_column_check(
+        "DB.SCHEMA.TABLE",
+        "customer_name",
+        "WHITESPACE",
+        {"mode": "NO_INTERNAL_ONLY_WHITESPACE"},
+    )
+    assert not is_agg
+    assert (
+        sql
+        == "(\"customer_name\" IS NULL OR REGEXP_REPLACE(\"customer_name\", '\\s+', ' ') = \"customer_name\")"
+    )

--- a/tests/test_sql_golden.py
+++ b/tests/test_sql_golden.py
@@ -1,0 +1,64 @@
+from services.profiling import (
+    _avg_length_metric,
+    _column_length_expression,
+    _string_column_sql_fragments,
+)
+from utils.checkdefs import build_rule_for_column_check
+
+
+def test_string_whitespace_fragments_are_stable():
+    qcol = '"CUSTOMER_NAME"'
+    fragments = _string_column_sql_fragments(qcol)
+
+    assert (
+        fragments.empty_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\"::STRING = '' THEN 1 ELSE 0 END) AS EMPTY_STR_ROWS"
+    )
+    assert (
+        fragments.whitespace_only_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL AND REGEXP_LIKE(\"CUSTOMER_NAME\"::STRING, '^\\\\s+$') THEN 1 ELSE 0 END) AS WS_ONLY_ROWS"
+    )
+    assert (
+        fragments.whitespace_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL AND REGEXP_LIKE(\"CUSTOMER_NAME\"::STRING, '^\\\\s|\\\\s$|\\\\s{{2,}}') THEN 1 ELSE 0 END) AS WHITESPACE_ROWS"
+    )
+    assert (
+        fragments.lead_trail_expr
+        == "SUM(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL AND \"CUSTOMER_NAME\"::STRING != TRIM(\"CUSTOMER_NAME\"::STRING) THEN 1 ELSE 0 END) AS LEAD_TRAIL_WS_ROWS"
+    )
+
+
+def test_string_numeric_date_fragment_is_stable():
+    qcol = '"CUSTOMER_NAME"'
+    fragments = _string_column_sql_fragments(qcol)
+    expected = (
+        "CASE WHEN LENGTH(REGEXP_REPLACE(\"CUSTOMER_NAME\"::STRING, '[^0-9]', '')) = 8 "
+        "AND REGEXP_REPLACE(\"CUSTOMER_NAME\"::STRING, '[^0-9]', '') NOT IN ('00000000') "
+        "THEN TRY_TO_DATE(REGEXP_REPLACE(\"CUSTOMER_NAME\"::STRING, '[^0-9]', ''), 'YYYYMMDD') ELSE NULL END"
+    )
+    assert fragments.numeric_date_expr == expected
+
+
+def test_avg_length_metric_uses_case_guard():
+    qcol = '"CUSTOMER_NAME"'
+    length_expr = _column_length_expression(qcol, is_string=True, is_numeric=False)
+    assert length_expr == "LENGTH(\"CUSTOMER_NAME\"::STRING)"
+    metric = _avg_length_metric(qcol, length_expr)
+    assert (
+        metric
+        == "AVG(CASE WHEN \"CUSTOMER_NAME\" IS NOT NULL THEN LENGTH(\"CUSTOMER_NAME\"::STRING) END) AS AVG_LEN"
+    )
+
+
+def test_checkdef_whitespace_internal_only_pattern():
+    sql, is_agg = build_rule_for_column_check(
+        "DB.SCHEMA.TABLE",
+        "customer_name",
+        "WHITESPACE",
+        {"mode": "NO_INTERNAL_ONLY_WHITESPACE"},
+    )
+    assert not is_agg
+    assert (
+        sql
+        == "(\"customer_name\" IS NULL OR REGEXP_REPLACE(\"customer_name\", '\\s+', ' ') = \"customer_name\")"
+    )


### PR DESCRIPTION
Lock SQL builder outputs and lint

- Refactor profiling SQL assembly into reusable helpers and expose fragments for testing.
- Add golden tests to assert whitespace, numeric date, and length metrics along with mirrored snapshots.
- Configure sqlfluff with a GitHub Action to lint SQL on every push and pull request.


------
https://chatgpt.com/codex/tasks/task_e_69047bed36788324bbb77e59110d4d3a