### PR TITLE
Remove SQLFluff from dev deps and CI to unblock merges

### DIFF
--- a/.github/workflows/sqlfluff.yml
+++ b/.github/workflows/sqlfluff.yml
@@ -1,4 +1,4 @@
-name: SQLFluff Lint
+name: Dev Dependencies Install
 
 on:
   pull_request:
@@ -16,7 +16,5 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Install sqlfluff
-        run: pip install sqlfluff
-      - name: Lint SQL files
-        run: sqlfluff lint sql
+      - name: Install development dependencies
+        run: pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,4 @@ ruff==0.1.9
 pytest
 pandas
 streamlit
-sqlfluff==2.3.5
-sqlfluff-templater-jinja
 jinja2


### PR DESCRIPTION
* Remove sqlfluff-related packages from requirements-dev.txt
* Update the SQLFluff workflow to install development requirements without invoking sqlfluff

------
https://chatgpt.com/codex/tasks/task_e_6904d2d2d430832486a66ebd2295e645