### PR TITLE
Guardrails Phase 2 — tighten CI guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          pip install pre-commit pytest sqlfluff
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run tests
+        env:
+          UPDATE_SNAPSHOTS: ${{ env.UPDATE_SNAPSHOTS }}
+        run: |
+          if [ "${UPDATE_SNAPSHOTS}" = "1" ]; then
+            pytest -q
+          else
+            pytest -q
+          fi
+      - name: Ensure snapshots untouched
+        run: |
+          if [ -n "$(git status --short tests/__snapshots__)" ]; then
+            echo "Snapshot files changed during CI. Set UPDATE_SNAPSHOTS=1 to update intentionally." >&2
+            exit 1
+          fi
+      - name: Run UI guard check
+        run: python tools/guard_check.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 2.1.1
+    hooks:
+      - id: sqlfluff-lint
+        additional_dependencies: ["sqlfluff-templater-jinja"]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Zeus Data Quality
 
+[![CI](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml/badge.svg)](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml)
+[![Lint](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml/badge.svg?label=Lint)](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml)
+[![Snapshots](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml/badge.svg?label=Snapshots)](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml)
+[![UI Contract](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml/badge.svg?label=UI%20Contract)](https://github.com/Zeus-Labs/zeus_data_quality/actions/workflows/ci.yml)
+
 Zeus Data Quality brings monitoring, profiling, and remediation workflows directly into Snowflake so data owners can spot and resolve issues before they affect reporting.
+
+## Governance
+
+- Review [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request; follow the [pull request template](.github/pull_request_template.md) and squash via the automation workflow.
+- Architectural decisions live in [ARCHITECTURE.md](ARCHITECTURE.md); align changes with the documented boundaries and module responsibilities.
+- UI contracts are defined in [docs/ui_contract_docs.md](docs/ui_contract_docs.md). Do not change layout, labels, or snapshots without explicit approval.
+- Experimental UI features must be gated behind environment flags from `utils/flags.py`. Snapshots are updated only when intentional UI changes are approved.
 
 ## Product snapshot
 - **Use case**: Centralise data quality rules for business-critical tables without exporting data.

--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -83,6 +83,7 @@ from views.profile_view import render_profile
 from views.table_picker import stateless_table_picker, session_cache_token
 from views.docs_view import render_docs as render_docs_view
 from views.config_editor import render_row_count_preview
+from utils.flags import DEMO_LOCK
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs"}
 
@@ -1678,8 +1679,12 @@ with st.sidebar:
         ):
             open_config_editor()
         st.divider()
-    run_as_role = st.text_input("RUN_AS_ROLE", value=state.get("run_as_role") or "")
-    dmf_role = st.text_input("DMF_ROLE", value=state.get("dmf_role") or "")
+    run_as_role = st.text_input(
+        "RUN_AS_ROLE", value=state.get("run_as_role") or "", disabled=DEMO_LOCK
+    )
+    dmf_role = st.text_input(
+        "DMF_ROLE", value=state.get("dmf_role") or "", disabled=DEMO_LOCK
+    )
     set_state(run_as_role or None, dmf_role or None)
 
 # Maintain a subtle separation between the sidebar navigation

--- a/snapshots/tests/test_profile_view_snapshot.p
+++ b/snapshots/tests/test_profile_view_snapshot.p
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+from ui.strings import ProfileStrings as PS
 
 
 def _unique(values: List[str]) -> List[str]:
@@ -22,18 +24,47 @@ class _ProfileContractCollector(ast.NodeVisitor):
         self.captions: List[str] = []
         self.buttons: List[str] = []
         self.grid_columns: List[str] | None = None
+        self._bindings: Dict[str, str] = {}
 
     def _strings_from_node(self, node: ast.AST | None) -> List[str]:
         if node is None:
             return []
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            return [node.value]
+        evaluated = self._evaluate_string(node)
+        if evaluated is not None:
+            return [evaluated]
         if isinstance(node, ast.IfExp):
             values: List[str] = []
             values.extend(self._strings_from_node(node.body))
             values.extend(self._strings_from_node(node.orelse))
             return values
         return []
+
+    def _evaluate_string(self, node: ast.AST) -> Optional[str]:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Attribute):
+            resolved = self._resolve_attribute(node)
+            if isinstance(resolved, str):
+                return resolved
+        if isinstance(node, ast.Name):
+            return self._bindings.get(node.id)
+        return None
+
+    def _resolve_attribute(self, node: ast.Attribute) -> Any:
+        target: Any
+        if isinstance(node.value, ast.Name):
+            if node.value.id == "PS":
+                target = PS
+            else:
+                return None
+        elif isinstance(node.value, ast.Attribute):
+            parent = self._resolve_attribute(node.value)
+            if parent is None:
+                return None
+            target = parent
+        else:
+            return None
+        return getattr(target, node.attr, None)
 
     def visit_Call(self, node: ast.Call) -> Any:  # type: ignore[override]
         func = node.func
@@ -53,12 +84,18 @@ class _ProfileContractCollector(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> Any:  # type: ignore[override]
         for target in node.targets:
             if isinstance(target, ast.Name) and target.id == "grid_columns":
-                try:
-                    value = ast.literal_eval(node.value)
-                except Exception:
-                    value = None
-                if isinstance(value, list) and all(isinstance(item, str) for item in value):
-                    self.grid_columns = value
+                values: List[str] = []
+                if isinstance(node.value, ast.List):
+                    for element in node.value.elts:
+                        evaluated = self._evaluate_string(element)
+                        if evaluated is not None:
+                            values.append(evaluated)
+                if values:
+                    self.grid_columns = values
+            elif isinstance(target, ast.Name):
+                evaluated = self._evaluate_string(node.value)
+                if evaluated is not None:
+                    self._bindings[target.id] = evaluated
         self.generic_visit(node)
 
 

--- a/snapshots/tools/guard_check.p
+++ b/snapshots/tools/guard_check.p
@@ -1,0 +1,81 @@
+"""Repository guard checks for UI contract compliance."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def check_profile_strings(errors: List[str]) -> None:
+    from ui.strings import ProfileStrings as PS
+
+    expected = {
+        "RUN_BUTTON": "▶️ Run Profile",
+        "SUGGEST_BUTTON": "✨ Suggest DQ Config",
+        "SAVE_TOGGLE": "💾 Save Profile",
+        "GRID_COLUMN_SELECT": "Select",
+        "GRID_COLUMN_COLUMN": "Column",
+        "GRID_COLUMN_PHYSICAL_TYPE": "Physical Type",
+        "GRID_COLUMN_NULLS": "Nulls",
+        "GRID_COLUMN_DISTINCT": "Distinct",
+        "GRID_COLUMN_AVG_LENGTH": "Avg Length",
+        "GRID_COLUMN_MIN_VALUE": "Min Value",
+        "GRID_COLUMN_MAX_VALUE": "Max Value",
+        "GRID_COLUMN_WHITESPACE": "Whitespace %",
+        "GRID_COLUMN_GUESSED_TYPE": "Guessed Type",
+        "GRID_COLUMN_CONFIDENCE": "Confidence",
+        "GRID_COLUMN_NOTE": "Note",
+        "SUGGEST_BUTTON": "✨ Suggest DQ Config",
+    }
+    for attr, expected_value in expected.items():
+        actual = getattr(PS, attr, None)
+        if actual != expected_value:
+            errors.append(
+                f"ProfileStrings.{attr} expected '{expected_value}' but found '{actual}'."
+            )
+
+
+def check_docs_strings(errors: List[str]) -> None:
+    from ui.strings import DocsStrings
+
+    expected_tabs = (
+        "User Guide",
+        "Profiling",
+        "DQ Framework",
+        "Technical Overview",
+        "Data Governance",
+        "Version History",
+    )
+    if tuple(DocsStrings.TABS) != expected_tabs:
+        errors.append(
+            "DocsStrings.TABS must remain the six default documentation tabs."
+        )
+
+
+def main() -> int:
+    errors: List[str] = []
+    try:
+        check_profile_strings(errors)
+        check_docs_strings(errors)
+    except Exception as exc:  # pragma: no cover - guard failure path
+        errors.append(f"Guard check execution error: {exc}")
+
+    if errors:
+        print("UI contract guard check failed:\n", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        print(
+            "Refer to docs/ui_contract_docs.md before modifying UI labels or layout.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/snapshots/ui/keys.p
+++ b/snapshots/ui/keys.p
@@ -1,0 +1,13 @@
+"""Centralised Streamlit widget keys for UI components."""
+
+from __future__ import annotations
+
+from typing import Final
+
+PROFILE_SAMPLE_PCT: Final[str] = "profile_sample_pct"
+PROFILE_SAMPLE_TARGET: Final[str] = "profile_sample_target"
+PROFILE_LOAD_SELECT: Final[str] = "profile_load_select"
+PROFILE_LOAD_BUTTON: Final[str] = "profile_load_button"
+PROFILE_CLEAR_LOADED: Final[str] = "profile_clear_loaded"
+PROFILE_SAVE_TOGGLE: Final[str] = "profile_save_toggle"
+PROFILE_RESULTS_SELECTION: Final[str] = "profile_results_selection"

--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -1,0 +1,378 @@
+"""Centralised UI strings for Streamlit views."""
+
+from __future__ import annotations
+
+from typing import Final, Tuple
+
+
+class ProfileStrings:
+    HEADER: Final[str] = "🧪 Profile Table"
+    CAPTION: Final[str] = (
+        "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks."
+    )
+    RUN_BUTTON: Final[str] = "▶️ Run Profile"
+    SUGGEST_BUTTON: Final[str] = "✨ Suggest DQ Config"
+    CLEAR_LOADED_BUTTON: Final[str] = "Clear loaded profile"
+    SAVED_PROFILE_INFO: Final[str] = "Viewing a saved profile."
+    SAVE_TOGGLE: Final[str] = "💾 Save Profile"
+    NO_COLUMNS_MATCHED: Final[str] = "No columns matched the selected filters."
+    TOP_VALUES_SUBHEADER: Final[str] = "Top values by column"
+    NO_NON_NULL_VALUES: Final[str] = "No non-null values to display."
+    NO_TOP_VALUES: Final[str] = "No top values available."
+    SAMPLE_LABEL: Final[str] = "Sample %"
+    TOP_N_LABEL: Final[str] = "Top N values"
+    TOP_N_HELP_TEMPLATE: Final[str] = "Collect up to {max_top} of the most common values per column."
+    LOAD_SAVED_LABEL: Final[str] = "Load saved profile"
+    LOAD_SAVED_EMPTY: Final[str] = "— No saved profiles —"
+    LOAD_SAVED_PLACEHOLDER: Final[str] = "— Select a saved run —"
+    LOAD_BUTTON: Final[str] = "Load"
+    LOAD_WARNING_CONNECTION: Final[str] = "Loading profiles requires a Snowflake connection and metadata configuration."
+    LOAD_WARNING_SELECT_RUN: Final[str] = "Select a saved run to load."
+    LOAD_ERROR: Final[str] = "Failed to load saved profile: {error}"
+    LOAD_WARNING_NOT_FOUND: Final[str] = "Saved profile was not found or is empty."
+    LOAD_SUCCESS: Final[str] = "Loaded saved profile {run_id}."
+    LOAD_DISABLED_CAPTION: Final[str] = "Connect to Snowflake and select metadata targets to enable saving."
+    LOAD_ENABLED_CAPTION: Final[str] = "Persist the current profile results to metadata tables."
+    CLEAR_PROFILE_SUCCESS: Final[str] = "Saved profile run {run_id} to metadata."
+    CLEAR_PROFILE_ERROR: Final[str] = "Failed to save profile: {error}"
+    NO_SUGGESTIONS: Final[str] = "No suggestions available for the current profile."
+    SAMPLE_REASON_METADATA: Final[str] = (
+        "The suggested value relies on Snowflake metadata only, so it doesn't trigger an extra table scan."
+    )
+    SAMPLE_REASON_FULL_SCAN: Final[str] = "Enter 0 for a full table scan."
+    SAMPLE_REASON_TABLE_ROWS: Final[str] = "Table metadata reports approximately {rows:,} rows."
+    SAMPLE_REASON_APPROX_ROWS: Final[str] = "This sample size profiles about {rows:,} rows."
+    SAMPLE_DEFAULT_REASON: Final[str] = "Defaulting to a 10% sample. Enter 0 for a full table scan."
+    SAMPLE_HELP_METADATA: Final[str] = SAMPLE_REASON_METADATA
+    SAMPLE_HELP_FULL_SCAN: Final[str] = SAMPLE_REASON_FULL_SCAN
+    SAMPLE_CAPTION: Final[str] = "Suggested: {selected} of {total} columns selected"
+    SAMPLE_SPINNER: Final[str] = "Profiling table..."
+    PROFILE_ERROR: Final[str] = "Failed to profile table: {error}"
+    PROFILE_WARNING_NO_SESSION: Final[str] = "No active Snowpark session — unable to profile tables."
+    PROFILE_WARNING_SELECT_TABLE: Final[str] = "Select a database, schema, and table to profile."
+    PROFILE_SUCCESS_SAVE: Final[str] = "Saved profile run {run_id} to metadata."
+    PROFILE_WARNING_SELECT_COLUMNS: Final[str] = "Select at least one column before generating DQ suggestions."
+    PROFILE_SUCCESS_SUGGESTION: Final[str] = "Loaded profile suggestion into the configuration editor."
+    SAMPLE_WARNING_FULL_SCAN: Final[str] = (
+        "Full table scan processed {rows:,} rows. Consider sampling to improve performance."
+    )
+    METRIC_ROWS_PROFILED: Final[str] = "Rows profiled"
+    METRIC_SAMPLING: Final[str] = "Sampling"
+    METRIC_DURATION: Final[str] = "Duration"
+    METRIC_VIEWING_SAVED: Final[str] = SAVED_PROFILE_INFO
+    SAMPLE_LABEL_FULL_SCAN: Final[str] = "Full scan"
+    FILTERS_SUBHEADER: Final[str] = "Filters"
+    FILTER_HIGH_NULL: Final[str] = "High null % (>20%)"
+    FILTER_UNIQUE: Final[str] = "Unique candidates"
+    FILTER_LOW_CARDINALITY: Final[str] = "Low cardinality"
+    FILTER_WHITESPACE: Final[str] = "Whitespace risk"
+    FILTER_SEMANTIC_LABEL: Final[str] = "Semantic tags"
+    FILTER_SEMANTIC_OPTIONS: Final[Tuple[str, ...]] = (
+        "Identifiers",
+        "Financial",
+        "Instrument",
+        "Geo",
+        "Contact",
+        "Date (Text)",
+        "Reference Codes",
+    )
+    SAMPLE_PCT_REASON_METADATA: Final[str] = SAMPLE_REASON_METADATA
+    SAVE_DISABLED_MESSAGE: Final[str] = LOAD_DISABLED_CAPTION
+    SAVE_ENABLED_MESSAGE: Final[str] = LOAD_ENABLED_CAPTION
+    SAVED_PROFILE_INFO_BOX: Final[str] = SAVED_PROFILE_INFO
+    GRID_COLUMN_SELECT: Final[str] = "Select"
+    GRID_COLUMN_COLUMN: Final[str] = "Column"
+    GRID_COLUMN_PHYSICAL_TYPE: Final[str] = "Physical Type"
+    GRID_COLUMN_NULLS: Final[str] = "Nulls"
+    GRID_COLUMN_DISTINCT: Final[str] = "Distinct"
+    GRID_COLUMN_AVG_LENGTH: Final[str] = "Avg Length"
+    GRID_COLUMN_MIN_VALUE: Final[str] = "Min Value"
+    GRID_COLUMN_MAX_VALUE: Final[str] = "Max Value"
+    GRID_COLUMN_WHITESPACE: Final[str] = "Whitespace %"
+    GRID_COLUMN_GUESSED_TYPE: Final[str] = "Guessed Type"
+    GRID_COLUMN_CONFIDENCE: Final[str] = "Confidence"
+    GRID_COLUMN_NOTE: Final[str] = "Note"
+    GRID_CHECKBOX_HELP: Final[str] = "Toggle to include the column in downstream DQ suggestions."
+    GRID_EMPTY_INFO: Final[str] = "No columns matched the selected filters."
+    LOAD_CAPTION_NO_SAVED: Final[str] = "No saved profiles found in metadata tables yet."
+    LOAD_CAPTION_NEEDS_CONNECTION: Final[str] = (
+        "Connect to Snowflake and configure metadata targets to enable loading saved profiles."
+    )
+    PROFILE_SUCCESS_SAVED_PROFILE: Final[str] = "Saved profile run {run_id} to metadata."
+    PROFILE_SUMMARY_SAVED_PROFILE: Final[str] = "Viewing a saved profile."
+    BUTTON_CLEAR_PROFILE: Final[str] = CLEAR_LOADED_BUTTON
+    INFO_VIEWING_SAVED: Final[str] = SAVED_PROFILE_INFO
+    INFO_NO_SAVED_PROFILE: Final[str] = "Saved profile was not found or is empty."
+    SUCCESS_LOADED_PROFILE: Final[str] = "Loaded saved profile {run_id}."
+    SUCCESS_PROFILE_SUGGESTION: Final[str] = PROFILE_SUCCESS_SUGGESTION
+    SUCCESS_PROFILE_SAVE: Final[str] = PROFILE_SUCCESS_SAVE
+    WARNING_SELECT_PROFILE: Final[str] = LOAD_WARNING_SELECT_RUN
+    WARNING_NO_CONNECTION: Final[str] = LOAD_WARNING_CONNECTION
+    WARNING_SELECT_COLUMNS: Final[str] = PROFILE_WARNING_SELECT_COLUMNS
+    WARNING_NO_COLUMNS: Final[str] = NO_COLUMNS_MATCHED
+    INFO_SAVED_PROFILE: Final[str] = SAVED_PROFILE_INFO
+    INFO_NO_VALUES: Final[str] = NO_TOP_VALUES
+    INFO_NO_NON_NULL: Final[str] = NO_NON_NULL_VALUES
+    INFO_SAVED_PROFILE_VIEW: Final[str] = SAVED_PROFILE_INFO
+    INFO_NO_COLUMNS: Final[str] = NO_COLUMNS_MATCHED
+    TOP_VALUES_VALUE_HEADER: Final[str] = "Value"
+    TOP_VALUES_COUNT_HEADER: Final[str] = "Count"
+    INLINE_SELECT_DISABLED: Final[str] = (
+        "UI contract violation: inline selection must remain enabled. Set PROFILE_INLINE_SELECT=1."
+    )
+    DEBUG_PROFILE_PAYLOAD: Final[str] = "Debug: profile payload"
+    DEBUG_SELECTION_STATE: Final[str] = "Debug: include map"
+
+
+class ConfigEditorStrings:
+    CONTRACT_DATAFRAME_EXPECTED: Final[str] = (
+        "UI contract violation in config preview: expected a pandas DataFrame."
+    )
+    CONTRACT_COLUMNS_MISMATCH: Final[str] = (
+        "UI contract violation in config preview: expected columns {expected} but found {actual}."
+    )
+
+
+class DocsStrings:
+    HEADER: Final[str] = "Zeus Data Quality documentation"
+    TABS: Final[Tuple[str, ...]] = (
+        "User Guide",
+        "Profiling",
+        "DQ Framework",
+        "Technical Overview",
+        "Data Governance",
+        "Version History",
+    )
+    CONTRACT_TABS_MISMATCH: Final[str] = (
+        "UI contract violation in documentation view: expected 6 tabs."
+    )
+    USER_GUIDE_SUBHEADER: Final[str] = "User Guide"
+    PROFILING_SUBHEADER: Final[str] = "Profiling"
+    FRAMEWORK_SUBHEADER: Final[str] = "Snowflake-native data quality framework"
+    TECHNICAL_SUBHEADER: Final[str] = "Technical Overview"
+    DATA_GOVERNANCE_SUBHEADER: Final[str] = "Data Governance and Security"
+    VERSION_HISTORY_SUBHEADER: Final[str] = "Version History"
+    VERSION_HISTORY_INFO: Final[str] = (
+        "Version history will be documented here once releases are tracked."
+    )
+    USER_GUIDE_CONTENT: Final[str] = (
+        """
+#### What the app delivers
+- **Purpose**: Monitor critical Snowflake tables so issues surface before reporting deadlines.
+- **Audience**: Data owners, analysts, and operations leads who prefer guided workflows over ad-hoc SQL.
+
+#### Create a configuration
+1. **Select a source** – choose the database, schema, and table to protect.
+2. **Name the setup** – use a business-friendly title so teams recognise the coverage.
+3. **Pick columns** – decide which checks apply to each column based on risk.
+4. **Review table options** – confirm the timestamp and warehouse before saving.
+5. **Save and apply** – the configuration is stored and the daily 08:00 (Europe/Berlin) task is scheduled.
+
+> **Tip:** Use **Save** to draft changes and **Save and apply** once the table is ready for monitoring.
+
+#### Checks in plain language
+- **Uniqueness** identifies duplicate business keys.
+- **Null count** tracks missing information.
+- **Minimum/maximum** keeps numeric ranges within agreed limits.
+- **Whitespace** flags leading or trailing spaces that break joins.
+- **Format distribution** watches identifier patterns such as IBAN, ISIN, or email.
+- **Value distribution** monitors the mix of categories and highlights unusual shifts.
+- **Freshness** confirms data arrives on time based on the chosen timestamp column.
+- **Row count anomaly** spots sudden volume changes relative to recent history.
+- **Aggregate checks** support custom totals or ratios when business validation requires them.
+
+#### Run and monitor results
+- **Run now** performs an immediate evaluation for spot checks.
+- **Daily tasks** operate automatically once a schedule is enabled.
+- **Monitor** surfaces outcomes with filters by table, check type, or status; results can be downloaded for follow-up.
+
+#### Troubleshooting essentials
+- Verify the Snowflake warehouse is running and sized for the workload.
+- Confirm the active role has access to the source objects and metadata schema.
+- Review stored procedure messages in the Monitor tab or execute the procedure manually for detailed logs.
+"""
+    )
+    PROFILING_CONTENT: Final[str] = (
+        """
+#### Why profile first
+Profiling runs lightweight column statistics so you understand data shape and completeness before finalising monitoring rules. The output points to high-risk fields, validates business keys, and surfaces unexpected formats.
+
+#### Metrics collected per column
+- **Null percentage and count** highlight missing data hotspots.
+- **Distinct percentage and count** confirm uniqueness or signal categorical fields.
+- **Minimum and maximum** verify numeric and timestamp ranges.
+- **Average length** spots truncated strings or inconsistent identifiers.
+- **Whitespace percentage** exposes formatting issues that can break joins.
+- **Top values** display the most frequent categories or potential outliers.
+
+#### Semantic insights and confidence
+- Columns receive semantic suggestions such as IBAN, ISIN, email, account ID, country, or timestamp based on detected patterns.
+- Confidence levels appear as High, Medium, Low, or Unknown with colour coding in the grid.
+- Hover the **Confidence rationale** tooltip to see why a tag was chosen (for example, "Regex match on 92% of rows").
+
+#### Filters that guide design
+- Apply filters for high null percentage, unique candidates, low cardinality, or whitespace risk to shortlist columns.
+- Use semantic tag filters (Identifiers, Financial, Instrument, Geography, Contact) to concentrate on sensitive fields.
+- Combine these insights to select uniqueness, null, pattern, or distribution checks inside the configuration editor.
+
+#### Performance and accuracy notes
+- Sampling defaults to a recommended percentage based on table size; set the value to `0` when a full scan is required.
+- Large tables automatically switch distinct counts to `APPROX_COUNT_DISTINCT`, balancing accuracy (within ~1%) and speed.
+- The summary banner reports rows profiled, sampling choice, and runtime so you can judge cost before rerunning.
+
+#### Persisting and reusing results
+- Enable **Save profile** once metadata targets are configured to store runs for auditing or historical comparison.
+- Use **Suggest DQ config** after profiling to pre-populate the configuration editor with recommended checks.
+"""
+    )
+    FRAMEWORK_CONTENT: Final[str] = (
+        """
+### Data Monitoring Framework (DMF) checks
+- Each row-level rule becomes a DMF view that runs inside Snowflake.
+- Failing rows surface in `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` within `{metadata_db}`.`{metadata_schema}`.
+- Views follow the pattern `SELECT * FROM <source> WHERE NOT (<rule_predicate>)`, using generated identifiers to avoid collisions.
+- Save and apply creates or refreshes the views and grants access. Removing a config cleans up unused artefacts.
+
+### Aggregate table-level checks
+- Freshness and row-count anomaly checks execute as aggregate SQL directly against the source table.
+- Because they summarise the entire table, they store only results in `{run_results_table}` and do not create DMF views.
+- Freshness compares the latest timestamp in the monitored column; row-count anomaly looks at recent history for spikes or droughts.
+
+### Stored procedures orchestrating runs
+- `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` (Snowpark Python) receives a configuration ID, evaluates every check, and records outcomes in `{run_results_table}`.
+- `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages task lifecycle with `EXECUTE AS CALLER`, ensuring warehouse and privilege alignment.
+
+### Tasks per configuration
+- Each configuration owns a Snowflake task `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`.
+- The task runs `CALL {proc_name}('<CONFIG_ID>')`, inheriting the caller's warehouse by default.
+- Cron syntax with IANA time zones supports 08:00 Europe/Berlin schedules and any overrides defined by administrators.
+
+### Roles, context, and required grants
+- Procedures execute as caller so data access policies remain intact.
+- The app expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both procedures.
+- Streamlit in Snowflake keeps ownership with the application role, simplifying audits and change tracking.
+
+### Why Snowflake for data quality
+- In-database compute keeps checks near the data—no egress or shadow copies.
+- Snowpark Python combines orchestration logic with native SQL execution.
+- Streamlit in Snowflake provides the UI where teams already work.
+- INFORMATION_SCHEMA and Account Usage power metadata-driven discovery and monitoring.
+- Governed sharing and roles ensure DMF views, tasks, and procedures respect enterprise security boundaries.
+"""
+    )
+    FRAMEWORK_ENTITY_GRAPH: Final[str] = (
+        """
+digraph G {{
+    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.4, nodesep=0.9, ranksep=1.1, splines=true];
+    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, fillcolor="#f4f6fb", color="#d5dbed", penwidth=1.2];
+    edge [color="#4f46e5", fontname="Helvetica", fontsize=10, arrowsize=0.8];
+
+    subgraph cluster_metadata {{
+        label="Metadata Schema";
+        fontname="Helvetica";
+        fontsize=11;
+        color="#c7d2fe";
+        style="rounded";
+        {cfg_tbl_node} [label="{cfg_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
+        {chk_tbl_node} [label="{chk_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
+        {run_tbl_node} [label="{run_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
+        {profile_run_node} [label="{profile_run_label}\\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
+        {profile_col_node} [label="{profile_col_label}\\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
+        dmfv [label="DMF_FAIL views\\n(per active check)", shape=folder, fillcolor="#fdf2f8", color="#fbcfe8", fontcolor="#831843"];
+    }}
+
+    app [label="Streamlit App", shape=rect, fillcolor="#ecfdf5", color="#bbf7d0", fontcolor="#047857"];
+    {proc_node} [label="{proc_label}", shape=rect, fillcolor="#ede9fe", color="#c4b5fd", fontcolor="#5b21b6"];
+    task [label="Snowflake Task\\nper config", shape=rect, fillcolor="#fef3c7", color="#fcd34d", fontcolor="#92400e"];
+
+    app -> {cfg_tbl_node} [label="creates / edits"];
+    app -> {chk_tbl_node} [label="creates / edits"];
+    app -> dmfv [label="renders"];
+    app -> {profile_run_node} [label="captures profiles"];
+    app -> {profile_col_node} [label="renders"];
+    {cfg_tbl_node} -> {chk_tbl_node} [label="defines"];
+    {cfg_tbl_node} -> task [label="schedules"];
+    task -> {proc_node} [label="calls"];
+    {proc_node} -> {run_tbl_node} [label="logs to"];
+    {proc_node} -> dmfv [label="populates"];
+    {proc_node} -> {profile_run_node} [label="logs to", style=dashed, color="#6b7280", fontcolor="#6b7280"];
+    {profile_run_node} -> {profile_col_node} [label="summarises"];
+    {run_tbl_node} -> app [label="renders"];
+    dmfv -> app [label="renders", style=dashed, color="#6b7280", fontcolor="#6b7280"];
+}}
+"""
+    )
+    FRAMEWORK_WORKFLOW_GRAPH: Final[str] = (
+        """
+digraph W {
+    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.5, nodesep=0.9, ranksep=1.1, splines=ortho];
+    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, width=2.2, height=0.8];
+    edge [color="#6366f1", fontname="Helvetica", fontsize=10, arrowsize=0.85];
+
+    step1 [label="User edits\\nconfig", fillcolor="#eef2ff", color="#c7d2fe", fontcolor="#312e81"];
+    step2 [label="Save & Apply", fillcolor="#e0f2fe", color="#bae6fd", fontcolor="#0c4a6e"];
+    step3 [label="Attach DMF\\nviews", fillcolor="#dcfce7", color="#bbf7d0", fontcolor="#065f46"];
+    step4 [label="Task schedule", fillcolor="#fef3c7", color="#fde68a", fontcolor="#92400e"];
+    step5 [label="Daily run", fillcolor="#fee2e2", color="#fecaca", fontcolor="#991b1b"];
+    step6 [label="Log results", fillcolor="#ede9fe", color="#ddd6fe", fontcolor="#5b21b6"];
+    step7 [label="Monitor", fillcolor="#f5f3ff", color="#c4b5fd", fontcolor="#4c1d95"];
+
+    step1 -> step2 [label="commit changes"];
+    step2 -> step3 [label="provision checks"];
+    step3 -> step4 [label="enable task"];
+    step4 -> step5 [label="cron trigger"];
+    step5 -> step6 [label="stored procedure"];
+    step6 -> step7 [label="Surface in app"];
+}
+"""
+    )
+    TECHNICAL_CONTENT: Final[str] = (
+        """
+#### Runtime
+- Streamlit in Snowflake using Snowpark Python.
+
+#### Metadata and results
+- Configs: `{cfg_tbl_display}`
+- Checks: `{chk_tbl_display}`
+- Results: `{run_results_table}`
+
+#### Procedures
+- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` evaluates checks and logs to the results table.
+- Task manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` creates or updates tasks and runs as caller.
+
+#### Tasks
+- One per configuration: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}` with body `CALL {proc_name}('<CONFIG_ID>')`.
+
+#### Warehouses
+- Schedules run on the default application warehouse (for example, `DQ_WH`).
+"""
+    )
+    TECHNICAL_PRIVILEGES_HEADING: Final[str] = "#### Required privileges for the caller role"
+    TECHNICAL_PRIVILEGES_SNIPPET: Final[str] = (
+        """
+USAGE ON WAREHOUSE DQ_WH
+USAGE ON DATABASE {metadata_db}
+USAGE ON SCHEMA {metadata_db}.{metadata_schema}
+CREATE TASK ON SCHEMA {metadata_db}.{metadata_schema}
+EXECUTE ON PROCEDURE {metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)
+"""
+    )
+    DATA_GOVERNANCE_CONTENT: Final[str] = (
+        """
+#### Roles and isolation
+- The application runs with a defined caller role and relies on `EXECUTE AS CALLER` when managing tasks.
+- Configuration and results tables live in a dedicated metadata schema to control privileges.
+
+#### Traceability
+- `DQ_RUN_RESULTS` captures timestamps, check identifiers, failure counts, success flags, and error messages.
+- Each configuration owns a Snowflake task, which is auditable through ACCOUNT USAGE views.
+
+#### Access patterns
+- Source tables are read-only; writes are limited to metadata objects for configs, checks, and results.
+- DMF failing-row views remain in the metadata schema so investigators avoid querying production tables directly.
+
+#### Handling sensitive data
+- Prefer checks that avoid materialising personal data in logs; views expose only what investigators need.
+- Apply column masking to metadata views when sensitive attributes require additional protection.
+"""
+    )

--- a/snapshots/utils/flags.p
+++ b/snapshots/utils/flags.p
@@ -1,0 +1,21 @@
+"""Runtime feature flags and kill switches for Streamlit views."""
+
+from __future__ import annotations
+
+import os
+
+
+def flag(name: str, default: bool = False) -> bool:
+    """Return the boolean value of an environment flag."""
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+UI_CONTRACT_STRICT = flag("UI_CONTRACT_STRICT", False)
+DEMO_LOCK = flag("DEMO_LOCK", False)
+DEBUG_PROFILING = flag("DEBUG_PROFILING_PAYLOAD", False)
+PROFILE_INLINE_SELECT = flag("PROFILE_INLINE_SELECT", True)
+PROFILE_TOP_VALUES_NULLS = flag("PROFILE_TOP_VALUES_NULLS", True)

--- a/snapshots/utils/state.p
+++ b/snapshots/utils/state.p
@@ -1,0 +1,32 @@
+"""Session-state helpers for profile selections."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import streamlit as st
+
+_INCLUDE_MAP = "profile_include_map"
+
+
+def get_include_map() -> Dict[str, bool]:
+    """Return a copy of the current include map from session state."""
+
+    value = st.session_state.get(_INCLUDE_MAP, {})
+    if isinstance(value, dict):
+        return {str(key): bool(val) for key, val in value.items()}
+    return {}
+
+
+def set_include(column: str, include: bool) -> None:
+    """Set the include flag for a single column."""
+
+    include_map = get_include_map()
+    include_map[str(column)] = bool(include)
+    st.session_state[_INCLUDE_MAP] = include_map
+
+
+def bulk_set_includes(columns: List[str], include: bool) -> None:
+    """Replace the include map with a uniform value for provided columns."""
+
+    st.session_state[_INCLUDE_MAP] = {str(column): bool(include) for column in columns}

--- a/snapshots/views/config_editor.p
+++ b/snapshots/views/config_editor.p
@@ -2,20 +2,21 @@
 
 from __future__ import annotations
 
-import os
 from typing import Sequence
 
 import pandas as pd
 import streamlit as st
 
-_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
+from ui.strings import ConfigEditorStrings
+from utils.flags import DEMO_LOCK, UI_CONTRACT_STRICT
+
 _EXPECTED_PREVIEW_COLUMNS: Sequence[str] = ("day", "cnt")
 
 
 def _contract_message(message: str) -> None:
     """Display a contract warning or elevate to an error when strict."""
 
-    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    strict = UI_CONTRACT_STRICT or DEMO_LOCK
     if strict:
         st.error(message)
     else:
@@ -26,17 +27,16 @@ def render_row_count_preview(df: pd.DataFrame) -> None:
     """Render the row-count preview grid with UI contract validation."""
 
     if not isinstance(df, pd.DataFrame):
-        _contract_message(
-            "UI contract violation in config preview: expected a pandas DataFrame."
-        )
+        _contract_message(ConfigEditorStrings.CONTRACT_DATAFRAME_EXPECTED)
         return
 
     actual_columns = list(df.columns)
     expected_columns = list(_EXPECTED_PREVIEW_COLUMNS)
     if actual_columns != expected_columns:
         _contract_message(
-            "UI contract violation in config preview: expected columns "
-            f"{expected_columns} but found {actual_columns}."
+            ConfigEditorStrings.CONTRACT_COLUMNS_MISMATCH.format(
+                expected=expected_columns, actual=actual_columns
+            )
         )
         return
 

--- a/snapshots/views/docs_view.p
+++ b/snapshots/views/docs_view.p
@@ -2,14 +2,24 @@
 
 Layout requirements:
 1. Page header "Zeus Data Quality documentation" appears once at the top.
-2. A fixed `st.tabs` call defines six tabs in this exact order: "User Guide", "Profiling", "DQ Framework", "Technical Overview", "Data Governance", "Version History".  Tab labels and count must not change.
+2. A fixed `st.tabs` call defines six tabs in this exact order: "User Guide", "Profiling", "DQ Framework", "Technical Overview",
+ "Data Governance", "Version History".  Tab labels and count must not change.
 3. Tab content expectations:
-   • "User Guide" tab renders the subheader "User Guide" followed by the existing markdown sections (What the app delivers, Create a configuration, Checks in plain language, Run and monitor results, Troubleshooting essentials).  No interactive widgets belong in this tab.
-   • "Profiling" tab renders the subheader "Profiling" and the markdown sections covering why to profile, metrics, semantic insights, filters, performance notes, and persistence guidance exactly as shipped.  This tab remains markdown-only.
-   • "DQ Framework" tab renders the subheader "Snowflake-native data quality framework" with descriptive markdown, then a divider, then subheader "Entity Diagram" with a Graphviz diagram (rendered via `st.graphviz_chart`) describing metadata objects, followed by subheader "Workflow Diagram" with its Graphviz diagram.  Chart ordering and titles must remain unchanged.
-   • "Technical Overview" tab renders the subheader "Technical Overview", markdown with runtime/metadata/procedure details, then a `st.markdown` heading "#### Required privileges for the caller role" and a single `st.code` block listing privilege statements.  No additional controls may be added.
-   • "Data Governance" tab renders the subheader "Data Governance and Security" plus the markdown sections on roles, traceability, access, and sensitive data handling.
-   • "Version History" tab renders the subheader "Version History" followed by the info message "Version history will be documented here once releases are tracked."  No other content is permitted.
+   • "User Guide" tab renders the subheader "User Guide" followed by the existing markdown sections (What the app delivers, Creat
+ e a configuration, Checks in plain language, Run and monitor results, Troubleshooting essentials).  No interactive widgets belo
+ng in this tab.
+   • "Profiling" tab renders the subheader "Profiling" and the markdown sections covering why to profile, metrics, semantic insig
+hts, filters, performance notes, and persistence guidance exactly as shipped.  This tab remains markdown-only.
+   • "DQ Framework" tab renders the subheader "Snowflake-native data quality framework" with descriptive markdown, then a divider
+, then subheader "Entity Diagram" with a Graphviz diagram (rendered via `st.graphviz_chart`) describing metadata objects, follow
+e d by subheader "Workflow Diagram" with its Graphviz diagram.  Chart ordering and titles must remain unchanged.
+   • "Technical Overview" tab renders the subheader "Technical Overview", markdown with runtime/metadata/procedure details, then
+ a `st.markdown` heading "#### Required privileges for the caller role" and a single `st.code` block listing privilege statements
+.  No additional controls may be added.
+   • "Data Governance" tab renders the subheader "Data Governance and Security" plus the markdown sections on roles, traceability
+, access, and sensitive data handling.
+   • "Version History" tab renders the subheader "Version History" followed by the info message "Version history will be documente
+d here once releases are tracked."  No other content is permitted.
 
 Forbidden patterns:
 • Do not change the tab order, labels, or count.
@@ -23,19 +33,18 @@ Forbidden patterns:
 from __future__ import annotations
 
 from typing import Tuple
-import os
 
 import streamlit as st
 
+from ui.strings import DocsStrings
+from utils.flags import DEMO_LOCK, UI_CONTRACT_STRICT
 from utils.meta import _q
-
-_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
 
 
 def _contract_message(message: str) -> None:
     """Display contract feedback as warning or error based on strict mode."""
 
-    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    strict = UI_CONTRACT_STRICT or DEMO_LOCK
     if strict:
         st.error(message)
     else:
@@ -44,6 +53,7 @@ def _contract_message(message: str) -> None:
 
 def _safe_quote(identifier: str) -> str:
     """Return a safely quoted identifier for display purposes."""
+
     try:
         return _q(identifier)
     except Exception:
@@ -51,11 +61,12 @@ def _safe_quote(identifier: str) -> str:
 
 
 def _sanitize_graph_label(label: str) -> Tuple[str, str]:
-    """Sanitize a fully qualified name for use in future graph visuals."""
+    """Sanitize a fully qualified name for use in graph visuals."""
+
     node_name = "".join(ch if ch.isalnum() else "_" for ch in label)
     if not node_name:
         node_name = "node"
-    display = _safe_quote(label).replace('"', '\\"')
+    display = _safe_quote(label).replace('"', "\\\"")
     return node_name, display
 
 
@@ -68,44 +79,25 @@ def render_docs(
     run_results_table: str,
 ) -> None:
     """Render the documentation tabs for the Streamlit application."""
-    st.header("Zeus Data Quality documentation")
 
-    tabs = st.tabs(
-        [
-            "User Guide",
-            "Profiling",
-            "DQ Framework",
-            "Technical Overview",
-            "Data Governance",
-            "Version History",
-        ]
-    )
+    st.header(DocsStrings.HEADER)
+
+    tabs = st.tabs(list(DocsStrings.TABS))
 
     if len(tabs) != 6:
-        _contract_message(
-            "UI contract violation in documentation view: expected 6 tabs."
-        )
+        _contract_message(DocsStrings.CONTRACT_TABS_MISMATCH)
         return
 
     cfg_tbl_display = _safe_quote(configs_table)
     chk_tbl_display = _safe_quote(checks_table)
+    run_results_display = _safe_quote(run_results_table)
+    metadata_db_display = _safe_quote(metadata_db)
+    metadata_schema_display = _safe_quote(metadata_schema)
 
-    (
-        cfg_tbl_node,
-        cfg_tbl_label,
-    ) = _sanitize_graph_label(configs_table)
-    (
-        chk_tbl_node,
-        chk_tbl_label,
-    ) = _sanitize_graph_label(checks_table)
-    (
-        run_tbl_node,
-        run_tbl_label,
-    ) = _sanitize_graph_label(run_results_table)
-    (
-        proc_node,
-        proc_label,
-    ) = _sanitize_graph_label(proc_name)
+    cfg_tbl_node, cfg_tbl_label = _sanitize_graph_label(configs_table)
+    chk_tbl_node, chk_tbl_label = _sanitize_graph_label(checks_table)
+    run_tbl_node, run_tbl_label = _sanitize_graph_label(run_results_table)
+    proc_node, proc_label = _sanitize_graph_label(proc_name)
 
     profile_run_node, profile_run_label = _sanitize_graph_label(
         f"{metadata_db}.{metadata_schema}.DQ_PROFILE_RUN"
@@ -115,248 +107,72 @@ def render_docs(
     )
 
     with tabs[0]:
-        st.subheader("User Guide")
-        st.markdown(
-            """
-#### What the app delivers
-- **Purpose**: Monitor critical Snowflake tables so issues surface before reporting deadlines.
-- **Audience**: Data owners, analysts, and operations leads who prefer guided workflows over ad-hoc SQL.
-
-#### Create a configuration
-1. **Select a source** – choose the database, schema, and table to protect.
-2. **Name the setup** – use a business-friendly title so teams recognise the coverage.
-3. **Pick columns** – decide which checks apply to each column based on risk.
-4. **Review table options** – confirm the timestamp and warehouse before saving.
-5. **Save and apply** – the configuration is stored and the daily 08:00 (Europe/Berlin) task is scheduled.
-
-> **Tip:** Use **Save** to draft changes and **Save and apply** once the table is ready for monitoring.
-
-#### Checks in plain language
-- **Uniqueness** identifies duplicate business keys.
-- **Null count** tracks missing information.
-- **Minimum/maximum** keeps numeric ranges within agreed limits.
-- **Whitespace** flags leading or trailing spaces that break joins.
-- **Format distribution** watches identifier patterns such as IBAN, ISIN, or email.
-- **Value distribution** monitors the mix of categories and highlights unusual shifts.
-- **Freshness** confirms data arrives on time based on the chosen timestamp column.
-- **Row count anomaly** spots sudden volume changes relative to recent history.
-- **Aggregate checks** support custom totals or ratios when business validation requires them.
-
-#### Run and monitor results
-- **Run now** performs an immediate evaluation for spot checks.
-- **Daily tasks** operate automatically once a schedule is enabled.
-- **Monitor** surfaces outcomes with filters by table, check type, or status; results can be downloaded for follow-up.
-
-#### Troubleshooting essentials
-- Verify the Snowflake warehouse is running and sized for the workload.
-- Confirm the active role has access to the source objects and metadata schema.
-- Review stored procedure messages in the Monitor tab or execute the procedure manually for detailed logs.
-            """
-        )
+        st.subheader(DocsStrings.USER_GUIDE_SUBHEADER)
+        st.markdown(DocsStrings.USER_GUIDE_CONTENT)
 
     with tabs[1]:
-        st.subheader("Profiling")
-        st.markdown(
-            """
-#### Why profile first
-Profiling runs lightweight column statistics so you understand data shape and completeness before finalising monitoring rules. The output points to high-risk fields, validates business keys, and surfaces unexpected formats.
-
-#### Metrics collected per column
-- **Null percentage and count** highlight missing data hotspots.
-- **Distinct percentage and count** confirm uniqueness or signal categorical fields.
-- **Minimum and maximum** verify numeric and timestamp ranges.
-- **Average length** spots truncated strings or inconsistent identifiers.
-- **Whitespace percentage** exposes formatting issues that can break joins.
-- **Top values** display the most frequent categories or potential outliers.
-
-#### Semantic insights and confidence
-- Columns receive semantic suggestions such as IBAN, ISIN, email, account ID, country, or timestamp based on detected patterns.
-- Confidence levels appear as High, Medium, Low, or Unknown with colour coding in the grid.
-- Hover the **Confidence rationale** tooltip to see why a tag was chosen (for example, "Regex match on 92% of rows").
-
-#### Filters that guide design
-- Apply filters for high null percentage, unique candidates, low cardinality, or whitespace risk to shortlist columns.
-- Use semantic tag filters (Identifiers, Financial, Instrument, Geography, Contact) to concentrate on sensitive fields.
-- Combine these insights to select uniqueness, null, pattern, or distribution checks inside the configuration editor.
-
-#### Performance and accuracy notes
-- Sampling defaults to a recommended percentage based on table size; set the value to `0` when a full scan is required.
-- Large tables automatically switch distinct counts to `APPROX_COUNT_DISTINCT`, balancing accuracy (within ~1%) and speed.
-- The summary banner reports rows profiled, sampling choice, and runtime so you can judge cost before rerunning.
-
-#### Persisting and reusing results
-- Enable **Save profile** once metadata targets are configured to store runs for auditing or historical comparison.
-- Use **Suggest DQ config** after profiling to pre-populate the configuration editor with recommended checks.
-            """
-        )
+        st.subheader(DocsStrings.PROFILING_SUBHEADER)
+        st.markdown(DocsStrings.PROFILING_CONTENT)
 
     with tabs[2]:
-        st.subheader("Snowflake-native data quality framework")
+        st.subheader(DocsStrings.FRAMEWORK_SUBHEADER)
         st.markdown(
-            f"""
-### Data Monitoring Framework (DMF) checks
-- Each row-level rule becomes a DMF view that runs inside Snowflake.
-- Failing rows surface in `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` within `{_safe_quote(metadata_db)}.{_safe_quote(metadata_schema)}`.
-- Views follow the pattern `SELECT * FROM <source> WHERE NOT (<rule_predicate>)`, using generated identifiers to avoid collisions.
-- Save and apply creates or refreshes the views and grants access. Removing a config cleans up unused artefacts.
-
-### Aggregate table-level checks
-- Freshness and row-count anomaly checks execute as aggregate SQL directly against the source table.
-- Because they summarise the entire table, they store only results in `{run_results_table}` and do not create DMF views.
-- Freshness compares the latest timestamp in the monitored column; row-count anomaly looks at recent history for spikes or droughts.
-
-### Stored procedures orchestrating runs
-- `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` (Snowpark Python) receives a configuration ID, evaluates every check, and records outcomes in `{run_results_table}`.
-- `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages task lifecycle with `EXECUTE AS CALLER`, ensuring warehouse and privilege alignment.
-
-### Tasks per configuration
-- Each configuration owns a Snowflake task `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`.
-- The task runs `CALL {proc_name}('<CONFIG_ID>')`, inheriting the caller's warehouse by default.
-- Cron syntax with IANA time zones supports 08:00 Europe/Berlin schedules and any overrides defined by administrators.
-
-### Roles, context, and required grants
-- Procedures execute as caller so data access policies remain intact.
-- The app expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both procedures.
-- Streamlit in Snowflake keeps ownership with the application role, simplifying audits and change tracking.
-
-### Why Snowflake for data quality
-- In-database compute keeps checks near the data—no egress or shadow copies.
-- Snowpark Python combines orchestration logic with native SQL execution.
-- Streamlit in Snowflake provides the UI where teams already work.
-- INFORMATION_SCHEMA and Account Usage power metadata-driven discovery and monitoring.
-- Governed sharing and roles ensure DMF views, tasks, and procedures respect enterprise security boundaries.
-            """
+            DocsStrings.FRAMEWORK_CONTENT.format(
+                metadata_db=metadata_db_display,
+                metadata_schema=metadata_schema_display,
+                run_results_table=run_results_display,
+                proc_name=proc_name,
+            )
         )
 
         st.divider()
         st.subheader("Entity Diagram")
-        entity_graph = f"""
-digraph G {{
-    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.4, nodesep=0.9, ranksep=1.1, splines=true];
-    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, fillcolor="#f4f6fb", color="#d5dbed", penwidth=1.2];
-    edge [color="#4f46e5", fontname="Helvetica", fontsize=10, arrowsize=0.8];
-
-    subgraph cluster_metadata {{
-        label="Metadata Schema";
-        fontname="Helvetica";
-        fontsize=11;
-        color="#c7d2fe";
-        style="rounded";
-        {cfg_tbl_node} [label="{cfg_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
-        {chk_tbl_node} [label="{chk_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
-        {run_tbl_node} [label="{run_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
-        {profile_run_node} [label="{profile_run_label}\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
-        {profile_col_node} [label="{profile_col_label}\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
-        dmfv [label="DMF_FAIL views\n(per active check)", shape=folder, fillcolor="#fdf2f8", color="#fbcfe8", fontcolor="#831843"];
-    }}
-
-    app [label="Streamlit App", shape=rect, fillcolor="#ecfdf5", color="#bbf7d0", fontcolor="#047857"];
-    {proc_node} [label="{proc_label}", shape=rect, fillcolor="#ede9fe", color="#c4b5fd", fontcolor="#5b21b6"];
-    task [label="Snowflake Task\nper config", shape=rect, fillcolor="#fef3c7", color="#fcd34d", fontcolor="#92400e"];
-
-    app -> {cfg_tbl_node} [label="creates / edits"];
-    app -> {chk_tbl_node} [label="creates / edits"];
-    app -> dmfv [label="renders"];
-    app -> {profile_run_node} [label="captures profiles"];
-    app -> {profile_col_node} [label="renders"];
-    {cfg_tbl_node} -> {chk_tbl_node} [label="defines"];
-    {cfg_tbl_node} -> task [label="schedules"];
-    task -> {proc_node} [label="calls"];
-    {proc_node} -> {run_tbl_node} [label="logs to"];
-    {proc_node} -> dmfv [label="populates"];
-    {proc_node} -> {profile_run_node} [label="logs to", style=dashed, color="#6b7280", fontcolor="#6b7280"];
-    {profile_run_node} -> {profile_col_node} [label="summarises"];
-    {run_tbl_node} -> app [label="renders"];
-    dmfv -> app [label="renders", style=dashed, color="#6b7280", fontcolor="#6b7280"];
-}}
-        """
-
+        entity_graph = DocsStrings.FRAMEWORK_ENTITY_GRAPH.format(
+            cfg_tbl_node=cfg_tbl_node,
+            cfg_tbl_label=cfg_tbl_label,
+            chk_tbl_node=chk_tbl_node,
+            chk_tbl_label=chk_tbl_label,
+            run_tbl_node=run_tbl_node,
+            run_tbl_label=run_tbl_label,
+            profile_run_node=profile_run_node,
+            profile_run_label=profile_run_label,
+            profile_col_node=profile_col_node,
+            profile_col_label=profile_col_label,
+            proc_node=proc_node,
+            proc_label=proc_label,
+        )
         st.graphviz_chart(entity_graph, use_container_width=True)
 
         st.subheader("Workflow Diagram")
-        workflow_graph = """
-digraph W {
-    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.5, nodesep=0.9, ranksep=1.1, splines=ortho];
-    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, width=2.2, height=0.8];
-    edge [color="#6366f1", fontname="Helvetica", fontsize=10, arrowsize=0.85];
-
-    step1 [label="User edits\nconfig", fillcolor="#eef2ff", color="#c7d2fe", fontcolor="#312e81"];
-    step2 [label="Save & Apply", fillcolor="#e0f2fe", color="#bae6fd", fontcolor="#0c4a6e"];
-    step3 [label="Attach DMF\nviews", fillcolor="#dcfce7", color="#bbf7d0", fontcolor="#065f46"];
-    step4 [label="Task schedule", fillcolor="#fef3c7", color="#fde68a", fontcolor="#92400e"];
-    step5 [label="Daily run", fillcolor="#fee2e2", color="#fecaca", fontcolor="#991b1b"];
-    step6 [label="Log results", fillcolor="#ede9fe", color="#ddd6fe", fontcolor="#5b21b6"];
-    step7 [label="Monitor", fillcolor="#f5f3ff", color="#c4b5fd", fontcolor="#4c1d95"];
-
-    step1 -> step2 [label="commit changes"];
-    step2 -> step3 [label="provision checks"];
-    step3 -> step4 [label="enable task"];
-    step4 -> step5 [label="cron trigger"];
-    step5 -> step6 [label="stored procedure"];
-    step6 -> step7 [label="Surface in app"];
-}
-        """
-
-        st.graphviz_chart(workflow_graph, use_container_width=True)
+        st.graphviz_chart(DocsStrings.FRAMEWORK_WORKFLOW_GRAPH, use_container_width=True)
 
     with tabs[3]:
-        st.subheader("Technical Overview")
+        st.subheader(DocsStrings.TECHNICAL_SUBHEADER)
         st.markdown(
-            f"""
-#### Runtime
-- Streamlit in Snowflake using Snowpark Python.
-
-#### Metadata and results
-- Configs: `{cfg_tbl_display}`
-- Checks: `{chk_tbl_display}`
-- Results: `{run_results_table}`
-
-#### Procedures
-- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` evaluates checks and logs to the results table.
-- Task manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` creates or updates tasks and runs as caller.
-
-#### Tasks
-- One per configuration: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}` with body `CALL {proc_name}('<CONFIG_ID>')`.
-
-#### Warehouses
-- Schedules run on the default application warehouse (for example, `DQ_WH`).
-            """
+            DocsStrings.TECHNICAL_CONTENT.format(
+                cfg_tbl_display=cfg_tbl_display,
+                chk_tbl_display=chk_tbl_display,
+                run_results_table=run_results_display,
+                metadata_db=metadata_db_display,
+                metadata_schema=metadata_schema_display,
+                proc_name=proc_name,
+            )
         )
 
-        st.markdown("#### Required privileges for the caller role")
+        st.markdown(DocsStrings.TECHNICAL_PRIVILEGES_HEADING)
         st.code(
-            f"""
-USAGE ON WAREHOUSE DQ_WH
-USAGE ON DATABASE {metadata_db}
-USAGE ON SCHEMA {metadata_db}.{metadata_schema}
-CREATE TASK ON SCHEMA {metadata_db}.{metadata_schema}
-EXECUTE ON PROCEDURE {metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)
-            """,
+            DocsStrings.TECHNICAL_PRIVILEGES_SNIPPET.format(
+                metadata_db=metadata_db_display,
+                metadata_schema=metadata_schema_display,
+                proc_name=proc_name,
+            ),
             language="text",
         )
 
     with tabs[4]:
-        st.subheader("Data Governance and Security")
-        st.markdown(
-            """
-#### Roles and isolation
-- The application runs with a defined caller role and relies on `EXECUTE AS CALLER` when managing tasks.
-- Configuration and results tables live in a dedicated metadata schema to control privileges.
-
-#### Traceability
-- `DQ_RUN_RESULTS` captures timestamps, check identifiers, failure counts, success flags, and error messages.
-- Each configuration owns a Snowflake task, which is auditable through ACCOUNT USAGE views.
-
-#### Access patterns
-- Source tables are read-only; writes are limited to metadata objects for configs, checks, and results.
-- DMF failing-row views remain in the metadata schema so investigators avoid querying production tables directly.
-
-#### Handling sensitive data
-- Prefer checks that avoid materialising personal data in logs; views expose only what investigators need.
-- Apply column masking to metadata views when sensitive attributes require additional protection.
-            """
-        )
+        st.subheader(DocsStrings.DATA_GOVERNANCE_SUBHEADER)
+        st.markdown(DocsStrings.DATA_GOVERNANCE_CONTENT)
 
     with tabs[5]:
-        st.subheader("Version History")
-        st.info("Version history will be documented here once releases are tracked.")
+        st.subheader(DocsStrings.VERSION_HISTORY_SUBHEADER)
+        st.info(DocsStrings.VERSION_HISTORY_INFO)

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -29,10 +29,10 @@ Forbidden patterns:
 """
 
 from __future__ import annotations
+
 import html
 import json
 import math
-import os
 import textwrap
 import time
 from dataclasses import dataclass, field
@@ -51,15 +51,30 @@ from services.profiling import (
     run_table_profile,
     save_profile_results,
 )
+from ui.keys import (
+    PROFILE_CLEAR_LOADED,
+    PROFILE_LOAD_BUTTON,
+    PROFILE_LOAD_SELECT,
+    PROFILE_RESULTS_SELECTION,
+    PROFILE_SAMPLE_PCT,
+    PROFILE_SAMPLE_TARGET,
+    PROFILE_SAVE_TOGGLE,
+)
+from ui.strings import ProfileStrings as PS
+from utils.flags import (
+    DEBUG_PROFILING,
+    DEMO_LOCK,
+    PROFILE_INLINE_SELECT,
+    PROFILE_TOP_VALUES_NULLS,
+    UI_CONTRACT_STRICT,
+)
 from utils.meta import get_table_row_count
+from utils.state import bulk_set_includes, get_include_map, set_include
 from views.table_picker import session_cache_token, stateless_table_picker
 
 
 FULL_SCAN_WARNING_THRESHOLD = 1_000_000
 MAX_TOP_N = 10
-
-_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
-
 
 def _safe_int(value: Any) -> Optional[int]:
     """Convert a numeric-like value to an int when possible."""
@@ -139,7 +154,7 @@ def _selection_key(table_fqn: str, column_name: str) -> str:
 def _contract_message(message: str) -> None:
     """Emit a contract warning or error depending on env configuration."""
 
-    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    strict = UI_CONTRACT_STRICT or DEMO_LOCK
     if strict:
         st.error(message)
     else:
@@ -637,10 +652,8 @@ def _render_metric_card(
     st.markdown(card_html, unsafe_allow_html=True)
 
 def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: ARG001 - interface matches requirement
-    st.header("🧪 Profile Table")
-    st.caption(
-        "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks."
-    )
+    st.header(PS.HEADER)
+    st.caption(PS.CAPTION)
 
     base_selection = st.session_state.get("profile_target_fqn")
     _db_sel, _sch_sel, _tbl_sel, selected_fqn = _table_picker(session, base_selection)
@@ -691,15 +704,13 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     controls = st.columns(3)
     suggested_pct = 10.0
     row_count: Optional[int] = None
-    selected_reason = (
-        "Defaulting to a 10% sample. Enter 0 for a full table scan."
-    )
+    selected_reason = PS.SAMPLE_DEFAULT_REASON
     if selected_fqn:
         row_count = _load_table_row_count(session, selected_fqn)
         suggested_pct, selected_reason = _recommend_sample_pct(row_count)
 
-    sample_pct_state_key = "profile_sample_pct"
-    sample_target_key = "profile_sample_target"
+    sample_pct_state_key = PROFILE_SAMPLE_PCT
+    sample_target_key = PROFILE_SAMPLE_TARGET
     if st.session_state.get(sample_target_key) != selected_fqn:
         st.session_state[sample_target_key] = selected_fqn
         st.session_state[sample_pct_state_key] = float(suggested_pct)
@@ -712,71 +723,71 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     reason_parts = [selected_reason]
     if row_count is not None:
-        reason_parts.append(f"Table metadata reports approximately {row_count:,} rows.")
+        reason_parts.append(
+            PS.SAMPLE_REASON_TABLE_ROWS.format(rows=row_count)
+        )
     if approx_rows:
-        reason_parts.append(f"This sample size profiles about {approx_rows:,} rows.")
-    reason_parts.append(
-        "The suggested value relies on Snowflake metadata only, so it doesn't trigger an extra table scan."
-    )
-    reason_parts.append("Enter 0 for a full table scan.")
+        reason_parts.append(
+            PS.SAMPLE_REASON_APPROX_ROWS.format(rows=approx_rows)
+        )
+    reason_parts.append(PS.SAMPLE_REASON_METADATA)
+    reason_parts.append(PS.SAMPLE_REASON_FULL_SCAN)
     sample_help_text = "\n".join(reason_parts)
 
     with controls[0]:
         sample_pct_input = st.number_input(
-            "Sample %",
+            PS.SAMPLE_LABEL,
             min_value=0.0,
             max_value=100.0,
             step=1.0,
             help=sample_help_text,
-            key=sample_pct_state_key,
+            key=PROFILE_SAMPLE_PCT,
         )
         sample_pct = None if math.isclose(sample_pct_input, 0.0, abs_tol=1e-6) else sample_pct_input
     with controls[1]:
         top_n = st.number_input(
-            "Top N values",
+            PS.TOP_N_LABEL,
             min_value=1,
             max_value=MAX_TOP_N,
             value=min(10, MAX_TOP_N),
             step=1,
-            help=f"Collect up to {MAX_TOP_N} of the most common values per column.",
+            help=PS.TOP_N_HELP_TEMPLATE.format(max_top=MAX_TOP_N),
         )
     load_selected_run_id: Optional[str] = None
     load_button_clicked = False
     with controls[2]:
         if saved_run_labels:
-            load_options = ["— Select a saved run —"] + saved_run_labels
+            load_options = [PS.LOAD_SAVED_PLACEHOLDER] + saved_run_labels
             selected_option = st.selectbox(
-                "Load saved profile",
+                PS.LOAD_SAVED_LABEL,
                 options=load_options,
-                key="profile_load_select",
+                key=PROFILE_LOAD_SELECT,
                 disabled=not saved_profiles_enabled,
             )
             if selected_option in saved_run_lookup:
                 load_selected_run_id = saved_run_lookup[selected_option]
         else:
             st.selectbox(
-                "Load saved profile",
-                options=["— No saved profiles —"],
-                key="profile_load_select",
+                PS.LOAD_SAVED_LABEL,
+                options=[PS.LOAD_SAVED_EMPTY],
+                key=PROFILE_LOAD_SELECT,
                 disabled=True,
             )
         load_button_clicked = st.button(
-            "Load",
-            key="profile_load_button",
+            PS.LOAD_BUTTON,
+            key=PROFILE_LOAD_BUTTON,
             disabled=not (saved_profiles_enabled and load_selected_run_id),
         )
         if not saved_profiles_enabled:
-            st.caption(
-                "Connect to Snowflake and configure metadata targets to enable loading saved profiles."
-            )
+            st.caption(PS.LOAD_CAPTION_NEEDS_CONNECTION)
         elif not saved_run_labels:
-            st.caption("No saved profiles found in metadata tables yet.")
+            st.caption(PS.LOAD_CAPTION_NO_SAVED)
 
     if load_button_clicked:
         if not saved_profiles_enabled:
-            st.warning("Loading profiles requires a Snowflake connection and metadata configuration.")
+            st.warning(PS.WARNING_NO_CONNECTION)
         elif not load_selected_run_id:
-            st.warning("Select a saved run to load.")
+            st.warning(PS.WARNING_SELECT_PROFILE)
         else:
             try:
                 loaded_profile = load_profile_run(
@@ -786,17 +797,17 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     run_id=load_selected_run_id,
                 )
             except Exception as exc:  # pragma: no cover - Snowflake specific
-                st.error(f"Failed to load saved profile: {exc}")
+                st.error(PS.LOAD_ERROR.format(error=exc))
             else:
                 if not loaded_profile:
-                    st.warning("Saved profile was not found or is empty.")
+                    st.warning(PS.INFO_NO_SAVED_PROFILE)
                 else:
                     st.session_state["profile_results"] = loaded_profile
                     st.session_state["profile_loaded_run_id"] = load_selected_run_id
                     target_table = loaded_profile.get("target_table")
                     if target_table:
                         st.session_state["profile_target_fqn"] = target_table
-                    st.success(f"Loaded saved profile {load_selected_run_id}.")
+                    st.success(PS.SUCCESS_LOADED_PROFILE.format(run_id=load_selected_run_id))
                     st.rerun()
 
     stored_profile_result = st.session_state.get("profile_results")
@@ -857,16 +868,19 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     st.session_state["profile_selection_counts"] = selection_counts
 
     st.caption(
-        f"Suggested: {int(selection_counts[0])} of {int(selection_counts[1])} columns selected"
+        PS.SAMPLE_CAPTION.format(
+            selected=int(selection_counts[0]),
+            total=int(selection_counts[1]),
+        )
     )
 
     button_cols = st.columns([1, 1, 2])
     run_disabled = bool(loaded_run_id)
     with button_cols[0]:
-        run_profile = st.button("▶️ Run Profile", type="primary", disabled=run_disabled)
+        run_profile = st.button(PS.RUN_BUTTON, type="primary", disabled=run_disabled)
     with button_cols[1]:
         suggest_cfg = st.button(
-            "✨ Suggest DQ Config",
+            PS.SUGGEST_BUTTON,
             type="secondary",
             disabled=not stored_profile_result,
         )
@@ -874,8 +888,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     clear_loaded = False
     if loaded_run_id:
         with button_cols[2]:
-            st.info("Viewing a saved profile.")
-            clear_loaded = st.button("Clear loaded profile", key="profile_clear_loaded")
+            st.info(PS.SAVED_PROFILE_INFO)
+            clear_loaded = st.button(PS.CLEAR_LOADED_BUTTON, key=PROFILE_CLEAR_LOADED)
     else:
         button_cols[2].empty()
 
@@ -890,11 +904,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         st.session_state.pop("profile_loaded_run_id", None)
         loaded_run_id = None
         if not session:
-            st.error("No active Snowpark session — unable to profile tables.")
+            st.error(PS.PROFILE_WARNING_NO_SESSION)
         elif not selected_fqn:
-            st.warning("Select a database, schema, and table to profile.")
+            st.warning(PS.PROFILE_WARNING_SELECT_TABLE)
         else:
-            with st.spinner("Profiling table..."):
+            with st.spinner(PS.SAMPLE_SPINNER):
                 start = time.time()
                 profile_error: Optional[Exception] = None
                 summary_raw: Dict[str, Any] = {}
@@ -911,7 +925,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 duration = time.time() - start
 
             if profile_error is not None:
-                st.error(f"Failed to profile table: {profile_error}")
+                st.error(PS.PROFILE_ERROR.format(error=profile_error))
             else:
                 rows_profiled = int(summary_raw.get("rows_profiled") or 0)
                 profiles: List[ColumnProfile] = []
@@ -937,7 +951,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     def _load_suggestion(profile_payload: Dict[str, Any], success_message: str) -> None:
         suggestion = build_profile_suggestion(profile_payload)
         if not suggestion:
-            st.info("No suggestions available for the current profile.")
+            st.info(PS.NO_SUGGESTIONS)
             return
         st.session_state["cfg_mode"] = "edit"
         st.session_state["selected_config_id"] = None
@@ -966,7 +980,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     if suggest_cfg and profile_result:
         selected_columns = _selected_columns(profile_result)
         if not selected_columns:
-            st.warning("Select at least one column before generating DQ suggestions.")
+            st.warning(PS.PROFILE_WARNING_SELECT_COLUMNS)
         else:
             filtered_profile = dict(profile_result)
             filtered_summary = dict(filtered_profile.get("summary") or {})
@@ -975,7 +989,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             filtered_profile["columns"] = selected_columns
             _load_suggestion(
                 filtered_profile,
-                "Loaded profile suggestion into the configuration editor.",
+                PS.PROFILE_SUCCESS_SUGGESTION,
             )
 
     if not profile_result:
@@ -983,16 +997,20 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     summary = profile_result.get("summary", {})
     metrics_cols = st.columns(3)
-    metrics_cols[0].metric("Rows profiled", f"{summary.get('rows_profiled', 0):,}")
+    metrics_cols[0].metric(PS.METRIC_ROWS_PROFILED, f"{summary.get('rows_profiled', 0):,}")
     sample_pct_display = summary.get("sample_pct")
-    sample_label = "Full scan" if sample_pct_display is None else f"{float(sample_pct_display):.1f}%"
-    metrics_cols[1].metric("Sampling", sample_label)
-    metrics_cols[2].metric("Duration", f"{summary.get('duration_sec', 0.0):.2f}s")
+    sample_label = (
+        PS.SAMPLE_LABEL_FULL_SCAN
+        if sample_pct_display is None
+        else f"{float(sample_pct_display):.1f}%"
+    )
+    metrics_cols[1].metric(PS.METRIC_SAMPLING, sample_label)
+    metrics_cols[2].metric(PS.METRIC_DURATION, f"{summary.get('duration_sec', 0.0):.2f}s")
 
     if summary.get("sample_pct") is None and summary.get("rows_profiled", 0) > FULL_SCAN_WARNING_THRESHOLD:
         profiled = int(summary.get("rows_profiled", 0))
         st.warning(
-            f"Full table scan processed {profiled:,} rows. Consider sampling to improve performance.",
+            PS.SAMPLE_WARNING_FULL_SCAN.format(rows=profiled),
             icon="⚠️",
         )
 
@@ -1020,36 +1038,48 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     filter_box = st.container()
     with filter_box:
-        st.subheader("Filters", anchor=False)
+        st.subheader(PS.FILTERS_SUBHEADER, anchor=False)
         filter_cols = st.columns(4)
-        high_null = filter_cols[0].toggle("High null % (>20%)", value=False)
-        unique_candidates = filter_cols[1].toggle("Unique candidates", value=False)
-        low_cardinality = filter_cols[2].toggle("Low cardinality", value=False)
-        whitespace_risk = filter_cols[3].toggle("Whitespace risk", value=False)
-        st.markdown("**Semantic tags**")
-        semantic_cols = st.columns(7)
-        filter_identifiers = semantic_cols[0].checkbox("Identifiers", value=False)
-        filter_financial = semantic_cols[1].checkbox("Financial", value=False)
-        filter_instrument = semantic_cols[2].checkbox("Instrument", value=False)
-        filter_geo = semantic_cols[3].checkbox("Geo", value=False)
-        filter_contact = semantic_cols[4].checkbox("Contact", value=False)
-        filter_date_text = semantic_cols[5].checkbox("Date (Text)", value=False)
-        filter_ref_codes = semantic_cols[6].checkbox("Reference Codes", value=False)
+        high_null = filter_cols[0].toggle(PS.FILTER_HIGH_NULL, value=False)
+        unique_candidates = filter_cols[1].toggle(PS.FILTER_UNIQUE, value=False)
+        low_cardinality = filter_cols[2].toggle(PS.FILTER_LOW_CARDINALITY, value=False)
+        whitespace_risk = filter_cols[3].toggle(PS.FILTER_WHITESPACE, value=False)
+        st.markdown(f"**{PS.FILTER_SEMANTIC_LABEL}**")
+        semantic_cols = st.columns(len(PS.FILTER_SEMANTIC_OPTIONS))
+        filter_identifiers = semantic_cols[0].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[0], value=False
+        )
+        filter_financial = semantic_cols[1].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[1], value=False
+        )
+        filter_instrument = semantic_cols[2].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[2], value=False
+        )
+        filter_geo = semantic_cols[3].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[3], value=False
+        )
+        filter_contact = semantic_cols[4].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[4], value=False
+        )
+        filter_date_text = semantic_cols[5].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[5], value=False
+        )
+        filter_ref_codes = semantic_cols[6].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[6], value=False
+        )
 
     save_enabled = bool(session and meta_db and meta_schema)
     if not save_enabled:
-        st.session_state.pop("profile_save_toggle", None)
+        st.session_state.pop(PROFILE_SAVE_TOGGLE, None)
         st.session_state.pop("_profile_save_prev", None)
         st.session_state.pop("profile_saved_run_id", None)
 
     save_help = (
-        "Persist the current profile results to metadata tables."
-        if save_enabled
-        else "Connect to Snowflake and select metadata targets to enable saving."
+        PS.SAVE_ENABLED_MESSAGE if save_enabled else PS.SAVE_DISABLED_MESSAGE
     )
     save_toggle = st.toggle(
-        "💾 Save Profile",
-        key="profile_save_toggle",
+        PS.SAVE_TOGGLE,
+        key=PROFILE_SAVE_TOGGLE,
         value=False,
         disabled=not save_enabled,
         help=save_help,
@@ -1084,10 +1114,10 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 rows=rows_payload,
             )
         except Exception as exc:  # pragma: no cover - Snowflake specific
-            st.error(f"Failed to save profile: {exc}")
+            st.error(PS.CLEAR_PROFILE_ERROR.format(error=exc))
         else:
             st.session_state["profile_saved_run_id"] = run_id
-            st.success(f"Saved profile run {run_id} to metadata.")
+            st.success(PS.PROFILE_SUCCESS_SAVE.format(run_id=run_id))
 
     if not save_toggle:
         st.session_state.pop("profile_saved_run_id", None)
@@ -1105,29 +1135,29 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         filtered_df = filtered_df[(filtered_df["whitespace_pct"].fillna(0) > 5)]
 
     semantic_filter_map = {
-        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN", "REF_CODE"},
-        "Financial": {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
-        "Instrument": {"ISIN", "TICKER/SYMBOL"},
-        "Geo": {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
-        "Contact": {"EMAIL", "PHONE"},
-        "Date (Text)": {"DATE_IN_TEXT"},
-        "Reference Codes": {"REF_CODE"},
+        PS.FILTER_SEMANTIC_OPTIONS[0]: {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN", "REF_CODE"},
+        PS.FILTER_SEMANTIC_OPTIONS[1]: {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
+        PS.FILTER_SEMANTIC_OPTIONS[2]: {"ISIN", "TICKER/SYMBOL"},
+        PS.FILTER_SEMANTIC_OPTIONS[3]: {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
+        PS.FILTER_SEMANTIC_OPTIONS[4]: {"EMAIL", "PHONE"},
+        PS.FILTER_SEMANTIC_OPTIONS[5]: {"DATE_IN_TEXT"},
+        PS.FILTER_SEMANTIC_OPTIONS[6]: {"REF_CODE"},
     }
     active_semantic_filters: List[str] = []
     if filter_identifiers:
-        active_semantic_filters.append("Identifiers")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[0])
     if filter_financial:
-        active_semantic_filters.append("Financial")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[1])
     if filter_instrument:
-        active_semantic_filters.append("Instrument")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[2])
     if filter_geo:
-        active_semantic_filters.append("Geo")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[3])
     if filter_contact:
-        active_semantic_filters.append("Contact")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[4])
     if filter_date_text:
-        active_semantic_filters.append("Date (Text)")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[5])
     if filter_ref_codes:
-        active_semantic_filters.append("Reference Codes")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[6])
 
     if active_semantic_filters:
         allowed_types = set()
@@ -1135,20 +1165,36 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             allowed_types.update(semantic_filter_map.get(key, set()))
         filtered_df = filtered_df[filtered_df["semantic_type"].isin(allowed_types)]
     display_df = filtered_df.copy()
+    select_label = PS.GRID_COLUMN_SELECT
+    column_label = PS.GRID_COLUMN_COLUMN
+    physical_type_label = PS.GRID_COLUMN_PHYSICAL_TYPE
+    nulls_label = PS.GRID_COLUMN_NULLS
+    distinct_label = PS.GRID_COLUMN_DISTINCT
+    avg_length_label = PS.GRID_COLUMN_AVG_LENGTH
+    min_value_label = PS.GRID_COLUMN_MIN_VALUE
+    max_value_label = PS.GRID_COLUMN_MAX_VALUE
+    whitespace_label = PS.GRID_COLUMN_WHITESPACE
+    guessed_type_label = PS.GRID_COLUMN_GUESSED_TYPE
+    confidence_label = PS.GRID_COLUMN_CONFIDENCE
+    note_label = PS.GRID_COLUMN_NOTE
+
     grid_columns = [
-        "Select",
-        "Column",
-        "Physical Type",
-        "Nulls",
-        "Distinct",
-        "Avg Length",
-        "Min Value",
-        "Max Value",
-        "Whitespace %",
-        "Guessed Type",
-        "Confidence",
-        "Note",
+        select_label,
+        column_label,
+        physical_type_label,
+        nulls_label,
+        distinct_label,
+        avg_length_label,
+        min_value_label,
+        max_value_label,
+        whitespace_label,
+        guessed_type_label,
+        confidence_label,
+        note_label,
     ]
+
+    if not PROFILE_INLINE_SELECT:
+        _contract_message(PS.INLINE_SELECT_DISABLED)
     confidence_legend_html = """
     <div style="display:flex; gap:12px; align-items:center; font-size:0.85rem; margin:0.5rem 0;">
         <span style="display:flex; align-items:center; gap:4px;">
@@ -1286,29 +1332,35 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             return note
 
         display_df_local = display_df.copy()
-        display_df_local["Column"] = display_df_local.get("column_name", "").fillna("").astype(str)
-        display_df_local["Select"] = display_df_local["Column"].apply(
+        display_df_local[column_label] = (
+            display_df_local.get("column_name", "").fillna("").astype(str)
+        )
+        display_df_local[select_label] = display_df_local[column_label].apply(
             lambda name: bool(selection_state.get(_selection_key(target_table, name), False))
         )
-        display_df_local["Select"] = display_df_local["Select"].astype(bool)
-        display_df_local["Physical Type"] = (
+        display_df_local[select_label] = display_df_local[select_label].astype(bool)
+        display_df_local[physical_type_label] = (
             display_df_local.get("data_type", "").fillna("").astype(str)
         )
-        display_df_local["Nulls"] = display_df_local.apply(
+        display_df_local[nulls_label] = display_df_local.apply(
             lambda row: _format_count_with_pct(row.get("nulls"), row.get("null_pct")), axis=1
         )
-        display_df_local["Distinct"] = display_df_local.apply(
+        display_df_local[distinct_label] = display_df_local.apply(
             lambda row: _format_count_with_pct(row.get("distincts"), row.get("distinct_pct")), axis=1
         )
-        display_df_local["Avg Length"] = display_df_local.apply(
+        display_df_local[avg_length_label] = display_df_local.apply(
             _format_length_stats_cell, axis=1
         )
-        display_df_local["Min Value"] = display_df_local["min_val"].apply(_format_value_cell)
-        display_df_local["Max Value"] = display_df_local["max_val"].apply(_format_value_cell)
-        display_df_local["Guessed Type"] = display_df_local["semantic_type"].apply(
+        display_df_local[min_value_label] = display_df_local["min_val"].apply(
+            _format_value_cell
+        )
+        display_df_local[max_value_label] = display_df_local["max_val"].apply(
+            _format_value_cell
+        )
+        display_df_local[guessed_type_label] = display_df_local["semantic_type"].apply(
             _format_semantic_label
         )
-        display_df_local["Whitespace %"] = display_df_local["whitespace_pct"].apply(
+        display_df_local[whitespace_label] = display_df_local["whitespace_pct"].apply(
             _format_whitespace_display
         )
 
@@ -1324,30 +1376,30 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         display_df_local["_confidence_pct"] = display_df_local["confidence"].apply(
             _normalize_confidence
         )
-        display_df_local["Note"] = display_df_local.apply(_compose_note, axis=1)
+        display_df_local[note_label] = display_df_local.apply(_compose_note, axis=1)
         grid_container = st.container()
 
         confidence_numeric = pd.to_numeric(
             display_df_local["_confidence_pct"], errors="coerce"
         ).clip(lower=0.0, upper=100.0)
-        display_df_local["Confidence"] = confidence_numeric
+        display_df_local[confidence_label] = confidence_numeric
 
         formatted_rows: List[List[Any]] = []
         for _, row in display_df_local.iterrows():
             formatted_rows.append(
                 [
-                    bool(row.get("Select", False)),
-                    row.get("Column"),
-                    row.get("Physical Type"),
-                    row.get("Nulls"),
-                    row.get("Distinct"),
-                    row.get("Avg Length"),
-                    row.get("Min Value"),
-                    row.get("Max Value"),
-                    row.get("Whitespace %"),
-                    row.get("Guessed Type"),
-                    row.get("Confidence"),
-                    row.get("Note"),
+                    bool(row.get(select_label, False)),
+                    row.get(column_label),
+                    row.get(physical_type_label),
+                    row.get(nulls_label),
+                    row.get(distinct_label),
+                    row.get(avg_length_label),
+                    row.get(min_value_label),
+                    row.get(max_value_label),
+                    row.get(whitespace_label),
+                    row.get(guessed_type_label),
+                    row.get(confidence_label),
+                    row.get(note_label),
                 ]
             )
 
@@ -1356,26 +1408,26 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             grid_df.columns, grid_columns, "profile results grid"
         )
         if grid_render_allowed:
-            grid_df["Select"] = grid_df["Select"].fillna(False).astype(bool)
-            grid_df["Confidence"] = grid_df["Confidence"].apply(_safe_float)
+            grid_df[select_label] = grid_df[select_label].fillna(False).astype(bool)
+            grid_df[confidence_label] = grid_df[confidence_label].apply(_safe_float)
 
         with grid_container:
             st.markdown(confidence_legend_html, unsafe_allow_html=True)
-            include_map: Dict[str, bool] = {}
+            include_map = get_include_map()
             selection_editor: Optional[pd.DataFrame] = None
             if grid_render_allowed and not grid_df.empty:
-                selection_editor_df = grid_df[["Select", "Column"]].copy()
+                selection_editor_df = grid_df[[select_label, column_label]].copy()
                 selection_render_allowed = _validate_grid_columns(
                     selection_editor_df.columns,
-                    ["Select", "Column"],
+                    [select_label, column_label],
                     "profile selection editor",
                 )
                 if selection_render_allowed:
-                    selection_editor_df["Select"] = (
-                        selection_editor_df["Select"].fillna(False).astype(bool)
+                    selection_editor_df[select_label] = (
+                        selection_editor_df[select_label].fillna(False).astype(bool)
                     )
                     suspicious_keys = _detect_secondary_selector_keys(
-                        "profile_results_selection"
+                        PROFILE_RESULTS_SELECTION
                     )
                     if suspicious_keys:
                         _contract_message(
@@ -1388,14 +1440,16 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                             use_container_width=True,
                             hide_index=True,
                             column_config={
-                                "Select": st.column_config.CheckboxColumn(
-                                    "Select",
-                                    help="Toggle to include the column in downstream DQ suggestions.",
+                                select_label: st.column_config.CheckboxColumn(
+                                    select_label,
+                                    help=PS.GRID_CHECKBOX_HELP,
                                 ),
-                                "Column": st.column_config.Column("Column", disabled=True),
+                                column_label: st.column_config.Column(
+                                    column_label, disabled=True
+                                ),
                             },
-                            disabled=["Column"],
-                            key="profile_results_selection",
+                            disabled=[column_label],
+                            key=PROFILE_RESULTS_SELECTION,
                         )
 
             if (
@@ -1403,24 +1457,36 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 and isinstance(selection_editor, pd.DataFrame)
                 and not selection_editor.empty
             ):
-                select_series = selection_editor.get("Select")
-                column_series = selection_editor.get("Column")
+                select_series = selection_editor.get(select_label)
+                column_series = selection_editor.get(column_label)
                 if select_series is not None and column_series is not None:
                     select_flags = select_series.fillna(False).astype(bool)
-                    include_map = {
+                    include_map_local = {
                         str(column_series.iloc[idx]): bool(select_flags.iloc[idx])
                         for idx in range(len(select_flags))
                     }
+                    column_names = list(include_map_local.keys())
+                    if column_names:
+                        bulk_set_includes(column_names, False)
+                        for column_name, selected_flag in include_map_local.items():
+                            set_include(column_name, selected_flag)
+                        include_map = get_include_map()
 
             if grid_render_allowed and include_map:
                 for column_name, selected_flag in include_map.items():
                     key = _selection_key(target_table, column_name)
                     selection_state[key] = selected_flag
-                    grid_df.loc[grid_df["Column"] == column_name, "Select"] = selected_flag
+                    mask = grid_df[column_label] == column_name
+                    if mask.any():
+                        grid_df.loc[mask, select_label] = selected_flag
 
             if grid_render_allowed:
-                styler = grid_df.style.format({"Confidence": _format_confidence_display})
-                styler = styler.applymap(_confidence_style, subset=["Confidence"])
+                styler = grid_df.style.format(
+                    {confidence_label: _format_confidence_display}
+                )
+                styler = styler.applymap(
+                    _confidence_style, subset=[confidence_label]
+                )
                 st.dataframe(styler, hide_index=True, use_container_width=True)
 
         selection_counts = _apply_selection_state(
@@ -1434,19 +1500,25 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     else:
         empty_df = pd.DataFrame(
             {
-                column: pd.Series(dtype="bool" if column == "Select" else "object")
+                column: pd.Series(
+                    dtype="bool" if column == select_label else "object"
+                )
                 for column in grid_columns
             }
         )
         st.markdown(confidence_legend_html, unsafe_allow_html=True)
-        empty_styler = empty_df.style.format({"Confidence": _format_confidence_display})
-        empty_styler = empty_styler.applymap(_confidence_style, subset=["Confidence"])
+        empty_styler = empty_df.style.format(
+            {confidence_label: _format_confidence_display}
+        )
+        empty_styler = empty_styler.applymap(
+            _confidence_style, subset=[confidence_label]
+        )
         st.dataframe(empty_styler, hide_index=True, use_container_width=True)
 
     if filtered_df.empty:
-        st.info("No columns matched the selected filters.")
+        st.info(PS.NO_COLUMNS_MATCHED)
 
-    st.subheader("Top values by column", anchor=False)
+    st.subheader(PS.TOP_VALUES_SUBHEADER, anchor=False)
     for _, row in filtered_df.iterrows():
         values = row.get("top_values", [])
         non_nulls_value = _safe_int(row.get("non_nulls"))
@@ -1454,17 +1526,17 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         with st.expander(f"{row['column_name']} ({label_suffix})"):
             if not values:
                 if non_nulls_value is not None and non_nulls_value <= 0:
-                    st.info("No non-null values to display.")
+                    st.info(PS.INFO_NO_NON_NULL)
                 else:
-                    st.info("No top values available.")
+                    st.info(PS.INFO_NO_VALUES)
                 continue
 
             tv_df = pd.DataFrame(values)
             if tv_df.empty:
                 if non_nulls_value is not None and non_nulls_value <= 0:
-                    st.info("No non-null values to display.")
+                    st.info(PS.INFO_NO_NON_NULL)
                 else:
-                    st.info("No top values available.")
+                    st.info(PS.INFO_NO_VALUES)
                 continue
 
             # Normalize common column names when present; otherwise fall back gracefully
@@ -1478,24 +1550,30 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 if lowered in {"count", "cnt"} and count_column_name is None:
                     count_column_name = candidate
             if value_column_name is not None:
-                rename_map[value_column_name] = "Value"
+                rename_map[value_column_name] = PS.TOP_VALUES_VALUE_HEADER
             if count_column_name is not None:
-                rename_map[count_column_name] = "Count"
+                rename_map[count_column_name] = PS.TOP_VALUES_COUNT_HEADER
             if rename_map:
                 tv_df = tv_df.rename(columns=rename_map)
                 if value_column_name is not None:
-                    value_column_name = "Value"
+                    value_column_name = PS.TOP_VALUES_VALUE_HEADER
                 if count_column_name is not None:
-                    count_column_name = "Count"
+                    count_column_name = PS.TOP_VALUES_COUNT_HEADER
             elif tv_df.shape[1] == 2:
-                tv_df.columns = ["Value", "Count"]
-                value_column_name = "Value"
-                count_column_name = "Count"
+                tv_df.columns = [
+                    PS.TOP_VALUES_VALUE_HEADER,
+                    PS.TOP_VALUES_COUNT_HEADER,
+                ]
+                value_column_name = PS.TOP_VALUES_VALUE_HEADER
+                count_column_name = PS.TOP_VALUES_COUNT_HEADER
 
             if value_column_name is None and len(tv_df.columns) > 0:
                 value_column_name = tv_df.columns[0]
-            if count_column_name is None and "Count" in tv_df.columns:
-                count_column_name = "Count"
+            if (
+                count_column_name is None
+                and PS.TOP_VALUES_COUNT_HEADER in tv_df.columns
+            ):
+                count_column_name = PS.TOP_VALUES_COUNT_HEADER
 
             pct_columns = [col for col in tv_df.columns if "pct" in str(col).lower()]
 
@@ -1523,7 +1601,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
             if value_column_name and value_column_name in tv_df.columns:
                 null_bucket_mask = tv_df[value_column_name] == "__NULL__"
-                if null_bucket_mask.any():
+                if null_bucket_mask.any() and not PROFILE_TOP_VALUES_NULLS:
                     tv_df = tv_df.loc[~null_bucket_mask].copy()
                 tv_df = tv_df.loc[~tv_df[value_column_name].isna()].copy()
                 tv_df[value_column_name] = tv_df[value_column_name].replace(
@@ -1576,3 +1654,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     tv_df[col] = tv_df[col].apply(_format_percentage)
 
             st.table(tv_df)
+
+    if DEBUG_PROFILING and profile_result:
+        with st.expander(PS.DEBUG_PROFILE_PAYLOAD):
+            st.json(profile_result)
+        include_state = get_include_map()
+        if include_state:
+            with st.expander(PS.DEBUG_SELECTION_STATE):
+                st.write(include_state)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -83,6 +83,7 @@ from views.profile_view import render_profile
 from views.table_picker import stateless_table_picker, session_cache_token
 from views.docs_view import render_docs as render_docs_view
 from views.config_editor import render_row_count_preview
+from utils.flags import DEMO_LOCK
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs"}
 
@@ -1678,8 +1679,12 @@ with st.sidebar:
         ):
             open_config_editor()
         st.divider()
-    run_as_role = st.text_input("RUN_AS_ROLE", value=state.get("run_as_role") or "")
-    dmf_role = st.text_input("DMF_ROLE", value=state.get("dmf_role") or "")
+    run_as_role = st.text_input(
+        "RUN_AS_ROLE", value=state.get("run_as_role") or "", disabled=DEMO_LOCK
+    )
+    dmf_role = st.text_input(
+        "DMF_ROLE", value=state.get("dmf_role") or "", disabled=DEMO_LOCK
+    )
     set_state(run_as_role or None, dmf_role or None)
 
 # Maintain a subtle separation between the sidebar navigation

--- a/tests/test_profile_view_snapshot.py
+++ b/tests/test_profile_view_snapshot.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+from ui.strings import ProfileStrings as PS
 
 
 def _unique(values: List[str]) -> List[str]:
@@ -22,18 +24,47 @@ class _ProfileContractCollector(ast.NodeVisitor):
         self.captions: List[str] = []
         self.buttons: List[str] = []
         self.grid_columns: List[str] | None = None
+        self._bindings: Dict[str, str] = {}
 
     def _strings_from_node(self, node: ast.AST | None) -> List[str]:
         if node is None:
             return []
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            return [node.value]
+        evaluated = self._evaluate_string(node)
+        if evaluated is not None:
+            return [evaluated]
         if isinstance(node, ast.IfExp):
             values: List[str] = []
             values.extend(self._strings_from_node(node.body))
             values.extend(self._strings_from_node(node.orelse))
             return values
         return []
+
+    def _evaluate_string(self, node: ast.AST) -> Optional[str]:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Attribute):
+            resolved = self._resolve_attribute(node)
+            if isinstance(resolved, str):
+                return resolved
+        if isinstance(node, ast.Name):
+            return self._bindings.get(node.id)
+        return None
+
+    def _resolve_attribute(self, node: ast.Attribute) -> Any:
+        target: Any
+        if isinstance(node.value, ast.Name):
+            if node.value.id == "PS":
+                target = PS
+            else:
+                return None
+        elif isinstance(node.value, ast.Attribute):
+            parent = self._resolve_attribute(node.value)
+            if parent is None:
+                return None
+            target = parent
+        else:
+            return None
+        return getattr(target, node.attr, None)
 
     def visit_Call(self, node: ast.Call) -> Any:  # type: ignore[override]
         func = node.func
@@ -53,12 +84,18 @@ class _ProfileContractCollector(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> Any:  # type: ignore[override]
         for target in node.targets:
             if isinstance(target, ast.Name) and target.id == "grid_columns":
-                try:
-                    value = ast.literal_eval(node.value)
-                except Exception:
-                    value = None
-                if isinstance(value, list) and all(isinstance(item, str) for item in value):
-                    self.grid_columns = value
+                values: List[str] = []
+                if isinstance(node.value, ast.List):
+                    for element in node.value.elts:
+                        evaluated = self._evaluate_string(element)
+                        if evaluated is not None:
+                            values.append(evaluated)
+                if values:
+                    self.grid_columns = values
+            elif isinstance(target, ast.Name):
+                evaluated = self._evaluate_string(node.value)
+                if evaluated is not None:
+                    self._bindings[target.id] = evaluated
         self.generic_visit(node)
 
 

--- a/tools/guard_check.py
+++ b/tools/guard_check.py
@@ -1,0 +1,81 @@
+"""Repository guard checks for UI contract compliance."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def check_profile_strings(errors: List[str]) -> None:
+    from ui.strings import ProfileStrings as PS
+
+    expected = {
+        "RUN_BUTTON": "▶️ Run Profile",
+        "SUGGEST_BUTTON": "✨ Suggest DQ Config",
+        "SAVE_TOGGLE": "💾 Save Profile",
+        "GRID_COLUMN_SELECT": "Select",
+        "GRID_COLUMN_COLUMN": "Column",
+        "GRID_COLUMN_PHYSICAL_TYPE": "Physical Type",
+        "GRID_COLUMN_NULLS": "Nulls",
+        "GRID_COLUMN_DISTINCT": "Distinct",
+        "GRID_COLUMN_AVG_LENGTH": "Avg Length",
+        "GRID_COLUMN_MIN_VALUE": "Min Value",
+        "GRID_COLUMN_MAX_VALUE": "Max Value",
+        "GRID_COLUMN_WHITESPACE": "Whitespace %",
+        "GRID_COLUMN_GUESSED_TYPE": "Guessed Type",
+        "GRID_COLUMN_CONFIDENCE": "Confidence",
+        "GRID_COLUMN_NOTE": "Note",
+        "SUGGEST_BUTTON": "✨ Suggest DQ Config",
+    }
+    for attr, expected_value in expected.items():
+        actual = getattr(PS, attr, None)
+        if actual != expected_value:
+            errors.append(
+                f"ProfileStrings.{attr} expected '{expected_value}' but found '{actual}'."
+            )
+
+
+def check_docs_strings(errors: List[str]) -> None:
+    from ui.strings import DocsStrings
+
+    expected_tabs = (
+        "User Guide",
+        "Profiling",
+        "DQ Framework",
+        "Technical Overview",
+        "Data Governance",
+        "Version History",
+    )
+    if tuple(DocsStrings.TABS) != expected_tabs:
+        errors.append(
+            "DocsStrings.TABS must remain the six default documentation tabs."
+        )
+
+
+def main() -> int:
+    errors: List[str] = []
+    try:
+        check_profile_strings(errors)
+        check_docs_strings(errors)
+    except Exception as exc:  # pragma: no cover - guard failure path
+        errors.append(f"Guard check execution error: {exc}")
+
+    if errors:
+        print("UI contract guard check failed:\n", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        print(
+            "Refer to docs/ui_contract_docs.md before modifying UI labels or layout.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ui/keys.py
+++ b/ui/keys.py
@@ -1,0 +1,13 @@
+"""Centralised Streamlit widget keys for UI components."""
+
+from __future__ import annotations
+
+from typing import Final
+
+PROFILE_SAMPLE_PCT: Final[str] = "profile_sample_pct"
+PROFILE_SAMPLE_TARGET: Final[str] = "profile_sample_target"
+PROFILE_LOAD_SELECT: Final[str] = "profile_load_select"
+PROFILE_LOAD_BUTTON: Final[str] = "profile_load_button"
+PROFILE_CLEAR_LOADED: Final[str] = "profile_clear_loaded"
+PROFILE_SAVE_TOGGLE: Final[str] = "profile_save_toggle"
+PROFILE_RESULTS_SELECTION: Final[str] = "profile_results_selection"

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -1,0 +1,378 @@
+"""Centralised UI strings for Streamlit views."""
+
+from __future__ import annotations
+
+from typing import Final, Tuple
+
+
+class ProfileStrings:
+    HEADER: Final[str] = "🧪 Profile Table"
+    CAPTION: Final[str] = (
+        "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks."
+    )
+    RUN_BUTTON: Final[str] = "▶️ Run Profile"
+    SUGGEST_BUTTON: Final[str] = "✨ Suggest DQ Config"
+    CLEAR_LOADED_BUTTON: Final[str] = "Clear loaded profile"
+    SAVED_PROFILE_INFO: Final[str] = "Viewing a saved profile."
+    SAVE_TOGGLE: Final[str] = "💾 Save Profile"
+    NO_COLUMNS_MATCHED: Final[str] = "No columns matched the selected filters."
+    TOP_VALUES_SUBHEADER: Final[str] = "Top values by column"
+    NO_NON_NULL_VALUES: Final[str] = "No non-null values to display."
+    NO_TOP_VALUES: Final[str] = "No top values available."
+    SAMPLE_LABEL: Final[str] = "Sample %"
+    TOP_N_LABEL: Final[str] = "Top N values"
+    TOP_N_HELP_TEMPLATE: Final[str] = "Collect up to {max_top} of the most common values per column."
+    LOAD_SAVED_LABEL: Final[str] = "Load saved profile"
+    LOAD_SAVED_EMPTY: Final[str] = "— No saved profiles —"
+    LOAD_SAVED_PLACEHOLDER: Final[str] = "— Select a saved run —"
+    LOAD_BUTTON: Final[str] = "Load"
+    LOAD_WARNING_CONNECTION: Final[str] = "Loading profiles requires a Snowflake connection and metadata configuration."
+    LOAD_WARNING_SELECT_RUN: Final[str] = "Select a saved run to load."
+    LOAD_ERROR: Final[str] = "Failed to load saved profile: {error}"
+    LOAD_WARNING_NOT_FOUND: Final[str] = "Saved profile was not found or is empty."
+    LOAD_SUCCESS: Final[str] = "Loaded saved profile {run_id}."
+    LOAD_DISABLED_CAPTION: Final[str] = "Connect to Snowflake and select metadata targets to enable saving."
+    LOAD_ENABLED_CAPTION: Final[str] = "Persist the current profile results to metadata tables."
+    CLEAR_PROFILE_SUCCESS: Final[str] = "Saved profile run {run_id} to metadata."
+    CLEAR_PROFILE_ERROR: Final[str] = "Failed to save profile: {error}"
+    NO_SUGGESTIONS: Final[str] = "No suggestions available for the current profile."
+    SAMPLE_REASON_METADATA: Final[str] = (
+        "The suggested value relies on Snowflake metadata only, so it doesn't trigger an extra table scan."
+    )
+    SAMPLE_REASON_FULL_SCAN: Final[str] = "Enter 0 for a full table scan."
+    SAMPLE_REASON_TABLE_ROWS: Final[str] = "Table metadata reports approximately {rows:,} rows."
+    SAMPLE_REASON_APPROX_ROWS: Final[str] = "This sample size profiles about {rows:,} rows."
+    SAMPLE_DEFAULT_REASON: Final[str] = "Defaulting to a 10% sample. Enter 0 for a full table scan."
+    SAMPLE_HELP_METADATA: Final[str] = SAMPLE_REASON_METADATA
+    SAMPLE_HELP_FULL_SCAN: Final[str] = SAMPLE_REASON_FULL_SCAN
+    SAMPLE_CAPTION: Final[str] = "Suggested: {selected} of {total} columns selected"
+    SAMPLE_SPINNER: Final[str] = "Profiling table..."
+    PROFILE_ERROR: Final[str] = "Failed to profile table: {error}"
+    PROFILE_WARNING_NO_SESSION: Final[str] = "No active Snowpark session — unable to profile tables."
+    PROFILE_WARNING_SELECT_TABLE: Final[str] = "Select a database, schema, and table to profile."
+    PROFILE_SUCCESS_SAVE: Final[str] = "Saved profile run {run_id} to metadata."
+    PROFILE_WARNING_SELECT_COLUMNS: Final[str] = "Select at least one column before generating DQ suggestions."
+    PROFILE_SUCCESS_SUGGESTION: Final[str] = "Loaded profile suggestion into the configuration editor."
+    SAMPLE_WARNING_FULL_SCAN: Final[str] = (
+        "Full table scan processed {rows:,} rows. Consider sampling to improve performance."
+    )
+    METRIC_ROWS_PROFILED: Final[str] = "Rows profiled"
+    METRIC_SAMPLING: Final[str] = "Sampling"
+    METRIC_DURATION: Final[str] = "Duration"
+    METRIC_VIEWING_SAVED: Final[str] = SAVED_PROFILE_INFO
+    SAMPLE_LABEL_FULL_SCAN: Final[str] = "Full scan"
+    FILTERS_SUBHEADER: Final[str] = "Filters"
+    FILTER_HIGH_NULL: Final[str] = "High null % (>20%)"
+    FILTER_UNIQUE: Final[str] = "Unique candidates"
+    FILTER_LOW_CARDINALITY: Final[str] = "Low cardinality"
+    FILTER_WHITESPACE: Final[str] = "Whitespace risk"
+    FILTER_SEMANTIC_LABEL: Final[str] = "Semantic tags"
+    FILTER_SEMANTIC_OPTIONS: Final[Tuple[str, ...]] = (
+        "Identifiers",
+        "Financial",
+        "Instrument",
+        "Geo",
+        "Contact",
+        "Date (Text)",
+        "Reference Codes",
+    )
+    SAMPLE_PCT_REASON_METADATA: Final[str] = SAMPLE_REASON_METADATA
+    SAVE_DISABLED_MESSAGE: Final[str] = LOAD_DISABLED_CAPTION
+    SAVE_ENABLED_MESSAGE: Final[str] = LOAD_ENABLED_CAPTION
+    SAVED_PROFILE_INFO_BOX: Final[str] = SAVED_PROFILE_INFO
+    GRID_COLUMN_SELECT: Final[str] = "Select"
+    GRID_COLUMN_COLUMN: Final[str] = "Column"
+    GRID_COLUMN_PHYSICAL_TYPE: Final[str] = "Physical Type"
+    GRID_COLUMN_NULLS: Final[str] = "Nulls"
+    GRID_COLUMN_DISTINCT: Final[str] = "Distinct"
+    GRID_COLUMN_AVG_LENGTH: Final[str] = "Avg Length"
+    GRID_COLUMN_MIN_VALUE: Final[str] = "Min Value"
+    GRID_COLUMN_MAX_VALUE: Final[str] = "Max Value"
+    GRID_COLUMN_WHITESPACE: Final[str] = "Whitespace %"
+    GRID_COLUMN_GUESSED_TYPE: Final[str] = "Guessed Type"
+    GRID_COLUMN_CONFIDENCE: Final[str] = "Confidence"
+    GRID_COLUMN_NOTE: Final[str] = "Note"
+    GRID_CHECKBOX_HELP: Final[str] = "Toggle to include the column in downstream DQ suggestions."
+    GRID_EMPTY_INFO: Final[str] = "No columns matched the selected filters."
+    LOAD_CAPTION_NO_SAVED: Final[str] = "No saved profiles found in metadata tables yet."
+    LOAD_CAPTION_NEEDS_CONNECTION: Final[str] = (
+        "Connect to Snowflake and configure metadata targets to enable loading saved profiles."
+    )
+    PROFILE_SUCCESS_SAVED_PROFILE: Final[str] = "Saved profile run {run_id} to metadata."
+    PROFILE_SUMMARY_SAVED_PROFILE: Final[str] = "Viewing a saved profile."
+    BUTTON_CLEAR_PROFILE: Final[str] = CLEAR_LOADED_BUTTON
+    INFO_VIEWING_SAVED: Final[str] = SAVED_PROFILE_INFO
+    INFO_NO_SAVED_PROFILE: Final[str] = "Saved profile was not found or is empty."
+    SUCCESS_LOADED_PROFILE: Final[str] = "Loaded saved profile {run_id}."
+    SUCCESS_PROFILE_SUGGESTION: Final[str] = PROFILE_SUCCESS_SUGGESTION
+    SUCCESS_PROFILE_SAVE: Final[str] = PROFILE_SUCCESS_SAVE
+    WARNING_SELECT_PROFILE: Final[str] = LOAD_WARNING_SELECT_RUN
+    WARNING_NO_CONNECTION: Final[str] = LOAD_WARNING_CONNECTION
+    WARNING_SELECT_COLUMNS: Final[str] = PROFILE_WARNING_SELECT_COLUMNS
+    WARNING_NO_COLUMNS: Final[str] = NO_COLUMNS_MATCHED
+    INFO_SAVED_PROFILE: Final[str] = SAVED_PROFILE_INFO
+    INFO_NO_VALUES: Final[str] = NO_TOP_VALUES
+    INFO_NO_NON_NULL: Final[str] = NO_NON_NULL_VALUES
+    INFO_SAVED_PROFILE_VIEW: Final[str] = SAVED_PROFILE_INFO
+    INFO_NO_COLUMNS: Final[str] = NO_COLUMNS_MATCHED
+    TOP_VALUES_VALUE_HEADER: Final[str] = "Value"
+    TOP_VALUES_COUNT_HEADER: Final[str] = "Count"
+    INLINE_SELECT_DISABLED: Final[str] = (
+        "UI contract violation: inline selection must remain enabled. Set PROFILE_INLINE_SELECT=1."
+    )
+    DEBUG_PROFILE_PAYLOAD: Final[str] = "Debug: profile payload"
+    DEBUG_SELECTION_STATE: Final[str] = "Debug: include map"
+
+
+class ConfigEditorStrings:
+    CONTRACT_DATAFRAME_EXPECTED: Final[str] = (
+        "UI contract violation in config preview: expected a pandas DataFrame."
+    )
+    CONTRACT_COLUMNS_MISMATCH: Final[str] = (
+        "UI contract violation in config preview: expected columns {expected} but found {actual}."
+    )
+
+
+class DocsStrings:
+    HEADER: Final[str] = "Zeus Data Quality documentation"
+    TABS: Final[Tuple[str, ...]] = (
+        "User Guide",
+        "Profiling",
+        "DQ Framework",
+        "Technical Overview",
+        "Data Governance",
+        "Version History",
+    )
+    CONTRACT_TABS_MISMATCH: Final[str] = (
+        "UI contract violation in documentation view: expected 6 tabs."
+    )
+    USER_GUIDE_SUBHEADER: Final[str] = "User Guide"
+    PROFILING_SUBHEADER: Final[str] = "Profiling"
+    FRAMEWORK_SUBHEADER: Final[str] = "Snowflake-native data quality framework"
+    TECHNICAL_SUBHEADER: Final[str] = "Technical Overview"
+    DATA_GOVERNANCE_SUBHEADER: Final[str] = "Data Governance and Security"
+    VERSION_HISTORY_SUBHEADER: Final[str] = "Version History"
+    VERSION_HISTORY_INFO: Final[str] = (
+        "Version history will be documented here once releases are tracked."
+    )
+    USER_GUIDE_CONTENT: Final[str] = (
+        """
+#### What the app delivers
+- **Purpose**: Monitor critical Snowflake tables so issues surface before reporting deadlines.
+- **Audience**: Data owners, analysts, and operations leads who prefer guided workflows over ad-hoc SQL.
+
+#### Create a configuration
+1. **Select a source** – choose the database, schema, and table to protect.
+2. **Name the setup** – use a business-friendly title so teams recognise the coverage.
+3. **Pick columns** – decide which checks apply to each column based on risk.
+4. **Review table options** – confirm the timestamp and warehouse before saving.
+5. **Save and apply** – the configuration is stored and the daily 08:00 (Europe/Berlin) task is scheduled.
+
+> **Tip:** Use **Save** to draft changes and **Save and apply** once the table is ready for monitoring.
+
+#### Checks in plain language
+- **Uniqueness** identifies duplicate business keys.
+- **Null count** tracks missing information.
+- **Minimum/maximum** keeps numeric ranges within agreed limits.
+- **Whitespace** flags leading or trailing spaces that break joins.
+- **Format distribution** watches identifier patterns such as IBAN, ISIN, or email.
+- **Value distribution** monitors the mix of categories and highlights unusual shifts.
+- **Freshness** confirms data arrives on time based on the chosen timestamp column.
+- **Row count anomaly** spots sudden volume changes relative to recent history.
+- **Aggregate checks** support custom totals or ratios when business validation requires them.
+
+#### Run and monitor results
+- **Run now** performs an immediate evaluation for spot checks.
+- **Daily tasks** operate automatically once a schedule is enabled.
+- **Monitor** surfaces outcomes with filters by table, check type, or status; results can be downloaded for follow-up.
+
+#### Troubleshooting essentials
+- Verify the Snowflake warehouse is running and sized for the workload.
+- Confirm the active role has access to the source objects and metadata schema.
+- Review stored procedure messages in the Monitor tab or execute the procedure manually for detailed logs.
+"""
+    )
+    PROFILING_CONTENT: Final[str] = (
+        """
+#### Why profile first
+Profiling runs lightweight column statistics so you understand data shape and completeness before finalising monitoring rules. The output points to high-risk fields, validates business keys, and surfaces unexpected formats.
+
+#### Metrics collected per column
+- **Null percentage and count** highlight missing data hotspots.
+- **Distinct percentage and count** confirm uniqueness or signal categorical fields.
+- **Minimum and maximum** verify numeric and timestamp ranges.
+- **Average length** spots truncated strings or inconsistent identifiers.
+- **Whitespace percentage** exposes formatting issues that can break joins.
+- **Top values** display the most frequent categories or potential outliers.
+
+#### Semantic insights and confidence
+- Columns receive semantic suggestions such as IBAN, ISIN, email, account ID, country, or timestamp based on detected patterns.
+- Confidence levels appear as High, Medium, Low, or Unknown with colour coding in the grid.
+- Hover the **Confidence rationale** tooltip to see why a tag was chosen (for example, "Regex match on 92% of rows").
+
+#### Filters that guide design
+- Apply filters for high null percentage, unique candidates, low cardinality, or whitespace risk to shortlist columns.
+- Use semantic tag filters (Identifiers, Financial, Instrument, Geography, Contact) to concentrate on sensitive fields.
+- Combine these insights to select uniqueness, null, pattern, or distribution checks inside the configuration editor.
+
+#### Performance and accuracy notes
+- Sampling defaults to a recommended percentage based on table size; set the value to `0` when a full scan is required.
+- Large tables automatically switch distinct counts to `APPROX_COUNT_DISTINCT`, balancing accuracy (within ~1%) and speed.
+- The summary banner reports rows profiled, sampling choice, and runtime so you can judge cost before rerunning.
+
+#### Persisting and reusing results
+- Enable **Save profile** once metadata targets are configured to store runs for auditing or historical comparison.
+- Use **Suggest DQ config** after profiling to pre-populate the configuration editor with recommended checks.
+"""
+    )
+    FRAMEWORK_CONTENT: Final[str] = (
+        """
+### Data Monitoring Framework (DMF) checks
+- Each row-level rule becomes a DMF view that runs inside Snowflake.
+- Failing rows surface in `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` within `{metadata_db}`.`{metadata_schema}`.
+- Views follow the pattern `SELECT * FROM <source> WHERE NOT (<rule_predicate>)`, using generated identifiers to avoid collisions.
+- Save and apply creates or refreshes the views and grants access. Removing a config cleans up unused artefacts.
+
+### Aggregate table-level checks
+- Freshness and row-count anomaly checks execute as aggregate SQL directly against the source table.
+- Because they summarise the entire table, they store only results in `{run_results_table}` and do not create DMF views.
+- Freshness compares the latest timestamp in the monitored column; row-count anomaly looks at recent history for spikes or droughts.
+
+### Stored procedures orchestrating runs
+- `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` (Snowpark Python) receives a configuration ID, evaluates every check, and records outcomes in `{run_results_table}`.
+- `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages task lifecycle with `EXECUTE AS CALLER`, ensuring warehouse and privilege alignment.
+
+### Tasks per configuration
+- Each configuration owns a Snowflake task `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`.
+- The task runs `CALL {proc_name}('<CONFIG_ID>')`, inheriting the caller's warehouse by default.
+- Cron syntax with IANA time zones supports 08:00 Europe/Berlin schedules and any overrides defined by administrators.
+
+### Roles, context, and required grants
+- Procedures execute as caller so data access policies remain intact.
+- The app expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both procedures.
+- Streamlit in Snowflake keeps ownership with the application role, simplifying audits and change tracking.
+
+### Why Snowflake for data quality
+- In-database compute keeps checks near the data—no egress or shadow copies.
+- Snowpark Python combines orchestration logic with native SQL execution.
+- Streamlit in Snowflake provides the UI where teams already work.
+- INFORMATION_SCHEMA and Account Usage power metadata-driven discovery and monitoring.
+- Governed sharing and roles ensure DMF views, tasks, and procedures respect enterprise security boundaries.
+"""
+    )
+    FRAMEWORK_ENTITY_GRAPH: Final[str] = (
+        """
+digraph G {{
+    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.4, nodesep=0.9, ranksep=1.1, splines=true];
+    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, fillcolor="#f4f6fb", color="#d5dbed", penwidth=1.2];
+    edge [color="#4f46e5", fontname="Helvetica", fontsize=10, arrowsize=0.8];
+
+    subgraph cluster_metadata {{
+        label="Metadata Schema";
+        fontname="Helvetica";
+        fontsize=11;
+        color="#c7d2fe";
+        style="rounded";
+        {cfg_tbl_node} [label="{cfg_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
+        {chk_tbl_node} [label="{chk_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
+        {run_tbl_node} [label="{run_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
+        {profile_run_node} [label="{profile_run_label}\\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
+        {profile_col_node} [label="{profile_col_label}\\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
+        dmfv [label="DMF_FAIL views\\n(per active check)", shape=folder, fillcolor="#fdf2f8", color="#fbcfe8", fontcolor="#831843"];
+    }}
+
+    app [label="Streamlit App", shape=rect, fillcolor="#ecfdf5", color="#bbf7d0", fontcolor="#047857"];
+    {proc_node} [label="{proc_label}", shape=rect, fillcolor="#ede9fe", color="#c4b5fd", fontcolor="#5b21b6"];
+    task [label="Snowflake Task\\nper config", shape=rect, fillcolor="#fef3c7", color="#fcd34d", fontcolor="#92400e"];
+
+    app -> {cfg_tbl_node} [label="creates / edits"];
+    app -> {chk_tbl_node} [label="creates / edits"];
+    app -> dmfv [label="renders"];
+    app -> {profile_run_node} [label="captures profiles"];
+    app -> {profile_col_node} [label="renders"];
+    {cfg_tbl_node} -> {chk_tbl_node} [label="defines"];
+    {cfg_tbl_node} -> task [label="schedules"];
+    task -> {proc_node} [label="calls"];
+    {proc_node} -> {run_tbl_node} [label="logs to"];
+    {proc_node} -> dmfv [label="populates"];
+    {proc_node} -> {profile_run_node} [label="logs to", style=dashed, color="#6b7280", fontcolor="#6b7280"];
+    {profile_run_node} -> {profile_col_node} [label="summarises"];
+    {run_tbl_node} -> app [label="renders"];
+    dmfv -> app [label="renders", style=dashed, color="#6b7280", fontcolor="#6b7280"];
+}}
+"""
+    )
+    FRAMEWORK_WORKFLOW_GRAPH: Final[str] = (
+        """
+digraph W {
+    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.5, nodesep=0.9, ranksep=1.1, splines=ortho];
+    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, width=2.2, height=0.8];
+    edge [color="#6366f1", fontname="Helvetica", fontsize=10, arrowsize=0.85];
+
+    step1 [label="User edits\\nconfig", fillcolor="#eef2ff", color="#c7d2fe", fontcolor="#312e81"];
+    step2 [label="Save & Apply", fillcolor="#e0f2fe", color="#bae6fd", fontcolor="#0c4a6e"];
+    step3 [label="Attach DMF\\nviews", fillcolor="#dcfce7", color="#bbf7d0", fontcolor="#065f46"];
+    step4 [label="Task schedule", fillcolor="#fef3c7", color="#fde68a", fontcolor="#92400e"];
+    step5 [label="Daily run", fillcolor="#fee2e2", color="#fecaca", fontcolor="#991b1b"];
+    step6 [label="Log results", fillcolor="#ede9fe", color="#ddd6fe", fontcolor="#5b21b6"];
+    step7 [label="Monitor", fillcolor="#f5f3ff", color="#c4b5fd", fontcolor="#4c1d95"];
+
+    step1 -> step2 [label="commit changes"];
+    step2 -> step3 [label="provision checks"];
+    step3 -> step4 [label="enable task"];
+    step4 -> step5 [label="cron trigger"];
+    step5 -> step6 [label="stored procedure"];
+    step6 -> step7 [label="Surface in app"];
+}
+"""
+    )
+    TECHNICAL_CONTENT: Final[str] = (
+        """
+#### Runtime
+- Streamlit in Snowflake using Snowpark Python.
+
+#### Metadata and results
+- Configs: `{cfg_tbl_display}`
+- Checks: `{chk_tbl_display}`
+- Results: `{run_results_table}`
+
+#### Procedures
+- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` evaluates checks and logs to the results table.
+- Task manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` creates or updates tasks and runs as caller.
+
+#### Tasks
+- One per configuration: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}` with body `CALL {proc_name}('<CONFIG_ID>')`.
+
+#### Warehouses
+- Schedules run on the default application warehouse (for example, `DQ_WH`).
+"""
+    )
+    TECHNICAL_PRIVILEGES_HEADING: Final[str] = "#### Required privileges for the caller role"
+    TECHNICAL_PRIVILEGES_SNIPPET: Final[str] = (
+        """
+USAGE ON WAREHOUSE DQ_WH
+USAGE ON DATABASE {metadata_db}
+USAGE ON SCHEMA {metadata_db}.{metadata_schema}
+CREATE TASK ON SCHEMA {metadata_db}.{metadata_schema}
+EXECUTE ON PROCEDURE {metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)
+"""
+    )
+    DATA_GOVERNANCE_CONTENT: Final[str] = (
+        """
+#### Roles and isolation
+- The application runs with a defined caller role and relies on `EXECUTE AS CALLER` when managing tasks.
+- Configuration and results tables live in a dedicated metadata schema to control privileges.
+
+#### Traceability
+- `DQ_RUN_RESULTS` captures timestamps, check identifiers, failure counts, success flags, and error messages.
+- Each configuration owns a Snowflake task, which is auditable through ACCOUNT USAGE views.
+
+#### Access patterns
+- Source tables are read-only; writes are limited to metadata objects for configs, checks, and results.
+- DMF failing-row views remain in the metadata schema so investigators avoid querying production tables directly.
+
+#### Handling sensitive data
+- Prefer checks that avoid materialising personal data in logs; views expose only what investigators need.
+- Apply column masking to metadata views when sensitive attributes require additional protection.
+"""
+    )

--- a/utils/flags.py
+++ b/utils/flags.py
@@ -1,0 +1,21 @@
+"""Runtime feature flags and kill switches for Streamlit views."""
+
+from __future__ import annotations
+
+import os
+
+
+def flag(name: str, default: bool = False) -> bool:
+    """Return the boolean value of an environment flag."""
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+UI_CONTRACT_STRICT = flag("UI_CONTRACT_STRICT", False)
+DEMO_LOCK = flag("DEMO_LOCK", False)
+DEBUG_PROFILING = flag("DEBUG_PROFILING_PAYLOAD", False)
+PROFILE_INLINE_SELECT = flag("PROFILE_INLINE_SELECT", True)
+PROFILE_TOP_VALUES_NULLS = flag("PROFILE_TOP_VALUES_NULLS", True)

--- a/utils/state.py
+++ b/utils/state.py
@@ -1,0 +1,32 @@
+"""Session-state helpers for profile selections."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import streamlit as st
+
+_INCLUDE_MAP = "profile_include_map"
+
+
+def get_include_map() -> Dict[str, bool]:
+    """Return a copy of the current include map from session state."""
+
+    value = st.session_state.get(_INCLUDE_MAP, {})
+    if isinstance(value, dict):
+        return {str(key): bool(val) for key, val in value.items()}
+    return {}
+
+
+def set_include(column: str, include: bool) -> None:
+    """Set the include flag for a single column."""
+
+    include_map = get_include_map()
+    include_map[str(column)] = bool(include)
+    st.session_state[_INCLUDE_MAP] = include_map
+
+
+def bulk_set_includes(columns: List[str], include: bool) -> None:
+    """Replace the include map with a uniform value for provided columns."""
+
+    st.session_state[_INCLUDE_MAP] = {str(column): bool(include) for column in columns}

--- a/views/config_editor.py
+++ b/views/config_editor.py
@@ -2,20 +2,21 @@
 
 from __future__ import annotations
 
-import os
 from typing import Sequence
 
 import pandas as pd
 import streamlit as st
 
-_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
+from ui.strings import ConfigEditorStrings
+from utils.flags import DEMO_LOCK, UI_CONTRACT_STRICT
+
 _EXPECTED_PREVIEW_COLUMNS: Sequence[str] = ("day", "cnt")
 
 
 def _contract_message(message: str) -> None:
     """Display a contract warning or elevate to an error when strict."""
 
-    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    strict = UI_CONTRACT_STRICT or DEMO_LOCK
     if strict:
         st.error(message)
     else:
@@ -26,17 +27,16 @@ def render_row_count_preview(df: pd.DataFrame) -> None:
     """Render the row-count preview grid with UI contract validation."""
 
     if not isinstance(df, pd.DataFrame):
-        _contract_message(
-            "UI contract violation in config preview: expected a pandas DataFrame."
-        )
+        _contract_message(ConfigEditorStrings.CONTRACT_DATAFRAME_EXPECTED)
         return
 
     actual_columns = list(df.columns)
     expected_columns = list(_EXPECTED_PREVIEW_COLUMNS)
     if actual_columns != expected_columns:
         _contract_message(
-            "UI contract violation in config preview: expected columns "
-            f"{expected_columns} but found {actual_columns}."
+            ConfigEditorStrings.CONTRACT_COLUMNS_MISMATCH.format(
+                expected=expected_columns, actual=actual_columns
+            )
         )
         return
 

--- a/views/docs_view.py
+++ b/views/docs_view.py
@@ -2,14 +2,24 @@
 
 Layout requirements:
 1. Page header "Zeus Data Quality documentation" appears once at the top.
-2. A fixed `st.tabs` call defines six tabs in this exact order: "User Guide", "Profiling", "DQ Framework", "Technical Overview", "Data Governance", "Version History".  Tab labels and count must not change.
+2. A fixed `st.tabs` call defines six tabs in this exact order: "User Guide", "Profiling", "DQ Framework", "Technical Overview",
+ "Data Governance", "Version History".  Tab labels and count must not change.
 3. Tab content expectations:
-   • "User Guide" tab renders the subheader "User Guide" followed by the existing markdown sections (What the app delivers, Create a configuration, Checks in plain language, Run and monitor results, Troubleshooting essentials).  No interactive widgets belong in this tab.
-   • "Profiling" tab renders the subheader "Profiling" and the markdown sections covering why to profile, metrics, semantic insights, filters, performance notes, and persistence guidance exactly as shipped.  This tab remains markdown-only.
-   • "DQ Framework" tab renders the subheader "Snowflake-native data quality framework" with descriptive markdown, then a divider, then subheader "Entity Diagram" with a Graphviz diagram (rendered via `st.graphviz_chart`) describing metadata objects, followed by subheader "Workflow Diagram" with its Graphviz diagram.  Chart ordering and titles must remain unchanged.
-   • "Technical Overview" tab renders the subheader "Technical Overview", markdown with runtime/metadata/procedure details, then a `st.markdown` heading "#### Required privileges for the caller role" and a single `st.code` block listing privilege statements.  No additional controls may be added.
-   • "Data Governance" tab renders the subheader "Data Governance and Security" plus the markdown sections on roles, traceability, access, and sensitive data handling.
-   • "Version History" tab renders the subheader "Version History" followed by the info message "Version history will be documented here once releases are tracked."  No other content is permitted.
+   • "User Guide" tab renders the subheader "User Guide" followed by the existing markdown sections (What the app delivers, Creat
+ e a configuration, Checks in plain language, Run and monitor results, Troubleshooting essentials).  No interactive widgets belo
+ng in this tab.
+   • "Profiling" tab renders the subheader "Profiling" and the markdown sections covering why to profile, metrics, semantic insig
+hts, filters, performance notes, and persistence guidance exactly as shipped.  This tab remains markdown-only.
+   • "DQ Framework" tab renders the subheader "Snowflake-native data quality framework" with descriptive markdown, then a divider
+, then subheader "Entity Diagram" with a Graphviz diagram (rendered via `st.graphviz_chart`) describing metadata objects, follow
+e d by subheader "Workflow Diagram" with its Graphviz diagram.  Chart ordering and titles must remain unchanged.
+   • "Technical Overview" tab renders the subheader "Technical Overview", markdown with runtime/metadata/procedure details, then
+ a `st.markdown` heading "#### Required privileges for the caller role" and a single `st.code` block listing privilege statements
+.  No additional controls may be added.
+   • "Data Governance" tab renders the subheader "Data Governance and Security" plus the markdown sections on roles, traceability
+, access, and sensitive data handling.
+   • "Version History" tab renders the subheader "Version History" followed by the info message "Version history will be documente
+d here once releases are tracked."  No other content is permitted.
 
 Forbidden patterns:
 • Do not change the tab order, labels, or count.
@@ -23,19 +33,18 @@ Forbidden patterns:
 from __future__ import annotations
 
 from typing import Tuple
-import os
 
 import streamlit as st
 
+from ui.strings import DocsStrings
+from utils.flags import DEMO_LOCK, UI_CONTRACT_STRICT
 from utils.meta import _q
-
-_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
 
 
 def _contract_message(message: str) -> None:
     """Display contract feedback as warning or error based on strict mode."""
 
-    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    strict = UI_CONTRACT_STRICT or DEMO_LOCK
     if strict:
         st.error(message)
     else:
@@ -44,6 +53,7 @@ def _contract_message(message: str) -> None:
 
 def _safe_quote(identifier: str) -> str:
     """Return a safely quoted identifier for display purposes."""
+
     try:
         return _q(identifier)
     except Exception:
@@ -51,11 +61,12 @@ def _safe_quote(identifier: str) -> str:
 
 
 def _sanitize_graph_label(label: str) -> Tuple[str, str]:
-    """Sanitize a fully qualified name for use in future graph visuals."""
+    """Sanitize a fully qualified name for use in graph visuals."""
+
     node_name = "".join(ch if ch.isalnum() else "_" for ch in label)
     if not node_name:
         node_name = "node"
-    display = _safe_quote(label).replace('"', '\\"')
+    display = _safe_quote(label).replace('"', "\\\"")
     return node_name, display
 
 
@@ -68,44 +79,25 @@ def render_docs(
     run_results_table: str,
 ) -> None:
     """Render the documentation tabs for the Streamlit application."""
-    st.header("Zeus Data Quality documentation")
 
-    tabs = st.tabs(
-        [
-            "User Guide",
-            "Profiling",
-            "DQ Framework",
-            "Technical Overview",
-            "Data Governance",
-            "Version History",
-        ]
-    )
+    st.header(DocsStrings.HEADER)
+
+    tabs = st.tabs(list(DocsStrings.TABS))
 
     if len(tabs) != 6:
-        _contract_message(
-            "UI contract violation in documentation view: expected 6 tabs."
-        )
+        _contract_message(DocsStrings.CONTRACT_TABS_MISMATCH)
         return
 
     cfg_tbl_display = _safe_quote(configs_table)
     chk_tbl_display = _safe_quote(checks_table)
+    run_results_display = _safe_quote(run_results_table)
+    metadata_db_display = _safe_quote(metadata_db)
+    metadata_schema_display = _safe_quote(metadata_schema)
 
-    (
-        cfg_tbl_node,
-        cfg_tbl_label,
-    ) = _sanitize_graph_label(configs_table)
-    (
-        chk_tbl_node,
-        chk_tbl_label,
-    ) = _sanitize_graph_label(checks_table)
-    (
-        run_tbl_node,
-        run_tbl_label,
-    ) = _sanitize_graph_label(run_results_table)
-    (
-        proc_node,
-        proc_label,
-    ) = _sanitize_graph_label(proc_name)
+    cfg_tbl_node, cfg_tbl_label = _sanitize_graph_label(configs_table)
+    chk_tbl_node, chk_tbl_label = _sanitize_graph_label(checks_table)
+    run_tbl_node, run_tbl_label = _sanitize_graph_label(run_results_table)
+    proc_node, proc_label = _sanitize_graph_label(proc_name)
 
     profile_run_node, profile_run_label = _sanitize_graph_label(
         f"{metadata_db}.{metadata_schema}.DQ_PROFILE_RUN"
@@ -115,248 +107,72 @@ def render_docs(
     )
 
     with tabs[0]:
-        st.subheader("User Guide")
-        st.markdown(
-            """
-#### What the app delivers
-- **Purpose**: Monitor critical Snowflake tables so issues surface before reporting deadlines.
-- **Audience**: Data owners, analysts, and operations leads who prefer guided workflows over ad-hoc SQL.
-
-#### Create a configuration
-1. **Select a source** – choose the database, schema, and table to protect.
-2. **Name the setup** – use a business-friendly title so teams recognise the coverage.
-3. **Pick columns** – decide which checks apply to each column based on risk.
-4. **Review table options** – confirm the timestamp and warehouse before saving.
-5. **Save and apply** – the configuration is stored and the daily 08:00 (Europe/Berlin) task is scheduled.
-
-> **Tip:** Use **Save** to draft changes and **Save and apply** once the table is ready for monitoring.
-
-#### Checks in plain language
-- **Uniqueness** identifies duplicate business keys.
-- **Null count** tracks missing information.
-- **Minimum/maximum** keeps numeric ranges within agreed limits.
-- **Whitespace** flags leading or trailing spaces that break joins.
-- **Format distribution** watches identifier patterns such as IBAN, ISIN, or email.
-- **Value distribution** monitors the mix of categories and highlights unusual shifts.
-- **Freshness** confirms data arrives on time based on the chosen timestamp column.
-- **Row count anomaly** spots sudden volume changes relative to recent history.
-- **Aggregate checks** support custom totals or ratios when business validation requires them.
-
-#### Run and monitor results
-- **Run now** performs an immediate evaluation for spot checks.
-- **Daily tasks** operate automatically once a schedule is enabled.
-- **Monitor** surfaces outcomes with filters by table, check type, or status; results can be downloaded for follow-up.
-
-#### Troubleshooting essentials
-- Verify the Snowflake warehouse is running and sized for the workload.
-- Confirm the active role has access to the source objects and metadata schema.
-- Review stored procedure messages in the Monitor tab or execute the procedure manually for detailed logs.
-            """
-        )
+        st.subheader(DocsStrings.USER_GUIDE_SUBHEADER)
+        st.markdown(DocsStrings.USER_GUIDE_CONTENT)
 
     with tabs[1]:
-        st.subheader("Profiling")
-        st.markdown(
-            """
-#### Why profile first
-Profiling runs lightweight column statistics so you understand data shape and completeness before finalising monitoring rules. The output points to high-risk fields, validates business keys, and surfaces unexpected formats.
-
-#### Metrics collected per column
-- **Null percentage and count** highlight missing data hotspots.
-- **Distinct percentage and count** confirm uniqueness or signal categorical fields.
-- **Minimum and maximum** verify numeric and timestamp ranges.
-- **Average length** spots truncated strings or inconsistent identifiers.
-- **Whitespace percentage** exposes formatting issues that can break joins.
-- **Top values** display the most frequent categories or potential outliers.
-
-#### Semantic insights and confidence
-- Columns receive semantic suggestions such as IBAN, ISIN, email, account ID, country, or timestamp based on detected patterns.
-- Confidence levels appear as High, Medium, Low, or Unknown with colour coding in the grid.
-- Hover the **Confidence rationale** tooltip to see why a tag was chosen (for example, "Regex match on 92% of rows").
-
-#### Filters that guide design
-- Apply filters for high null percentage, unique candidates, low cardinality, or whitespace risk to shortlist columns.
-- Use semantic tag filters (Identifiers, Financial, Instrument, Geography, Contact) to concentrate on sensitive fields.
-- Combine these insights to select uniqueness, null, pattern, or distribution checks inside the configuration editor.
-
-#### Performance and accuracy notes
-- Sampling defaults to a recommended percentage based on table size; set the value to `0` when a full scan is required.
-- Large tables automatically switch distinct counts to `APPROX_COUNT_DISTINCT`, balancing accuracy (within ~1%) and speed.
-- The summary banner reports rows profiled, sampling choice, and runtime so you can judge cost before rerunning.
-
-#### Persisting and reusing results
-- Enable **Save profile** once metadata targets are configured to store runs for auditing or historical comparison.
-- Use **Suggest DQ config** after profiling to pre-populate the configuration editor with recommended checks.
-            """
-        )
+        st.subheader(DocsStrings.PROFILING_SUBHEADER)
+        st.markdown(DocsStrings.PROFILING_CONTENT)
 
     with tabs[2]:
-        st.subheader("Snowflake-native data quality framework")
+        st.subheader(DocsStrings.FRAMEWORK_SUBHEADER)
         st.markdown(
-            f"""
-### Data Monitoring Framework (DMF) checks
-- Each row-level rule becomes a DMF view that runs inside Snowflake.
-- Failing rows surface in `DQ_<CONFIG_ID>_<CHECK_ID>_FAILS` within `{_safe_quote(metadata_db)}.{_safe_quote(metadata_schema)}`.
-- Views follow the pattern `SELECT * FROM <source> WHERE NOT (<rule_predicate>)`, using generated identifiers to avoid collisions.
-- Save and apply creates or refreshes the views and grants access. Removing a config cleans up unused artefacts.
-
-### Aggregate table-level checks
-- Freshness and row-count anomaly checks execute as aggregate SQL directly against the source table.
-- Because they summarise the entire table, they store only results in `{run_results_table}` and do not create DMF views.
-- Freshness compares the latest timestamp in the monitored column; row-count anomaly looks at recent history for spikes or droughts.
-
-### Stored procedures orchestrating runs
-- `{metadata_db}.{metadata_schema}.DQ_RUN_CONFIG` (Snowpark Python) receives a configuration ID, evaluates every check, and records outcomes in `{run_results_table}`.
-- `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK` manages task lifecycle with `EXECUTE AS CALLER`, ensuring warehouse and privilege alignment.
-
-### Tasks per configuration
-- Each configuration owns a Snowflake task `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}`.
-- The task runs `CALL {proc_name}('<CONFIG_ID>')`, inheriting the caller's warehouse by default.
-- Cron syntax with IANA time zones supports 08:00 Europe/Berlin schedules and any overrides defined by administrators.
-
-### Roles, context, and required grants
-- Procedures execute as caller so data access policies remain intact.
-- The app expects USAGE/MONITOR on the warehouse, USAGE on `{metadata_db}` and `{metadata_db}.{metadata_schema}`, CREATE TASK in the metadata schema, and EXECUTE on both procedures.
-- Streamlit in Snowflake keeps ownership with the application role, simplifying audits and change tracking.
-
-### Why Snowflake for data quality
-- In-database compute keeps checks near the data—no egress or shadow copies.
-- Snowpark Python combines orchestration logic with native SQL execution.
-- Streamlit in Snowflake provides the UI where teams already work.
-- INFORMATION_SCHEMA and Account Usage power metadata-driven discovery and monitoring.
-- Governed sharing and roles ensure DMF views, tasks, and procedures respect enterprise security boundaries.
-            """
+            DocsStrings.FRAMEWORK_CONTENT.format(
+                metadata_db=metadata_db_display,
+                metadata_schema=metadata_schema_display,
+                run_results_table=run_results_display,
+                proc_name=proc_name,
+            )
         )
 
         st.divider()
         st.subheader("Entity Diagram")
-        entity_graph = f"""
-digraph G {{
-    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.4, nodesep=0.9, ranksep=1.1, splines=true];
-    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, fillcolor="#f4f6fb", color="#d5dbed", penwidth=1.2];
-    edge [color="#4f46e5", fontname="Helvetica", fontsize=10, arrowsize=0.8];
-
-    subgraph cluster_metadata {{
-        label="Metadata Schema";
-        fontname="Helvetica";
-        fontsize=11;
-        color="#c7d2fe";
-        style="rounded";
-        {cfg_tbl_node} [label="{cfg_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
-        {chk_tbl_node} [label="{chk_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
-        {run_tbl_node} [label="{run_tbl_label}", fillcolor="#eef2ff", color="#c7d2fe"];
-        {profile_run_node} [label="{profile_run_label}\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
-        {profile_col_node} [label="{profile_col_label}\n(optional)", style="rounded,dashed,filled", fillcolor="#f8fafc", color="#d5dbed"];
-        dmfv [label="DMF_FAIL views\n(per active check)", shape=folder, fillcolor="#fdf2f8", color="#fbcfe8", fontcolor="#831843"];
-    }}
-
-    app [label="Streamlit App", shape=rect, fillcolor="#ecfdf5", color="#bbf7d0", fontcolor="#047857"];
-    {proc_node} [label="{proc_label}", shape=rect, fillcolor="#ede9fe", color="#c4b5fd", fontcolor="#5b21b6"];
-    task [label="Snowflake Task\nper config", shape=rect, fillcolor="#fef3c7", color="#fcd34d", fontcolor="#92400e"];
-
-    app -> {cfg_tbl_node} [label="creates / edits"];
-    app -> {chk_tbl_node} [label="creates / edits"];
-    app -> dmfv [label="renders"];
-    app -> {profile_run_node} [label="captures profiles"];
-    app -> {profile_col_node} [label="renders"];
-    {cfg_tbl_node} -> {chk_tbl_node} [label="defines"];
-    {cfg_tbl_node} -> task [label="schedules"];
-    task -> {proc_node} [label="calls"];
-    {proc_node} -> {run_tbl_node} [label="logs to"];
-    {proc_node} -> dmfv [label="populates"];
-    {proc_node} -> {profile_run_node} [label="logs to", style=dashed, color="#6b7280", fontcolor="#6b7280"];
-    {profile_run_node} -> {profile_col_node} [label="summarises"];
-    {run_tbl_node} -> app [label="renders"];
-    dmfv -> app [label="renders", style=dashed, color="#6b7280", fontcolor="#6b7280"];
-}}
-        """
-
+        entity_graph = DocsStrings.FRAMEWORK_ENTITY_GRAPH.format(
+            cfg_tbl_node=cfg_tbl_node,
+            cfg_tbl_label=cfg_tbl_label,
+            chk_tbl_node=chk_tbl_node,
+            chk_tbl_label=chk_tbl_label,
+            run_tbl_node=run_tbl_node,
+            run_tbl_label=run_tbl_label,
+            profile_run_node=profile_run_node,
+            profile_run_label=profile_run_label,
+            profile_col_node=profile_col_node,
+            profile_col_label=profile_col_label,
+            proc_node=proc_node,
+            proc_label=proc_label,
+        )
         st.graphviz_chart(entity_graph, use_container_width=True)
 
         st.subheader("Workflow Diagram")
-        workflow_graph = """
-digraph W {
-    graph [rankdir=LR, fontname="Helvetica", fontsize=11, bgcolor="white", pad=0.5, nodesep=0.9, ranksep=1.1, splines=ortho];
-    node [shape=rect, style="rounded,filled", fontname="Helvetica", fontsize=11, width=2.2, height=0.8];
-    edge [color="#6366f1", fontname="Helvetica", fontsize=10, arrowsize=0.85];
-
-    step1 [label="User edits\nconfig", fillcolor="#eef2ff", color="#c7d2fe", fontcolor="#312e81"];
-    step2 [label="Save & Apply", fillcolor="#e0f2fe", color="#bae6fd", fontcolor="#0c4a6e"];
-    step3 [label="Attach DMF\nviews", fillcolor="#dcfce7", color="#bbf7d0", fontcolor="#065f46"];
-    step4 [label="Task schedule", fillcolor="#fef3c7", color="#fde68a", fontcolor="#92400e"];
-    step5 [label="Daily run", fillcolor="#fee2e2", color="#fecaca", fontcolor="#991b1b"];
-    step6 [label="Log results", fillcolor="#ede9fe", color="#ddd6fe", fontcolor="#5b21b6"];
-    step7 [label="Monitor", fillcolor="#f5f3ff", color="#c4b5fd", fontcolor="#4c1d95"];
-
-    step1 -> step2 [label="commit changes"];
-    step2 -> step3 [label="provision checks"];
-    step3 -> step4 [label="enable task"];
-    step4 -> step5 [label="cron trigger"];
-    step5 -> step6 [label="stored procedure"];
-    step6 -> step7 [label="Surface in app"];
-}
-        """
-
-        st.graphviz_chart(workflow_graph, use_container_width=True)
+        st.graphviz_chart(DocsStrings.FRAMEWORK_WORKFLOW_GRAPH, use_container_width=True)
 
     with tabs[3]:
-        st.subheader("Technical Overview")
+        st.subheader(DocsStrings.TECHNICAL_SUBHEADER)
         st.markdown(
-            f"""
-#### Runtime
-- Streamlit in Snowflake using Snowpark Python.
-
-#### Metadata and results
-- Configs: `{cfg_tbl_display}`
-- Checks: `{chk_tbl_display}`
-- Results: `{run_results_table}`
-
-#### Procedures
-- Runner: `{metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)` evaluates checks and logs to the results table.
-- Task manager: `{metadata_db}.{metadata_schema}.SP_DQ_MANAGE_TASK(STRING, STRING, STRING, STRING, STRING, STRING, STRING, BOOLEAN)` creates or updates tasks and runs as caller.
-
-#### Tasks
-- One per configuration: `DQ_TASK_<CONFIG_ID>` in `{metadata_db}.{metadata_schema}` with body `CALL {proc_name}('<CONFIG_ID>')`.
-
-#### Warehouses
-- Schedules run on the default application warehouse (for example, `DQ_WH`).
-            """
+            DocsStrings.TECHNICAL_CONTENT.format(
+                cfg_tbl_display=cfg_tbl_display,
+                chk_tbl_display=chk_tbl_display,
+                run_results_table=run_results_display,
+                metadata_db=metadata_db_display,
+                metadata_schema=metadata_schema_display,
+                proc_name=proc_name,
+            )
         )
 
-        st.markdown("#### Required privileges for the caller role")
+        st.markdown(DocsStrings.TECHNICAL_PRIVILEGES_HEADING)
         st.code(
-            f"""
-USAGE ON WAREHOUSE DQ_WH
-USAGE ON DATABASE {metadata_db}
-USAGE ON SCHEMA {metadata_db}.{metadata_schema}
-CREATE TASK ON SCHEMA {metadata_db}.{metadata_schema}
-EXECUTE ON PROCEDURE {metadata_db}.{metadata_schema}.{proc_name}(VARCHAR)
-            """,
+            DocsStrings.TECHNICAL_PRIVILEGES_SNIPPET.format(
+                metadata_db=metadata_db_display,
+                metadata_schema=metadata_schema_display,
+                proc_name=proc_name,
+            ),
             language="text",
         )
 
     with tabs[4]:
-        st.subheader("Data Governance and Security")
-        st.markdown(
-            """
-#### Roles and isolation
-- The application runs with a defined caller role and relies on `EXECUTE AS CALLER` when managing tasks.
-- Configuration and results tables live in a dedicated metadata schema to control privileges.
-
-#### Traceability
-- `DQ_RUN_RESULTS` captures timestamps, check identifiers, failure counts, success flags, and error messages.
-- Each configuration owns a Snowflake task, which is auditable through ACCOUNT USAGE views.
-
-#### Access patterns
-- Source tables are read-only; writes are limited to metadata objects for configs, checks, and results.
-- DMF failing-row views remain in the metadata schema so investigators avoid querying production tables directly.
-
-#### Handling sensitive data
-- Prefer checks that avoid materialising personal data in logs; views expose only what investigators need.
-- Apply column masking to metadata views when sensitive attributes require additional protection.
-            """
-        )
+        st.subheader(DocsStrings.DATA_GOVERNANCE_SUBHEADER)
+        st.markdown(DocsStrings.DATA_GOVERNANCE_CONTENT)
 
     with tabs[5]:
-        st.subheader("Version History")
-        st.info("Version history will be documented here once releases are tracked.")
+        st.subheader(DocsStrings.VERSION_HISTORY_SUBHEADER)
+        st.info(DocsStrings.VERSION_HISTORY_INFO)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -29,10 +29,10 @@ Forbidden patterns:
 """
 
 from __future__ import annotations
+
 import html
 import json
 import math
-import os
 import textwrap
 import time
 from dataclasses import dataclass, field
@@ -51,15 +51,30 @@ from services.profiling import (
     run_table_profile,
     save_profile_results,
 )
+from ui.keys import (
+    PROFILE_CLEAR_LOADED,
+    PROFILE_LOAD_BUTTON,
+    PROFILE_LOAD_SELECT,
+    PROFILE_RESULTS_SELECTION,
+    PROFILE_SAMPLE_PCT,
+    PROFILE_SAMPLE_TARGET,
+    PROFILE_SAVE_TOGGLE,
+)
+from ui.strings import ProfileStrings as PS
+from utils.flags import (
+    DEBUG_PROFILING,
+    DEMO_LOCK,
+    PROFILE_INLINE_SELECT,
+    PROFILE_TOP_VALUES_NULLS,
+    UI_CONTRACT_STRICT,
+)
 from utils.meta import get_table_row_count
+from utils.state import bulk_set_includes, get_include_map, set_include
 from views.table_picker import session_cache_token, stateless_table_picker
 
 
 FULL_SCAN_WARNING_THRESHOLD = 1_000_000
 MAX_TOP_N = 10
-
-_CONTRACT_ENV_FLAG = "UI_CONTRACT_STRICT"
-
 
 def _safe_int(value: Any) -> Optional[int]:
     """Convert a numeric-like value to an int when possible."""
@@ -139,7 +154,7 @@ def _selection_key(table_fqn: str, column_name: str) -> str:
 def _contract_message(message: str) -> None:
     """Emit a contract warning or error depending on env configuration."""
 
-    strict = os.getenv(_CONTRACT_ENV_FLAG, "0") == "1"
+    strict = UI_CONTRACT_STRICT or DEMO_LOCK
     if strict:
         st.error(message)
     else:
@@ -637,10 +652,8 @@ def _render_metric_card(
     st.markdown(card_html, unsafe_allow_html=True)
 
 def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: ARG001 - interface matches requirement
-    st.header("🧪 Profile Table")
-    st.caption(
-        "Profile a table to explore null rates, distinct counts, ranges, and common values before defining data quality checks."
-    )
+    st.header(PS.HEADER)
+    st.caption(PS.CAPTION)
 
     base_selection = st.session_state.get("profile_target_fqn")
     _db_sel, _sch_sel, _tbl_sel, selected_fqn = _table_picker(session, base_selection)
@@ -691,15 +704,13 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     controls = st.columns(3)
     suggested_pct = 10.0
     row_count: Optional[int] = None
-    selected_reason = (
-        "Defaulting to a 10% sample. Enter 0 for a full table scan."
-    )
+    selected_reason = PS.SAMPLE_DEFAULT_REASON
     if selected_fqn:
         row_count = _load_table_row_count(session, selected_fqn)
         suggested_pct, selected_reason = _recommend_sample_pct(row_count)
 
-    sample_pct_state_key = "profile_sample_pct"
-    sample_target_key = "profile_sample_target"
+    sample_pct_state_key = PROFILE_SAMPLE_PCT
+    sample_target_key = PROFILE_SAMPLE_TARGET
     if st.session_state.get(sample_target_key) != selected_fqn:
         st.session_state[sample_target_key] = selected_fqn
         st.session_state[sample_pct_state_key] = float(suggested_pct)
@@ -712,71 +723,71 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     reason_parts = [selected_reason]
     if row_count is not None:
-        reason_parts.append(f"Table metadata reports approximately {row_count:,} rows.")
+        reason_parts.append(
+            PS.SAMPLE_REASON_TABLE_ROWS.format(rows=row_count)
+        )
     if approx_rows:
-        reason_parts.append(f"This sample size profiles about {approx_rows:,} rows.")
-    reason_parts.append(
-        "The suggested value relies on Snowflake metadata only, so it doesn't trigger an extra table scan."
-    )
-    reason_parts.append("Enter 0 for a full table scan.")
+        reason_parts.append(
+            PS.SAMPLE_REASON_APPROX_ROWS.format(rows=approx_rows)
+        )
+    reason_parts.append(PS.SAMPLE_REASON_METADATA)
+    reason_parts.append(PS.SAMPLE_REASON_FULL_SCAN)
     sample_help_text = "\n".join(reason_parts)
 
     with controls[0]:
         sample_pct_input = st.number_input(
-            "Sample %",
+            PS.SAMPLE_LABEL,
             min_value=0.0,
             max_value=100.0,
             step=1.0,
             help=sample_help_text,
-            key=sample_pct_state_key,
+            key=PROFILE_SAMPLE_PCT,
         )
         sample_pct = None if math.isclose(sample_pct_input, 0.0, abs_tol=1e-6) else sample_pct_input
     with controls[1]:
         top_n = st.number_input(
-            "Top N values",
+            PS.TOP_N_LABEL,
             min_value=1,
             max_value=MAX_TOP_N,
             value=min(10, MAX_TOP_N),
             step=1,
-            help=f"Collect up to {MAX_TOP_N} of the most common values per column.",
+            help=PS.TOP_N_HELP_TEMPLATE.format(max_top=MAX_TOP_N),
         )
     load_selected_run_id: Optional[str] = None
     load_button_clicked = False
     with controls[2]:
         if saved_run_labels:
-            load_options = ["— Select a saved run —"] + saved_run_labels
+            load_options = [PS.LOAD_SAVED_PLACEHOLDER] + saved_run_labels
             selected_option = st.selectbox(
-                "Load saved profile",
+                PS.LOAD_SAVED_LABEL,
                 options=load_options,
-                key="profile_load_select",
+                key=PROFILE_LOAD_SELECT,
                 disabled=not saved_profiles_enabled,
             )
             if selected_option in saved_run_lookup:
                 load_selected_run_id = saved_run_lookup[selected_option]
         else:
             st.selectbox(
-                "Load saved profile",
-                options=["— No saved profiles —"],
-                key="profile_load_select",
+                PS.LOAD_SAVED_LABEL,
+                options=[PS.LOAD_SAVED_EMPTY],
+                key=PROFILE_LOAD_SELECT,
                 disabled=True,
             )
         load_button_clicked = st.button(
-            "Load",
-            key="profile_load_button",
+            PS.LOAD_BUTTON,
+            key=PROFILE_LOAD_BUTTON,
             disabled=not (saved_profiles_enabled and load_selected_run_id),
         )
         if not saved_profiles_enabled:
-            st.caption(
-                "Connect to Snowflake and configure metadata targets to enable loading saved profiles."
-            )
+            st.caption(PS.LOAD_CAPTION_NEEDS_CONNECTION)
         elif not saved_run_labels:
-            st.caption("No saved profiles found in metadata tables yet.")
+            st.caption(PS.LOAD_CAPTION_NO_SAVED)
 
     if load_button_clicked:
         if not saved_profiles_enabled:
-            st.warning("Loading profiles requires a Snowflake connection and metadata configuration.")
+            st.warning(PS.WARNING_NO_CONNECTION)
         elif not load_selected_run_id:
-            st.warning("Select a saved run to load.")
+            st.warning(PS.WARNING_SELECT_PROFILE)
         else:
             try:
                 loaded_profile = load_profile_run(
@@ -786,17 +797,17 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     run_id=load_selected_run_id,
                 )
             except Exception as exc:  # pragma: no cover - Snowflake specific
-                st.error(f"Failed to load saved profile: {exc}")
+                st.error(PS.LOAD_ERROR.format(error=exc))
             else:
                 if not loaded_profile:
-                    st.warning("Saved profile was not found or is empty.")
+                    st.warning(PS.INFO_NO_SAVED_PROFILE)
                 else:
                     st.session_state["profile_results"] = loaded_profile
                     st.session_state["profile_loaded_run_id"] = load_selected_run_id
                     target_table = loaded_profile.get("target_table")
                     if target_table:
                         st.session_state["profile_target_fqn"] = target_table
-                    st.success(f"Loaded saved profile {load_selected_run_id}.")
+                    st.success(PS.SUCCESS_LOADED_PROFILE.format(run_id=load_selected_run_id))
                     st.rerun()
 
     stored_profile_result = st.session_state.get("profile_results")
@@ -857,16 +868,19 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     st.session_state["profile_selection_counts"] = selection_counts
 
     st.caption(
-        f"Suggested: {int(selection_counts[0])} of {int(selection_counts[1])} columns selected"
+        PS.SAMPLE_CAPTION.format(
+            selected=int(selection_counts[0]),
+            total=int(selection_counts[1]),
+        )
     )
 
     button_cols = st.columns([1, 1, 2])
     run_disabled = bool(loaded_run_id)
     with button_cols[0]:
-        run_profile = st.button("▶️ Run Profile", type="primary", disabled=run_disabled)
+        run_profile = st.button(PS.RUN_BUTTON, type="primary", disabled=run_disabled)
     with button_cols[1]:
         suggest_cfg = st.button(
-            "✨ Suggest DQ Config",
+            PS.SUGGEST_BUTTON,
             type="secondary",
             disabled=not stored_profile_result,
         )
@@ -874,8 +888,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     clear_loaded = False
     if loaded_run_id:
         with button_cols[2]:
-            st.info("Viewing a saved profile.")
-            clear_loaded = st.button("Clear loaded profile", key="profile_clear_loaded")
+            st.info(PS.SAVED_PROFILE_INFO)
+            clear_loaded = st.button(PS.CLEAR_LOADED_BUTTON, key=PROFILE_CLEAR_LOADED)
     else:
         button_cols[2].empty()
 
@@ -890,11 +904,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         st.session_state.pop("profile_loaded_run_id", None)
         loaded_run_id = None
         if not session:
-            st.error("No active Snowpark session — unable to profile tables.")
+            st.error(PS.PROFILE_WARNING_NO_SESSION)
         elif not selected_fqn:
-            st.warning("Select a database, schema, and table to profile.")
+            st.warning(PS.PROFILE_WARNING_SELECT_TABLE)
         else:
-            with st.spinner("Profiling table..."):
+            with st.spinner(PS.SAMPLE_SPINNER):
                 start = time.time()
                 profile_error: Optional[Exception] = None
                 summary_raw: Dict[str, Any] = {}
@@ -911,7 +925,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 duration = time.time() - start
 
             if profile_error is not None:
-                st.error(f"Failed to profile table: {profile_error}")
+                st.error(PS.PROFILE_ERROR.format(error=profile_error))
             else:
                 rows_profiled = int(summary_raw.get("rows_profiled") or 0)
                 profiles: List[ColumnProfile] = []
@@ -937,7 +951,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     def _load_suggestion(profile_payload: Dict[str, Any], success_message: str) -> None:
         suggestion = build_profile_suggestion(profile_payload)
         if not suggestion:
-            st.info("No suggestions available for the current profile.")
+            st.info(PS.NO_SUGGESTIONS)
             return
         st.session_state["cfg_mode"] = "edit"
         st.session_state["selected_config_id"] = None
@@ -966,7 +980,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     if suggest_cfg and profile_result:
         selected_columns = _selected_columns(profile_result)
         if not selected_columns:
-            st.warning("Select at least one column before generating DQ suggestions.")
+            st.warning(PS.PROFILE_WARNING_SELECT_COLUMNS)
         else:
             filtered_profile = dict(profile_result)
             filtered_summary = dict(filtered_profile.get("summary") or {})
@@ -975,7 +989,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             filtered_profile["columns"] = selected_columns
             _load_suggestion(
                 filtered_profile,
-                "Loaded profile suggestion into the configuration editor.",
+                PS.PROFILE_SUCCESS_SUGGESTION,
             )
 
     if not profile_result:
@@ -983,16 +997,20 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     summary = profile_result.get("summary", {})
     metrics_cols = st.columns(3)
-    metrics_cols[0].metric("Rows profiled", f"{summary.get('rows_profiled', 0):,}")
+    metrics_cols[0].metric(PS.METRIC_ROWS_PROFILED, f"{summary.get('rows_profiled', 0):,}")
     sample_pct_display = summary.get("sample_pct")
-    sample_label = "Full scan" if sample_pct_display is None else f"{float(sample_pct_display):.1f}%"
-    metrics_cols[1].metric("Sampling", sample_label)
-    metrics_cols[2].metric("Duration", f"{summary.get('duration_sec', 0.0):.2f}s")
+    sample_label = (
+        PS.SAMPLE_LABEL_FULL_SCAN
+        if sample_pct_display is None
+        else f"{float(sample_pct_display):.1f}%"
+    )
+    metrics_cols[1].metric(PS.METRIC_SAMPLING, sample_label)
+    metrics_cols[2].metric(PS.METRIC_DURATION, f"{summary.get('duration_sec', 0.0):.2f}s")
 
     if summary.get("sample_pct") is None and summary.get("rows_profiled", 0) > FULL_SCAN_WARNING_THRESHOLD:
         profiled = int(summary.get("rows_profiled", 0))
         st.warning(
-            f"Full table scan processed {profiled:,} rows. Consider sampling to improve performance.",
+            PS.SAMPLE_WARNING_FULL_SCAN.format(rows=profiled),
             icon="⚠️",
         )
 
@@ -1020,36 +1038,48 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     filter_box = st.container()
     with filter_box:
-        st.subheader("Filters", anchor=False)
+        st.subheader(PS.FILTERS_SUBHEADER, anchor=False)
         filter_cols = st.columns(4)
-        high_null = filter_cols[0].toggle("High null % (>20%)", value=False)
-        unique_candidates = filter_cols[1].toggle("Unique candidates", value=False)
-        low_cardinality = filter_cols[2].toggle("Low cardinality", value=False)
-        whitespace_risk = filter_cols[3].toggle("Whitespace risk", value=False)
-        st.markdown("**Semantic tags**")
-        semantic_cols = st.columns(7)
-        filter_identifiers = semantic_cols[0].checkbox("Identifiers", value=False)
-        filter_financial = semantic_cols[1].checkbox("Financial", value=False)
-        filter_instrument = semantic_cols[2].checkbox("Instrument", value=False)
-        filter_geo = semantic_cols[3].checkbox("Geo", value=False)
-        filter_contact = semantic_cols[4].checkbox("Contact", value=False)
-        filter_date_text = semantic_cols[5].checkbox("Date (Text)", value=False)
-        filter_ref_codes = semantic_cols[6].checkbox("Reference Codes", value=False)
+        high_null = filter_cols[0].toggle(PS.FILTER_HIGH_NULL, value=False)
+        unique_candidates = filter_cols[1].toggle(PS.FILTER_UNIQUE, value=False)
+        low_cardinality = filter_cols[2].toggle(PS.FILTER_LOW_CARDINALITY, value=False)
+        whitespace_risk = filter_cols[3].toggle(PS.FILTER_WHITESPACE, value=False)
+        st.markdown(f"**{PS.FILTER_SEMANTIC_LABEL}**")
+        semantic_cols = st.columns(len(PS.FILTER_SEMANTIC_OPTIONS))
+        filter_identifiers = semantic_cols[0].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[0], value=False
+        )
+        filter_financial = semantic_cols[1].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[1], value=False
+        )
+        filter_instrument = semantic_cols[2].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[2], value=False
+        )
+        filter_geo = semantic_cols[3].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[3], value=False
+        )
+        filter_contact = semantic_cols[4].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[4], value=False
+        )
+        filter_date_text = semantic_cols[5].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[5], value=False
+        )
+        filter_ref_codes = semantic_cols[6].checkbox(
+            PS.FILTER_SEMANTIC_OPTIONS[6], value=False
+        )
 
     save_enabled = bool(session and meta_db and meta_schema)
     if not save_enabled:
-        st.session_state.pop("profile_save_toggle", None)
+        st.session_state.pop(PROFILE_SAVE_TOGGLE, None)
         st.session_state.pop("_profile_save_prev", None)
         st.session_state.pop("profile_saved_run_id", None)
 
     save_help = (
-        "Persist the current profile results to metadata tables."
-        if save_enabled
-        else "Connect to Snowflake and select metadata targets to enable saving."
+        PS.SAVE_ENABLED_MESSAGE if save_enabled else PS.SAVE_DISABLED_MESSAGE
     )
     save_toggle = st.toggle(
-        "💾 Save Profile",
-        key="profile_save_toggle",
+        PS.SAVE_TOGGLE,
+        key=PROFILE_SAVE_TOGGLE,
         value=False,
         disabled=not save_enabled,
         help=save_help,
@@ -1084,10 +1114,10 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 rows=rows_payload,
             )
         except Exception as exc:  # pragma: no cover - Snowflake specific
-            st.error(f"Failed to save profile: {exc}")
+            st.error(PS.CLEAR_PROFILE_ERROR.format(error=exc))
         else:
             st.session_state["profile_saved_run_id"] = run_id
-            st.success(f"Saved profile run {run_id} to metadata.")
+            st.success(PS.PROFILE_SUCCESS_SAVE.format(run_id=run_id))
 
     if not save_toggle:
         st.session_state.pop("profile_saved_run_id", None)
@@ -1105,29 +1135,29 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         filtered_df = filtered_df[(filtered_df["whitespace_pct"].fillna(0) > 5)]
 
     semantic_filter_map = {
-        "Identifiers": {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN", "REF_CODE"},
-        "Financial": {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
-        "Instrument": {"ISIN", "TICKER/SYMBOL"},
-        "Geo": {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
-        "Contact": {"EMAIL", "PHONE"},
-        "Date (Text)": {"DATE_IN_TEXT"},
-        "Reference Codes": {"REF_CODE"},
+        PS.FILTER_SEMANTIC_OPTIONS[0]: {"ACCOUNT_ID", "ORDER_ID", "TRADE_ID", "UUID", "IBAN", "REF_CODE"},
+        PS.FILTER_SEMANTIC_OPTIONS[1]: {"PRICE/AMOUNT/QUANTITY", "IBAN", "BIC"},
+        PS.FILTER_SEMANTIC_OPTIONS[2]: {"ISIN", "TICKER/SYMBOL"},
+        PS.FILTER_SEMANTIC_OPTIONS[3]: {"COUNTRY_CODE/NAME", "CURRENCY_CODE", "BIC"},
+        PS.FILTER_SEMANTIC_OPTIONS[4]: {"EMAIL", "PHONE"},
+        PS.FILTER_SEMANTIC_OPTIONS[5]: {"DATE_IN_TEXT"},
+        PS.FILTER_SEMANTIC_OPTIONS[6]: {"REF_CODE"},
     }
     active_semantic_filters: List[str] = []
     if filter_identifiers:
-        active_semantic_filters.append("Identifiers")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[0])
     if filter_financial:
-        active_semantic_filters.append("Financial")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[1])
     if filter_instrument:
-        active_semantic_filters.append("Instrument")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[2])
     if filter_geo:
-        active_semantic_filters.append("Geo")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[3])
     if filter_contact:
-        active_semantic_filters.append("Contact")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[4])
     if filter_date_text:
-        active_semantic_filters.append("Date (Text)")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[5])
     if filter_ref_codes:
-        active_semantic_filters.append("Reference Codes")
+        active_semantic_filters.append(PS.FILTER_SEMANTIC_OPTIONS[6])
 
     if active_semantic_filters:
         allowed_types = set()
@@ -1135,20 +1165,36 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             allowed_types.update(semantic_filter_map.get(key, set()))
         filtered_df = filtered_df[filtered_df["semantic_type"].isin(allowed_types)]
     display_df = filtered_df.copy()
+    select_label = PS.GRID_COLUMN_SELECT
+    column_label = PS.GRID_COLUMN_COLUMN
+    physical_type_label = PS.GRID_COLUMN_PHYSICAL_TYPE
+    nulls_label = PS.GRID_COLUMN_NULLS
+    distinct_label = PS.GRID_COLUMN_DISTINCT
+    avg_length_label = PS.GRID_COLUMN_AVG_LENGTH
+    min_value_label = PS.GRID_COLUMN_MIN_VALUE
+    max_value_label = PS.GRID_COLUMN_MAX_VALUE
+    whitespace_label = PS.GRID_COLUMN_WHITESPACE
+    guessed_type_label = PS.GRID_COLUMN_GUESSED_TYPE
+    confidence_label = PS.GRID_COLUMN_CONFIDENCE
+    note_label = PS.GRID_COLUMN_NOTE
+
     grid_columns = [
-        "Select",
-        "Column",
-        "Physical Type",
-        "Nulls",
-        "Distinct",
-        "Avg Length",
-        "Min Value",
-        "Max Value",
-        "Whitespace %",
-        "Guessed Type",
-        "Confidence",
-        "Note",
+        select_label,
+        column_label,
+        physical_type_label,
+        nulls_label,
+        distinct_label,
+        avg_length_label,
+        min_value_label,
+        max_value_label,
+        whitespace_label,
+        guessed_type_label,
+        confidence_label,
+        note_label,
     ]
+
+    if not PROFILE_INLINE_SELECT:
+        _contract_message(PS.INLINE_SELECT_DISABLED)
     confidence_legend_html = """
     <div style="display:flex; gap:12px; align-items:center; font-size:0.85rem; margin:0.5rem 0;">
         <span style="display:flex; align-items:center; gap:4px;">
@@ -1286,29 +1332,35 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             return note
 
         display_df_local = display_df.copy()
-        display_df_local["Column"] = display_df_local.get("column_name", "").fillna("").astype(str)
-        display_df_local["Select"] = display_df_local["Column"].apply(
+        display_df_local[column_label] = (
+            display_df_local.get("column_name", "").fillna("").astype(str)
+        )
+        display_df_local[select_label] = display_df_local[column_label].apply(
             lambda name: bool(selection_state.get(_selection_key(target_table, name), False))
         )
-        display_df_local["Select"] = display_df_local["Select"].astype(bool)
-        display_df_local["Physical Type"] = (
+        display_df_local[select_label] = display_df_local[select_label].astype(bool)
+        display_df_local[physical_type_label] = (
             display_df_local.get("data_type", "").fillna("").astype(str)
         )
-        display_df_local["Nulls"] = display_df_local.apply(
+        display_df_local[nulls_label] = display_df_local.apply(
             lambda row: _format_count_with_pct(row.get("nulls"), row.get("null_pct")), axis=1
         )
-        display_df_local["Distinct"] = display_df_local.apply(
+        display_df_local[distinct_label] = display_df_local.apply(
             lambda row: _format_count_with_pct(row.get("distincts"), row.get("distinct_pct")), axis=1
         )
-        display_df_local["Avg Length"] = display_df_local.apply(
+        display_df_local[avg_length_label] = display_df_local.apply(
             _format_length_stats_cell, axis=1
         )
-        display_df_local["Min Value"] = display_df_local["min_val"].apply(_format_value_cell)
-        display_df_local["Max Value"] = display_df_local["max_val"].apply(_format_value_cell)
-        display_df_local["Guessed Type"] = display_df_local["semantic_type"].apply(
+        display_df_local[min_value_label] = display_df_local["min_val"].apply(
+            _format_value_cell
+        )
+        display_df_local[max_value_label] = display_df_local["max_val"].apply(
+            _format_value_cell
+        )
+        display_df_local[guessed_type_label] = display_df_local["semantic_type"].apply(
             _format_semantic_label
         )
-        display_df_local["Whitespace %"] = display_df_local["whitespace_pct"].apply(
+        display_df_local[whitespace_label] = display_df_local["whitespace_pct"].apply(
             _format_whitespace_display
         )
 
@@ -1324,30 +1376,30 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         display_df_local["_confidence_pct"] = display_df_local["confidence"].apply(
             _normalize_confidence
         )
-        display_df_local["Note"] = display_df_local.apply(_compose_note, axis=1)
+        display_df_local[note_label] = display_df_local.apply(_compose_note, axis=1)
         grid_container = st.container()
 
         confidence_numeric = pd.to_numeric(
             display_df_local["_confidence_pct"], errors="coerce"
         ).clip(lower=0.0, upper=100.0)
-        display_df_local["Confidence"] = confidence_numeric
+        display_df_local[confidence_label] = confidence_numeric
 
         formatted_rows: List[List[Any]] = []
         for _, row in display_df_local.iterrows():
             formatted_rows.append(
                 [
-                    bool(row.get("Select", False)),
-                    row.get("Column"),
-                    row.get("Physical Type"),
-                    row.get("Nulls"),
-                    row.get("Distinct"),
-                    row.get("Avg Length"),
-                    row.get("Min Value"),
-                    row.get("Max Value"),
-                    row.get("Whitespace %"),
-                    row.get("Guessed Type"),
-                    row.get("Confidence"),
-                    row.get("Note"),
+                    bool(row.get(select_label, False)),
+                    row.get(column_label),
+                    row.get(physical_type_label),
+                    row.get(nulls_label),
+                    row.get(distinct_label),
+                    row.get(avg_length_label),
+                    row.get(min_value_label),
+                    row.get(max_value_label),
+                    row.get(whitespace_label),
+                    row.get(guessed_type_label),
+                    row.get(confidence_label),
+                    row.get(note_label),
                 ]
             )
 
@@ -1356,26 +1408,26 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             grid_df.columns, grid_columns, "profile results grid"
         )
         if grid_render_allowed:
-            grid_df["Select"] = grid_df["Select"].fillna(False).astype(bool)
-            grid_df["Confidence"] = grid_df["Confidence"].apply(_safe_float)
+            grid_df[select_label] = grid_df[select_label].fillna(False).astype(bool)
+            grid_df[confidence_label] = grid_df[confidence_label].apply(_safe_float)
 
         with grid_container:
             st.markdown(confidence_legend_html, unsafe_allow_html=True)
-            include_map: Dict[str, bool] = {}
+            include_map = get_include_map()
             selection_editor: Optional[pd.DataFrame] = None
             if grid_render_allowed and not grid_df.empty:
-                selection_editor_df = grid_df[["Select", "Column"]].copy()
+                selection_editor_df = grid_df[[select_label, column_label]].copy()
                 selection_render_allowed = _validate_grid_columns(
                     selection_editor_df.columns,
-                    ["Select", "Column"],
+                    [select_label, column_label],
                     "profile selection editor",
                 )
                 if selection_render_allowed:
-                    selection_editor_df["Select"] = (
-                        selection_editor_df["Select"].fillna(False).astype(bool)
+                    selection_editor_df[select_label] = (
+                        selection_editor_df[select_label].fillna(False).astype(bool)
                     )
                     suspicious_keys = _detect_secondary_selector_keys(
-                        "profile_results_selection"
+                        PROFILE_RESULTS_SELECTION
                     )
                     if suspicious_keys:
                         _contract_message(
@@ -1388,14 +1440,16 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                             use_container_width=True,
                             hide_index=True,
                             column_config={
-                                "Select": st.column_config.CheckboxColumn(
-                                    "Select",
-                                    help="Toggle to include the column in downstream DQ suggestions.",
+                                select_label: st.column_config.CheckboxColumn(
+                                    select_label,
+                                    help=PS.GRID_CHECKBOX_HELP,
                                 ),
-                                "Column": st.column_config.Column("Column", disabled=True),
+                                column_label: st.column_config.Column(
+                                    column_label, disabled=True
+                                ),
                             },
-                            disabled=["Column"],
-                            key="profile_results_selection",
+                            disabled=[column_label],
+                            key=PROFILE_RESULTS_SELECTION,
                         )
 
             if (
@@ -1403,24 +1457,36 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 and isinstance(selection_editor, pd.DataFrame)
                 and not selection_editor.empty
             ):
-                select_series = selection_editor.get("Select")
-                column_series = selection_editor.get("Column")
+                select_series = selection_editor.get(select_label)
+                column_series = selection_editor.get(column_label)
                 if select_series is not None and column_series is not None:
                     select_flags = select_series.fillna(False).astype(bool)
-                    include_map = {
+                    include_map_local = {
                         str(column_series.iloc[idx]): bool(select_flags.iloc[idx])
                         for idx in range(len(select_flags))
                     }
+                    column_names = list(include_map_local.keys())
+                    if column_names:
+                        bulk_set_includes(column_names, False)
+                        for column_name, selected_flag in include_map_local.items():
+                            set_include(column_name, selected_flag)
+                        include_map = get_include_map()
 
             if grid_render_allowed and include_map:
                 for column_name, selected_flag in include_map.items():
                     key = _selection_key(target_table, column_name)
                     selection_state[key] = selected_flag
-                    grid_df.loc[grid_df["Column"] == column_name, "Select"] = selected_flag
+                    mask = grid_df[column_label] == column_name
+                    if mask.any():
+                        grid_df.loc[mask, select_label] = selected_flag
 
             if grid_render_allowed:
-                styler = grid_df.style.format({"Confidence": _format_confidence_display})
-                styler = styler.applymap(_confidence_style, subset=["Confidence"])
+                styler = grid_df.style.format(
+                    {confidence_label: _format_confidence_display}
+                )
+                styler = styler.applymap(
+                    _confidence_style, subset=[confidence_label]
+                )
                 st.dataframe(styler, hide_index=True, use_container_width=True)
 
         selection_counts = _apply_selection_state(
@@ -1434,19 +1500,25 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     else:
         empty_df = pd.DataFrame(
             {
-                column: pd.Series(dtype="bool" if column == "Select" else "object")
+                column: pd.Series(
+                    dtype="bool" if column == select_label else "object"
+                )
                 for column in grid_columns
             }
         )
         st.markdown(confidence_legend_html, unsafe_allow_html=True)
-        empty_styler = empty_df.style.format({"Confidence": _format_confidence_display})
-        empty_styler = empty_styler.applymap(_confidence_style, subset=["Confidence"])
+        empty_styler = empty_df.style.format(
+            {confidence_label: _format_confidence_display}
+        )
+        empty_styler = empty_styler.applymap(
+            _confidence_style, subset=[confidence_label]
+        )
         st.dataframe(empty_styler, hide_index=True, use_container_width=True)
 
     if filtered_df.empty:
-        st.info("No columns matched the selected filters.")
+        st.info(PS.NO_COLUMNS_MATCHED)
 
-    st.subheader("Top values by column", anchor=False)
+    st.subheader(PS.TOP_VALUES_SUBHEADER, anchor=False)
     for _, row in filtered_df.iterrows():
         values = row.get("top_values", [])
         non_nulls_value = _safe_int(row.get("non_nulls"))
@@ -1454,17 +1526,17 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         with st.expander(f"{row['column_name']} ({label_suffix})"):
             if not values:
                 if non_nulls_value is not None and non_nulls_value <= 0:
-                    st.info("No non-null values to display.")
+                    st.info(PS.INFO_NO_NON_NULL)
                 else:
-                    st.info("No top values available.")
+                    st.info(PS.INFO_NO_VALUES)
                 continue
 
             tv_df = pd.DataFrame(values)
             if tv_df.empty:
                 if non_nulls_value is not None and non_nulls_value <= 0:
-                    st.info("No non-null values to display.")
+                    st.info(PS.INFO_NO_NON_NULL)
                 else:
-                    st.info("No top values available.")
+                    st.info(PS.INFO_NO_VALUES)
                 continue
 
             # Normalize common column names when present; otherwise fall back gracefully
@@ -1478,24 +1550,30 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 if lowered in {"count", "cnt"} and count_column_name is None:
                     count_column_name = candidate
             if value_column_name is not None:
-                rename_map[value_column_name] = "Value"
+                rename_map[value_column_name] = PS.TOP_VALUES_VALUE_HEADER
             if count_column_name is not None:
-                rename_map[count_column_name] = "Count"
+                rename_map[count_column_name] = PS.TOP_VALUES_COUNT_HEADER
             if rename_map:
                 tv_df = tv_df.rename(columns=rename_map)
                 if value_column_name is not None:
-                    value_column_name = "Value"
+                    value_column_name = PS.TOP_VALUES_VALUE_HEADER
                 if count_column_name is not None:
-                    count_column_name = "Count"
+                    count_column_name = PS.TOP_VALUES_COUNT_HEADER
             elif tv_df.shape[1] == 2:
-                tv_df.columns = ["Value", "Count"]
-                value_column_name = "Value"
-                count_column_name = "Count"
+                tv_df.columns = [
+                    PS.TOP_VALUES_VALUE_HEADER,
+                    PS.TOP_VALUES_COUNT_HEADER,
+                ]
+                value_column_name = PS.TOP_VALUES_VALUE_HEADER
+                count_column_name = PS.TOP_VALUES_COUNT_HEADER
 
             if value_column_name is None and len(tv_df.columns) > 0:
                 value_column_name = tv_df.columns[0]
-            if count_column_name is None and "Count" in tv_df.columns:
-                count_column_name = "Count"
+            if (
+                count_column_name is None
+                and PS.TOP_VALUES_COUNT_HEADER in tv_df.columns
+            ):
+                count_column_name = PS.TOP_VALUES_COUNT_HEADER
 
             pct_columns = [col for col in tv_df.columns if "pct" in str(col).lower()]
 
@@ -1523,7 +1601,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
             if value_column_name and value_column_name in tv_df.columns:
                 null_bucket_mask = tv_df[value_column_name] == "__NULL__"
-                if null_bucket_mask.any():
+                if null_bucket_mask.any() and not PROFILE_TOP_VALUES_NULLS:
                     tv_df = tv_df.loc[~null_bucket_mask].copy()
                 tv_df = tv_df.loc[~tv_df[value_column_name].isna()].copy()
                 tv_df[value_column_name] = tv_df[value_column_name].replace(
@@ -1576,3 +1654,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     tv_df[col] = tv_df[col].apply(_format_percentage)
 
             st.table(tv_df)
+
+    if DEBUG_PROFILING and profile_result:
+        with st.expander(PS.DEBUG_PROFILE_PAYLOAD):
+            st.json(profile_result)
+        include_state = get_include_map()
+        if include_state:
+            with st.expander(PS.DEBUG_SELECTION_STATE):
+                st.write(include_state)


### PR DESCRIPTION
Guardrails Phase 2 — Pre-commit/CI gates, feature flags, centralized strings/keys, dev-only debug, UI contract linter, state helpers, demo safety, README governance badges

- ensure the CI workflow installs pre-commit alongside pytest and sqlfluff
- add dedicated pytest execution and snapshot integrity guard to CI before running the UI contract check
- keep guard checks wired into the shared guardrails pipeline

------
https://chatgpt.com/codex/tasks/task_e_69049b4f52e08324985926a5df0272a7