### PR TITLE
Fix circular import in profiling, extract saved-profiles helpers

### DIFF
--- a/services/profiles_repo.py
+++ b/services/profiles_repo.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from utils.meta import _q
+
+RUNS_TBL = "DQ_PROFILE_RUN"
+COLS_TBL = "DQ_PROFILE_COLUMN"
+
+
+def _tbl(meta_db: str, meta_schema: str, name: str) -> str:
+    return f"{_q(meta_db)}.{_q(meta_schema)}.{_q(name)}"
+
+
+def list_saved_profiles(session, meta_db: str, meta_schema: str, limit: int = 50) -> List[Dict[str, Any]]:
+    try:
+        sql = f"""
+            SELECT RUN_ID, RUN_AT, SUMMARY
+            FROM {_tbl(meta_db, meta_schema, RUNS_TBL)}
+            ORDER BY RUN_AT DESC
+            LIMIT {int(limit)}
+        """
+        rows = session.sql(sql).collect()
+    except Exception:
+        return []
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        if hasattr(r, "asDict"):
+            d = r.asDict()
+        else:
+            try:
+                d = {
+                    "RUN_ID": r[0],
+                    "RUN_AT": r[1] if len(r) > 1 else None,
+                    "SUMMARY": r[2] if len(r) > 2 else None,
+                }
+            except Exception:
+                d = {}
+        out.append({
+            "run_id": d.get("RUN_ID") or d.get("run_id"),
+            "run_at": d.get("RUN_AT") or d.get("run_at"),
+            "summary": d.get("SUMMARY") or d.get("summary"),
+        })
+    return out
+
+
+def load_saved_profile_run(
+    session, meta_db: str, meta_schema: str, run_id: str
+) -> Tuple[Optional[Any], List[Dict[str, Any]]]:
+    try:
+        summary_sql = f"""
+            SELECT SUMMARY
+            FROM {_tbl(meta_db, meta_schema, RUNS_TBL)}
+            WHERE RUN_ID = ?
+        """
+        rows = session.sql(summary_sql, params=[run_id]).collect()
+        if rows:
+            if hasattr(rows[0], "asDict"):
+                summary = rows[0].asDict().get("SUMMARY")
+            else:
+                try:
+                    summary = rows[0][0]
+                except Exception:
+                    summary = None
+        else:
+            summary = None
+    except Exception:
+        summary = None
+
+    try:
+        cols_sql = f"""
+            SELECT COLUMN_NAME, PROFILE, SEMANTIC_TYPE, CONFIDENCE, RATIONALE, SIGNALS, SUGGESTED_CHECKS
+            FROM {_tbl(meta_db, meta_schema, COLS_TBL)}
+            WHERE RUN_ID = ?
+            ORDER BY COLUMN_NAME
+        """
+        rows = session.sql(cols_sql, params=[run_id]).collect()
+        columns: List[Dict[str, Any]] = []
+        for r in rows:
+            if hasattr(r, "asDict"):
+                d = r.asDict()
+            else:
+                try:
+                    d = {
+                        "COLUMN_NAME": r[0],
+                        "PROFILE": r[1] if len(r) > 1 else None,
+                        "SEMANTIC_TYPE": r[2] if len(r) > 2 else None,
+                        "CONFIDENCE": r[3] if len(r) > 3 else None,
+                        "RATIONALE": r[4] if len(r) > 4 else None,
+                        "SIGNALS": r[5] if len(r) > 5 else None,
+                        "SUGGESTED_CHECKS": r[6] if len(r) > 6 else None,
+                    }
+                except Exception:
+                    d = {}
+            columns.append(
+                {
+                    "column_name": d.get("COLUMN_NAME") or d.get("column_name"),
+                    "profile": d.get("PROFILE") or d.get("profile"),
+                    "semantic_type": d.get("SEMANTIC_TYPE") or d.get("semantic_type"),
+                    "confidence": d.get("CONFIDENCE") or d.get("confidence"),
+                    "rationale": d.get("RATIONALE") or d.get("rationale"),
+                    "signals": d.get("SIGNALS") or d.get("signals"),
+                    "suggested_checks": d.get("SUGGESTED_CHECKS")
+                    or d.get("suggested_checks"),
+                }
+            )
+    except Exception:
+        columns = []
+
+    return summary, columns
+
+
+def delete_saved_profile_run(session, meta_db: str, meta_schema: str, run_id: str) -> bool:
+    try:
+        session.sql(
+            f"DELETE FROM {_tbl(meta_db, meta_schema, COLS_TBL)} WHERE RUN_ID = ?",
+            params=[run_id],
+        ).collect()
+        session.sql(
+            f"DELETE FROM {_tbl(meta_db, meta_schema, RUNS_TBL)} WHERE RUN_ID = ?",
+            params=[run_id],
+        ).collect()
+        return True
+    except Exception:
+        return False

--- a/services/profiling.py
+++ b/services/profiling.py
@@ -13,12 +13,12 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import uuid4
 
 from services.profile import _is_numeric, _is_temporal, _stringify
+from services.profiles_repo import load_saved_profile_run
 from services.semantics import clamp_confidence, truncate_note
 from utils.meta import _q
 
 __all__ = [
     "list_columns",
-    "list_saved_profiles",
     "load_profile_run",
     "run_table_profile",
     "suggest_checks_from_profile",
@@ -3335,82 +3335,42 @@ def save_profile_results(
     return str(run_id)
 
 
-def list_saved_profiles(session, meta_db: str, meta_schema: str) -> List[Dict[str, Any]]:
-    """Return recent saved profile runs from the metadata tables."""
-
-    if not session or not (meta_db and meta_schema):
-        return []
-
-    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
-    sql = (
-        f"SELECT RUN_ID, RUN_AT, SUMMARY FROM {runs_tbl} "
-        "ORDER BY RUN_AT DESC LIMIT 25"
-    )
-
-    try:
-        rows = session.sql(sql).collect()
-    except Exception:  # pragma: no cover - Snowflake specific
-        logger.debug("Unable to list saved profile runs", exc_info=True)
-        return []
-
-    results: List[Dict[str, Any]] = []
-    for row in rows:
-        if hasattr(row, "asDict"):
-            data = row.asDict()
-        else:
-            data = {}
-            try:
-                data["RUN_ID"] = row[0]
-                data["RUN_AT"] = row[1] if len(row) > 1 else None
-                data["SUMMARY"] = row[2] if len(row) > 2 else None
-            except Exception:
-                data = {}
-
-        run_id_value = data.get("RUN_ID") or data.get("run_id")
-        if not run_id_value:
-            continue
-
-        summary_payload = _coerce_variant_map(data.get("SUMMARY") or data.get("summary"))
-        results.append(
-            {
-                "run_id": str(run_id_value),
-                "run_at": data.get("RUN_AT") or data.get("run_at"),
-                "summary": summary_payload,
-            }
-        )
-
-    return results
-
-
 def load_profile_run(
     session,
     meta_db: str,
     meta_schema: str,
     run_id: str,
+    *,
+    summary_record: Optional[Any] = None,
+    column_records: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Reconstruct a saved profile run from metadata tables."""
 
     if not session or not (meta_db and meta_schema) or not run_id:
         return {}
 
-    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
-    cols_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_COLUMN"
+    summary_payload_raw: Optional[Any] = summary_record
+    column_payloads_raw: Optional[List[Dict[str, Any]]] = column_records
 
-    try:
-        run_rows = session.sql(
-            f"SELECT RUN_ID, SUMMARY FROM {runs_tbl} WHERE RUN_ID = ?",
-            params=[run_id],
-        ).collect()
-    except Exception:  # pragma: no cover - Snowflake specific
-        logger.debug("Unable to load saved profile run %s", run_id, exc_info=True)
+    if summary_payload_raw is None or column_payloads_raw is None:
+        try:
+            fetched_summary, fetched_columns = load_saved_profile_run(
+                session, meta_db, meta_schema, run_id
+            )
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.debug(
+                "Unable to fetch saved profile run %s", run_id, exc_info=True
+            )
+            fetched_summary, fetched_columns = None, []
+        if summary_payload_raw is None:
+            summary_payload_raw = fetched_summary
+        if column_payloads_raw is None:
+            column_payloads_raw = fetched_columns
+
+    if summary_payload_raw is None:
         return {}
 
-    if not run_rows:
-        return {}
-
-    summary_payload = _coerce_variant_map(
-        _extract_row_value(run_rows[0], "SUMMARY")
-    )
+    summary_payload = _coerce_variant_map(summary_payload_raw)
 
     target_table = summary_payload.get("target_table") or summary_payload.get("table")
 
@@ -3430,38 +3390,14 @@ def load_profile_run(
     top_n = _coerce_int(summary_payload.get("top_n"))
 
     columns: List[Dict[str, Any]] = []
-    try:
-        column_rows = session.sql(
-            f"""
-            SELECT COLUMN_NAME, PROFILE, SEMANTIC_TYPE, CONFIDENCE, RATIONALE, SIGNALS, SUGGESTED_CHECKS
-            FROM {cols_tbl}
-            WHERE RUN_ID = ?
-            ORDER BY COLUMN_NAME
-            """,
-            params=[run_id],
-        ).collect()
-    except Exception:  # pragma: no cover - Snowflake specific
-        logger.debug("Unable to load saved profile columns for %s", run_id, exc_info=True)
-        column_rows = []
+    column_rows = column_payloads_raw or []
 
     for row in column_rows:
-        if hasattr(row, "asDict"):
-            data = row.asDict()
-        else:
-            try:
-                data = {
-                    "COLUMN_NAME": row[0],
-                    "PROFILE": row[1] if len(row) > 1 else None,
-                    "SEMANTIC_TYPE": row[2] if len(row) > 2 else None,
-                    "CONFIDENCE": row[3] if len(row) > 3 else None,
-                    "RATIONALE": row[4] if len(row) > 4 else None,
-                    "SIGNALS": row[5] if len(row) > 5 else None,
-                    "SUGGESTED_CHECKS": row[6] if len(row) > 6 else None,
-                }
-            except Exception:
-                data = {}
+        data = dict(row) if isinstance(row, dict) else {}
 
-        profile_payload = _coerce_variant_map(data.get("PROFILE") or data.get("profile"))
+        profile_payload = _coerce_variant_map(
+            data.get("PROFILE") or data.get("profile")
+        )
         if not profile_payload:
             profile_payload = {}
 
@@ -3481,7 +3417,10 @@ def load_profile_run(
         if suggested_value is not None:
             merged["suggested_checks"] = _coerce_variant_value(suggested_value)
 
-        merged.setdefault("column_name", data.get("COLUMN_NAME") or data.get("column_name") or "")
+        merged.setdefault(
+            "column_name",
+            data.get("COLUMN_NAME") or data.get("column_name") or "",
+        )
 
         normalized = normalize_profile_row(merged)
         columns.append(normalized)

--- a/snapshots/services/profiles_repo.p
+++ b/snapshots/services/profiles_repo.p
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from utils.meta import _q
+
+RUNS_TBL = "DQ_PROFILE_RUN"
+COLS_TBL = "DQ_PROFILE_COLUMN"
+
+
+def _tbl(meta_db: str, meta_schema: str, name: str) -> str:
+    return f"{_q(meta_db)}.{_q(meta_schema)}.{_q(name)}"
+
+
+def list_saved_profiles(session, meta_db: str, meta_schema: str, limit: int = 50) -> List[Dict[str, Any]]:
+    try:
+        sql = f"""
+            SELECT RUN_ID, RUN_AT, SUMMARY
+            FROM {_tbl(meta_db, meta_schema, RUNS_TBL)}
+            ORDER BY RUN_AT DESC
+            LIMIT {int(limit)}
+        """
+        rows = session.sql(sql).collect()
+    except Exception:
+        return []
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        if hasattr(r, "asDict"):
+            d = r.asDict()
+        else:
+            try:
+                d = {
+                    "RUN_ID": r[0],
+                    "RUN_AT": r[1] if len(r) > 1 else None,
+                    "SUMMARY": r[2] if len(r) > 2 else None,
+                }
+            except Exception:
+                d = {}
+        out.append({
+            "run_id": d.get("RUN_ID") or d.get("run_id"),
+            "run_at": d.get("RUN_AT") or d.get("run_at"),
+            "summary": d.get("SUMMARY") or d.get("summary"),
+        })
+    return out
+
+
+def load_saved_profile_run(
+    session, meta_db: str, meta_schema: str, run_id: str
+) -> Tuple[Optional[Any], List[Dict[str, Any]]]:
+    try:
+        summary_sql = f"""
+            SELECT SUMMARY
+            FROM {_tbl(meta_db, meta_schema, RUNS_TBL)}
+            WHERE RUN_ID = ?
+        """
+        rows = session.sql(summary_sql, params=[run_id]).collect()
+        if rows:
+            if hasattr(rows[0], "asDict"):
+                summary = rows[0].asDict().get("SUMMARY")
+            else:
+                try:
+                    summary = rows[0][0]
+                except Exception:
+                    summary = None
+        else:
+            summary = None
+    except Exception:
+        summary = None
+
+    try:
+        cols_sql = f"""
+            SELECT COLUMN_NAME, PROFILE, SEMANTIC_TYPE, CONFIDENCE, RATIONALE, SIGNALS, SUGGESTED_CHECKS
+            FROM {_tbl(meta_db, meta_schema, COLS_TBL)}
+            WHERE RUN_ID = ?
+            ORDER BY COLUMN_NAME
+        """
+        rows = session.sql(cols_sql, params=[run_id]).collect()
+        columns: List[Dict[str, Any]] = []
+        for r in rows:
+            if hasattr(r, "asDict"):
+                d = r.asDict()
+            else:
+                try:
+                    d = {
+                        "COLUMN_NAME": r[0],
+                        "PROFILE": r[1] if len(r) > 1 else None,
+                        "SEMANTIC_TYPE": r[2] if len(r) > 2 else None,
+                        "CONFIDENCE": r[3] if len(r) > 3 else None,
+                        "RATIONALE": r[4] if len(r) > 4 else None,
+                        "SIGNALS": r[5] if len(r) > 5 else None,
+                        "SUGGESTED_CHECKS": r[6] if len(r) > 6 else None,
+                    }
+                except Exception:
+                    d = {}
+            columns.append(
+                {
+                    "column_name": d.get("COLUMN_NAME") or d.get("column_name"),
+                    "profile": d.get("PROFILE") or d.get("profile"),
+                    "semantic_type": d.get("SEMANTIC_TYPE") or d.get("semantic_type"),
+                    "confidence": d.get("CONFIDENCE") or d.get("confidence"),
+                    "rationale": d.get("RATIONALE") or d.get("rationale"),
+                    "signals": d.get("SIGNALS") or d.get("signals"),
+                    "suggested_checks": d.get("SUGGESTED_CHECKS")
+                    or d.get("suggested_checks"),
+                }
+            )
+    except Exception:
+        columns = []
+
+    return summary, columns
+
+
+def delete_saved_profile_run(session, meta_db: str, meta_schema: str, run_id: str) -> bool:
+    try:
+        session.sql(
+            f"DELETE FROM {_tbl(meta_db, meta_schema, COLS_TBL)} WHERE RUN_ID = ?",
+            params=[run_id],
+        ).collect()
+        session.sql(
+            f"DELETE FROM {_tbl(meta_db, meta_schema, RUNS_TBL)} WHERE RUN_ID = ?",
+            params=[run_id],
+        ).collect()
+        return True
+    except Exception:
+        return False

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -13,12 +13,12 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import uuid4
 
 from services.profile import _is_numeric, _is_temporal, _stringify
+from services.profiles_repo import load_saved_profile_run
 from services.semantics import clamp_confidence, truncate_note
 from utils.meta import _q
 
 __all__ = [
     "list_columns",
-    "list_saved_profiles",
     "load_profile_run",
     "run_table_profile",
     "suggest_checks_from_profile",
@@ -3335,82 +3335,42 @@ def save_profile_results(
     return str(run_id)
 
 
-def list_saved_profiles(session, meta_db: str, meta_schema: str) -> List[Dict[str, Any]]:
-    """Return recent saved profile runs from the metadata tables."""
-
-    if not session or not (meta_db and meta_schema):
-        return []
-
-    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
-    sql = (
-        f"SELECT RUN_ID, RUN_AT, SUMMARY FROM {runs_tbl} "
-        "ORDER BY RUN_AT DESC LIMIT 25"
-    )
-
-    try:
-        rows = session.sql(sql).collect()
-    except Exception:  # pragma: no cover - Snowflake specific
-        logger.debug("Unable to list saved profile runs", exc_info=True)
-        return []
-
-    results: List[Dict[str, Any]] = []
-    for row in rows:
-        if hasattr(row, "asDict"):
-            data = row.asDict()
-        else:
-            data = {}
-            try:
-                data["RUN_ID"] = row[0]
-                data["RUN_AT"] = row[1] if len(row) > 1 else None
-                data["SUMMARY"] = row[2] if len(row) > 2 else None
-            except Exception:
-                data = {}
-
-        run_id_value = data.get("RUN_ID") or data.get("run_id")
-        if not run_id_value:
-            continue
-
-        summary_payload = _coerce_variant_map(data.get("SUMMARY") or data.get("summary"))
-        results.append(
-            {
-                "run_id": str(run_id_value),
-                "run_at": data.get("RUN_AT") or data.get("run_at"),
-                "summary": summary_payload,
-            }
-        )
-
-    return results
-
-
 def load_profile_run(
     session,
     meta_db: str,
     meta_schema: str,
     run_id: str,
+    *,
+    summary_record: Optional[Any] = None,
+    column_records: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Reconstruct a saved profile run from metadata tables."""
 
     if not session or not (meta_db and meta_schema) or not run_id:
         return {}
 
-    runs_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
-    cols_tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_COLUMN"
+    summary_payload_raw: Optional[Any] = summary_record
+    column_payloads_raw: Optional[List[Dict[str, Any]]] = column_records
 
-    try:
-        run_rows = session.sql(
-            f"SELECT RUN_ID, SUMMARY FROM {runs_tbl} WHERE RUN_ID = ?",
-            params=[run_id],
-        ).collect()
-    except Exception:  # pragma: no cover - Snowflake specific
-        logger.debug("Unable to load saved profile run %s", run_id, exc_info=True)
+    if summary_payload_raw is None or column_payloads_raw is None:
+        try:
+            fetched_summary, fetched_columns = load_saved_profile_run(
+                session, meta_db, meta_schema, run_id
+            )
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.debug(
+                "Unable to fetch saved profile run %s", run_id, exc_info=True
+            )
+            fetched_summary, fetched_columns = None, []
+        if summary_payload_raw is None:
+            summary_payload_raw = fetched_summary
+        if column_payloads_raw is None:
+            column_payloads_raw = fetched_columns
+
+    if summary_payload_raw is None:
         return {}
 
-    if not run_rows:
-        return {}
-
-    summary_payload = _coerce_variant_map(
-        _extract_row_value(run_rows[0], "SUMMARY")
-    )
+    summary_payload = _coerce_variant_map(summary_payload_raw)
 
     target_table = summary_payload.get("target_table") or summary_payload.get("table")
 
@@ -3430,38 +3390,14 @@ def load_profile_run(
     top_n = _coerce_int(summary_payload.get("top_n"))
 
     columns: List[Dict[str, Any]] = []
-    try:
-        column_rows = session.sql(
-            f"""
-            SELECT COLUMN_NAME, PROFILE, SEMANTIC_TYPE, CONFIDENCE, RATIONALE, SIGNALS, SUGGESTED_CHECKS
-            FROM {cols_tbl}
-            WHERE RUN_ID = ?
-            ORDER BY COLUMN_NAME
-            """,
-            params=[run_id],
-        ).collect()
-    except Exception:  # pragma: no cover - Snowflake specific
-        logger.debug("Unable to load saved profile columns for %s", run_id, exc_info=True)
-        column_rows = []
+    column_rows = column_payloads_raw or []
 
     for row in column_rows:
-        if hasattr(row, "asDict"):
-            data = row.asDict()
-        else:
-            try:
-                data = {
-                    "COLUMN_NAME": row[0],
-                    "PROFILE": row[1] if len(row) > 1 else None,
-                    "SEMANTIC_TYPE": row[2] if len(row) > 2 else None,
-                    "CONFIDENCE": row[3] if len(row) > 3 else None,
-                    "RATIONALE": row[4] if len(row) > 4 else None,
-                    "SIGNALS": row[5] if len(row) > 5 else None,
-                    "SUGGESTED_CHECKS": row[6] if len(row) > 6 else None,
-                }
-            except Exception:
-                data = {}
+        data = dict(row) if isinstance(row, dict) else {}
 
-        profile_payload = _coerce_variant_map(data.get("PROFILE") or data.get("profile"))
+        profile_payload = _coerce_variant_map(
+            data.get("PROFILE") or data.get("profile")
+        )
         if not profile_payload:
             profile_payload = {}
 
@@ -3481,7 +3417,10 @@ def load_profile_run(
         if suggested_value is not None:
             merged["suggested_checks"] = _coerce_variant_value(suggested_value)
 
-        merged.setdefault("column_name", data.get("COLUMN_NAME") or data.get("column_name") or "")
+        merged.setdefault(
+            "column_name",
+            data.get("COLUMN_NAME") or data.get("column_name") or "",
+        )
 
         normalized = normalize_profile_row(merged)
         columns.append(normalized)

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -44,12 +44,12 @@ import streamlit as st
 
 from services.profile import build_profile_suggestion
 from services.profiling import (
-    list_saved_profiles,
     load_profile_run,
     normalize_profile_row,
     run_table_profile,
     save_profile_results,
 )
+from services.profiles_repo import list_saved_profiles, load_saved_profile_run
 from ui import keys as ui_keys
 from ui import strings as ui_strings
 from utils.flags import (
@@ -667,6 +667,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     saved_profile_runs: List[Dict[str, Any]] = []
     if saved_profiles_enabled:
         saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema)
+        if not saved_profile_runs:
+            st.info(
+                "No saved profiles found (or metadata tables haven’t been created yet). "
+                "Run and save a profile first."
+            )
 
     saved_run_lookup: Dict[str, str] = {}
     saved_run_labels: List[str] = []
@@ -766,29 +771,47 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             st.warning(ui_strings.PROFILE_LOAD_WARNING_NO_SELECTION)
         else:
             try:
-                loaded_profile = load_profile_run(
-                    session=session,
-                    meta_db=meta_db,
-                    meta_schema=meta_schema,
-                    run_id=load_selected_run_id,
+                summary_payload, column_payloads = load_saved_profile_run(
+                    session,
+                    meta_db,
+                    meta_schema,
+                    load_selected_run_id,
                 )
             except Exception as exc:  # pragma: no cover - Snowflake specific
                 st.error(ui_strings.PROFILE_LOAD_ERROR_GENERIC.format(error=exc))
             else:
-                if not loaded_profile:
-                    st.warning(ui_strings.PROFILE_WARNING_SAVED_EMPTY)
-                else:
-                    st.session_state[ui_keys.PROFILE_RESULTS_STATE] = loaded_profile
-                    st.session_state[ui_keys.PROFILE_LOADED_RUN_ID] = load_selected_run_id
-                    target_table = loaded_profile.get("target_table")
-                    if target_table:
-                        st.session_state[ui_keys.PROFILE_TARGET_FQN] = target_table
-                    st.success(
-                        ui_strings.PROFILE_SUCCESS_LOAD_SAVED.format(
-                            run_id=load_selected_run_id
-                        )
+                if summary_payload is None and not column_payloads:
+                    st.info(
+                        "No saved profiles found (or metadata tables haven’t been created yet). "
+                        "Run and save a profile first."
                     )
-                    st.rerun()
+                else:
+                    try:
+                        loaded_profile = load_profile_run(
+                            session=session,
+                            meta_db=meta_db,
+                            meta_schema=meta_schema,
+                            run_id=load_selected_run_id,
+                            summary_record=summary_payload,
+                            column_records=column_payloads,
+                        )
+                    except Exception as exc:  # pragma: no cover - Snowflake specific
+                        st.error(ui_strings.PROFILE_LOAD_ERROR_GENERIC.format(error=exc))
+                    else:
+                        if not loaded_profile:
+                            st.warning(ui_strings.PROFILE_WARNING_SAVED_EMPTY)
+                        else:
+                            st.session_state[ui_keys.PROFILE_RESULTS_STATE] = loaded_profile
+                            st.session_state[ui_keys.PROFILE_LOADED_RUN_ID] = load_selected_run_id
+                            target_table = loaded_profile.get("target_table")
+                            if target_table:
+                                st.session_state[ui_keys.PROFILE_TARGET_FQN] = target_table
+                            st.success(
+                                ui_strings.PROFILE_SUCCESS_LOAD_SAVED.format(
+                                    run_id=load_selected_run_id
+                                )
+                            )
+                            st.rerun()
 
     stored_profile_result = st.session_state.get(ui_keys.PROFILE_RESULTS_STATE)
     loaded_run_id = st.session_state.get(ui_keys.PROFILE_LOADED_RUN_ID)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -44,12 +44,12 @@ import streamlit as st
 
 from services.profile import build_profile_suggestion
 from services.profiling import (
-    list_saved_profiles,
     load_profile_run,
     normalize_profile_row,
     run_table_profile,
     save_profile_results,
 )
+from services.profiles_repo import list_saved_profiles, load_saved_profile_run
 from ui import keys as ui_keys
 from ui import strings as ui_strings
 from utils.flags import (
@@ -667,6 +667,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     saved_profile_runs: List[Dict[str, Any]] = []
     if saved_profiles_enabled:
         saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema)
+        if not saved_profile_runs:
+            st.info(
+                "No saved profiles found (or metadata tables haven’t been created yet). "
+                "Run and save a profile first."
+            )
 
     saved_run_lookup: Dict[str, str] = {}
     saved_run_labels: List[str] = []
@@ -766,29 +771,47 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             st.warning(ui_strings.PROFILE_LOAD_WARNING_NO_SELECTION)
         else:
             try:
-                loaded_profile = load_profile_run(
-                    session=session,
-                    meta_db=meta_db,
-                    meta_schema=meta_schema,
-                    run_id=load_selected_run_id,
+                summary_payload, column_payloads = load_saved_profile_run(
+                    session,
+                    meta_db,
+                    meta_schema,
+                    load_selected_run_id,
                 )
             except Exception as exc:  # pragma: no cover - Snowflake specific
                 st.error(ui_strings.PROFILE_LOAD_ERROR_GENERIC.format(error=exc))
             else:
-                if not loaded_profile:
-                    st.warning(ui_strings.PROFILE_WARNING_SAVED_EMPTY)
-                else:
-                    st.session_state[ui_keys.PROFILE_RESULTS_STATE] = loaded_profile
-                    st.session_state[ui_keys.PROFILE_LOADED_RUN_ID] = load_selected_run_id
-                    target_table = loaded_profile.get("target_table")
-                    if target_table:
-                        st.session_state[ui_keys.PROFILE_TARGET_FQN] = target_table
-                    st.success(
-                        ui_strings.PROFILE_SUCCESS_LOAD_SAVED.format(
-                            run_id=load_selected_run_id
-                        )
+                if summary_payload is None and not column_payloads:
+                    st.info(
+                        "No saved profiles found (or metadata tables haven’t been created yet). "
+                        "Run and save a profile first."
                     )
-                    st.rerun()
+                else:
+                    try:
+                        loaded_profile = load_profile_run(
+                            session=session,
+                            meta_db=meta_db,
+                            meta_schema=meta_schema,
+                            run_id=load_selected_run_id,
+                            summary_record=summary_payload,
+                            column_records=column_payloads,
+                        )
+                    except Exception as exc:  # pragma: no cover - Snowflake specific
+                        st.error(ui_strings.PROFILE_LOAD_ERROR_GENERIC.format(error=exc))
+                    else:
+                        if not loaded_profile:
+                            st.warning(ui_strings.PROFILE_WARNING_SAVED_EMPTY)
+                        else:
+                            st.session_state[ui_keys.PROFILE_RESULTS_STATE] = loaded_profile
+                            st.session_state[ui_keys.PROFILE_LOADED_RUN_ID] = load_selected_run_id
+                            target_table = loaded_profile.get("target_table")
+                            if target_table:
+                                st.session_state[ui_keys.PROFILE_TARGET_FQN] = target_table
+                            st.success(
+                                ui_strings.PROFILE_SUCCESS_LOAD_SAVED.format(
+                                    run_id=load_selected_run_id
+                                )
+                            )
+                            st.rerun()
 
     stored_profile_result = st.session_state.get(ui_keys.PROFILE_RESULTS_STATE)
     loaded_run_id = st.session_state.get(ui_keys.PROFILE_LOADED_RUN_ID)


### PR DESCRIPTION
* add `services/profiles_repo` module for listing, loading, and deleting saved profiles with defensive fallbacks
* update `services/profiling.load_profile_run` to source metadata through the repository helpers without self-imports
* point the profile view at the repository helpers and surface an empty-state banner when metadata tables are absent

------
https://chatgpt.com/codex/tasks/task_e_69059711a9a08324bd3ad2f11a7ff8df