### PR TITLE
Fix from __future__ import annotations placement in docs_view.py

### DIFF
--- a/snapshots/views/docs_view.p
+++ b/snapshots/views/docs_view.p
@@ -18,9 +18,9 @@ Forbidden patterns:
 • Do not add new alerts, buttons, or accordions to any tab without explicit approval.
 """
 
-"""Documentation view rendering helpers."""
-
 from __future__ import annotations
+
+"""Documentation view rendering helpers."""
 
 from typing import Tuple
 

--- a/views/docs_view.py
+++ b/views/docs_view.py
@@ -18,9 +18,9 @@ Forbidden patterns:
 • Do not add new alerts, buttons, or accordions to any tab without explicit approval.
 """
 
-"""Documentation view rendering helpers."""
-
 from __future__ import annotations
+
+"""Documentation view rendering helpers."""
 
 from typing import Tuple
 


### PR DESCRIPTION
* Ensure the future annotations import is the first executable statement in `views/docs_view.py`.
* Refresh the mirrored `/snapshots` entry for the documentation view.

------
https://chatgpt.com/codex/tasks/task_e_6904d3f062888324a5c608d7879560d4