### PR TITLE
Fix profiling dropdown labels for saved runs

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -24,10 +24,82 @@ __all__ = [
     "suggest_checks_from_profile",
     "save_profile_results",
     "normalize_profile_row",
+    "list_saved_profiles",
+    "_label_for_profile_entry",
 ]
 
 
 logger = logging.getLogger(__name__)
+
+
+def list_saved_profiles(session, meta_db: str, meta_schema: str, limit: int = 200):
+    """
+    Return a list of saved profile runs for the dropdown.
+    Each item is a dict with:
+      run_id, run_at (TIMESTAMP_LTZ -> str), target_fqn, database, schema, table_name,
+      rows_profiled, saved_at (ISO string if present), sample_pct
+    Never raises; returns [] on error.
+    """
+
+    if not session or not meta_db or not meta_schema:
+        return []
+
+    tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
+    sql = f"""
+        SELECT
+          RUN_ID,
+          TO_VARCHAR(COALESCE(RUN_AT, CURRENT_TIMESTAMP())) AS RUN_AT_STR,
+          TRY_TO_VARCHAR(SUMMARY:target_table)       AS TARGET_FQN,
+          TRY_TO_VARCHAR(SUMMARY:database)           AS DB_NAME,
+          TRY_TO_VARCHAR(SUMMARY:schema)             AS SCH_NAME,
+          TRY_TO_VARCHAR(SUMMARY:table_name)         AS TBL_NAME,
+          TRY_TO_NUMBER(SUMMARY:rows_profiled)       AS ROWS_PROFILED,
+          TRY_TO_VARCHAR(SUMMARY:saved_at)           AS SAVED_AT,
+          TRY_TO_NUMBER(SUMMARY:sample_pct)          AS SAMPLE_PCT
+        FROM {tbl}
+        ORDER BY RUN_AT DESC
+        LIMIT {int(max(1, min(limit, 1000)))}
+    """
+    try:
+        rows = session.sql(sql).collect()
+    except Exception:
+        return []
+
+    out = []
+    for r in rows:
+        d = r.asDict() if hasattr(r, "asDict") else {}
+        out.append(
+            {
+                "run_id": d.get("RUN_ID"),
+                "run_at": d.get("RUN_AT_STR"),
+                "target_fqn": (d.get("TARGET_FQN") or "").strip(),
+                "database": (d.get("DB_NAME") or "").strip('"'),
+                "schema": (d.get("SCH_NAME") or "").strip('"'),
+                "table_name": (d.get("TBL_NAME") or "").strip('"'),
+                "rows_profiled": d.get("ROWS_PROFILED"),
+                "saved_at": d.get("SAVED_AT"),
+                "sample_pct": d.get("SAMPLE_PCT"),
+            }
+        )
+    return out
+
+
+def _label_for_profile_entry(entry: dict) -> str:
+    # Prefer explicit pieces; fallback to target_fqn; never "unknown table"
+    db = (entry.get("database") or "").strip()
+    sch = (entry.get("schema") or "").strip()
+    tbl = (entry.get("table_name") or "").strip()
+    target = (entry.get("target_fqn") or "").strip().strip('"')
+    fqn = f"{db}.{sch}.{tbl}" if all([db, sch, tbl]) else (target or "(unlabeled)")
+    # Unquote any lingering double quotes
+    fqn = ".".join(p.strip().strip('"') for p in fqn.split(".") if p)
+    rows = entry.get("rows_profiled")
+    rows_txt = f"{int(rows):,}" if isinstance(rows, (int, float)) else "?"
+    pct = entry.get("sample_pct")
+    scan_txt = "full scan" if (pct is None) else f"{float(pct):.1f}%"
+    when = entry.get("saved_at") or entry.get("run_at") or ""
+    when_short = when.replace("T", " ").replace("Z", "")
+    return f"{fqn} — {rows_txt} rows — {scan_txt} — {when_short}"
 
 
 def _env_flag(name: str, default: bool = False) -> bool:

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -24,10 +24,82 @@ __all__ = [
     "suggest_checks_from_profile",
     "save_profile_results",
     "normalize_profile_row",
+    "list_saved_profiles",
+    "_label_for_profile_entry",
 ]
 
 
 logger = logging.getLogger(__name__)
+
+
+def list_saved_profiles(session, meta_db: str, meta_schema: str, limit: int = 200):
+    """
+    Return a list of saved profile runs for the dropdown.
+    Each item is a dict with:
+      run_id, run_at (TIMESTAMP_LTZ -> str), target_fqn, database, schema, table_name,
+      rows_profiled, saved_at (ISO string if present), sample_pct
+    Never raises; returns [] on error.
+    """
+
+    if not session or not meta_db or not meta_schema:
+        return []
+
+    tbl = f"{_q(meta_db)}.{_q(meta_schema)}.DQ_PROFILE_RUN"
+    sql = f"""
+        SELECT
+          RUN_ID,
+          TO_VARCHAR(COALESCE(RUN_AT, CURRENT_TIMESTAMP())) AS RUN_AT_STR,
+          TRY_TO_VARCHAR(SUMMARY:target_table)       AS TARGET_FQN,
+          TRY_TO_VARCHAR(SUMMARY:database)           AS DB_NAME,
+          TRY_TO_VARCHAR(SUMMARY:schema)             AS SCH_NAME,
+          TRY_TO_VARCHAR(SUMMARY:table_name)         AS TBL_NAME,
+          TRY_TO_NUMBER(SUMMARY:rows_profiled)       AS ROWS_PROFILED,
+          TRY_TO_VARCHAR(SUMMARY:saved_at)           AS SAVED_AT,
+          TRY_TO_NUMBER(SUMMARY:sample_pct)          AS SAMPLE_PCT
+        FROM {tbl}
+        ORDER BY RUN_AT DESC
+        LIMIT {int(max(1, min(limit, 1000)))}
+    """
+    try:
+        rows = session.sql(sql).collect()
+    except Exception:
+        return []
+
+    out = []
+    for r in rows:
+        d = r.asDict() if hasattr(r, "asDict") else {}
+        out.append(
+            {
+                "run_id": d.get("RUN_ID"),
+                "run_at": d.get("RUN_AT_STR"),
+                "target_fqn": (d.get("TARGET_FQN") or "").strip(),
+                "database": (d.get("DB_NAME") or "").strip('"'),
+                "schema": (d.get("SCH_NAME") or "").strip('"'),
+                "table_name": (d.get("TBL_NAME") or "").strip('"'),
+                "rows_profiled": d.get("ROWS_PROFILED"),
+                "saved_at": d.get("SAVED_AT"),
+                "sample_pct": d.get("SAMPLE_PCT"),
+            }
+        )
+    return out
+
+
+def _label_for_profile_entry(entry: dict) -> str:
+    # Prefer explicit pieces; fallback to target_fqn; never "unknown table"
+    db = (entry.get("database") or "").strip()
+    sch = (entry.get("schema") or "").strip()
+    tbl = (entry.get("table_name") or "").strip()
+    target = (entry.get("target_fqn") or "").strip().strip('"')
+    fqn = f"{db}.{sch}.{tbl}" if all([db, sch, tbl]) else (target or "(unlabeled)")
+    # Unquote any lingering double quotes
+    fqn = ".".join(p.strip().strip('"') for p in fqn.split(".") if p)
+    rows = entry.get("rows_profiled")
+    rows_txt = f"{int(rows):,}" if isinstance(rows, (int, float)) else "?"
+    pct = entry.get("sample_pct")
+    scan_txt = "full scan" if (pct is None) else f"{float(pct):.1f}%"
+    when = entry.get("saved_at") or entry.get("run_at") or ""
+    when_short = when.replace("T", " ").replace("Z", "")
+    return f"{fqn} — {rows_txt} rows — {scan_txt} — {when_short}"
 
 
 def _env_flag(name: str, default: bool = False) -> bool:

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -44,12 +44,14 @@ import streamlit as st
 
 from services.profile import build_profile_suggestion
 from services.profiling import (
+    _label_for_profile_entry,
+    list_saved_profiles,
     load_profile_run,
     normalize_profile_row,
     run_table_profile,
     save_profile_results,
 )
-from services.profiles_repo import list_saved_profiles, load_saved_profile_run
+from services.profiles_repo import load_saved_profile_run
 from ui import keys as ui_keys
 from ui import strings as ui_strings
 from utils.flags import (
@@ -640,49 +642,16 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         _contract_message(ui_strings.PROFILE_INLINE_SELECT_DISABLED)
         return
 
-    def _format_saved_run_label(run: Dict[str, Any]) -> str:
-        run_at = run.get("run_at")
-        if isinstance(run_at, datetime):
-            run_at_display = run_at.strftime("%Y-%m-%d %H:%M")
-        else:
-            run_at_display = str(run_at) if run_at else "Unknown time"
-        summary_payload = run.get("summary") or {}
-        if isinstance(summary_payload, dict):
-            target_table = summary_payload.get("target_table") or summary_payload.get("table")
-            top_n_raw = summary_payload.get("top_n")
-            try:
-                top_n = int(float(top_n_raw)) if top_n_raw is not None else None
-            except Exception:
-                top_n = None
-        else:
-            target_table = None
-            top_n = None
-        table_display = str(target_table or "Unknown table")
-        run_id_value = str(run.get("run_id") or "")
-        short_id = run_id_value[:8] if run_id_value else "—"
-        top_n_suffix = f" (Top {top_n})" if isinstance(top_n, (int, float)) else ""
-        return f"{run_at_display} — {table_display}{top_n_suffix} — {short_id}"
-
     saved_profiles_enabled = bool(session and meta_db and meta_schema)
     saved_profile_runs: List[Dict[str, Any]] = []
     if saved_profiles_enabled:
-        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema)
+        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema, limit=200)
         if not saved_profile_runs:
             st.info(
                 "No saved profiles found (or metadata tables haven’t been created yet). "
                 "Run and save a profile first."
             )
-
-    saved_run_lookup: Dict[str, str] = {}
-    saved_run_labels: List[str] = []
-    for run in saved_profile_runs:
-        run_id_value = run.get("run_id")
-        if not run_id_value:
-            continue
-        run_id_str = str(run_id_value)
-        label = _format_saved_run_label(run)
-        saved_run_lookup[label] = run_id_str
-        saved_run_labels.append(label)
+    dropdown_runs: List[Dict[str, Any]] = [run for run in saved_profile_runs if run.get("run_id")]
 
     controls = st.columns(3)
     suggested_pct = 10.0
@@ -734,19 +703,20 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             step=1,
             help=ui_strings.PROFILE_TOP_N_HELP.format(max_top_n=MAX_TOP_N),
         )
+    load_selected_run: Optional[Dict[str, Any]] = None
     load_selected_run_id: Optional[str] = None
     load_button_clicked = False
     with controls[2]:
-        if saved_run_labels:
-            load_options = [ui_strings.PROFILE_LOAD_SELECT_PLACEHOLDER] + saved_run_labels
-            selected_option = st.selectbox(
+        if dropdown_runs:
+            load_selected_run = st.selectbox(
                 ui_strings.PROFILE_LOAD_SELECT_LABEL,
-                options=load_options,
+                options=dropdown_runs,
+                format_func=_label_for_profile_entry,
                 key=ui_keys.PROFILE_LOAD_SELECT,
                 disabled=not saved_profiles_enabled,
+                index=None,
+                placeholder=ui_strings.PROFILE_LOAD_SELECT_PLACEHOLDER,
             )
-            if selected_option in saved_run_lookup:
-                load_selected_run_id = saved_run_lookup[selected_option]
         else:
             st.selectbox(
                 ui_strings.PROFILE_LOAD_SELECT_LABEL,
@@ -754,6 +724,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 key=ui_keys.PROFILE_LOAD_SELECT,
                 disabled=True,
             )
+        if load_selected_run and load_selected_run.get("run_id") is not None:
+            load_selected_run_id = str(load_selected_run.get("run_id"))
         load_button_clicked = st.button(
             ui_strings.PROFILE_LOAD_BUTTON_LABEL,
             key=ui_keys.PROFILE_LOAD_BUTTON,
@@ -761,7 +733,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         )
         if not saved_profiles_enabled:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_DISABLED)
-        elif not saved_run_labels:
+        elif not dropdown_runs:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_EMPTY)
 
     if load_button_clicked:

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -44,12 +44,14 @@ import streamlit as st
 
 from services.profile import build_profile_suggestion
 from services.profiling import (
+    _label_for_profile_entry,
+    list_saved_profiles,
     load_profile_run,
     normalize_profile_row,
     run_table_profile,
     save_profile_results,
 )
-from services.profiles_repo import list_saved_profiles, load_saved_profile_run
+from services.profiles_repo import load_saved_profile_run
 from ui import keys as ui_keys
 from ui import strings as ui_strings
 from utils.flags import (
@@ -640,49 +642,16 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         _contract_message(ui_strings.PROFILE_INLINE_SELECT_DISABLED)
         return
 
-    def _format_saved_run_label(run: Dict[str, Any]) -> str:
-        run_at = run.get("run_at")
-        if isinstance(run_at, datetime):
-            run_at_display = run_at.strftime("%Y-%m-%d %H:%M")
-        else:
-            run_at_display = str(run_at) if run_at else "Unknown time"
-        summary_payload = run.get("summary") or {}
-        if isinstance(summary_payload, dict):
-            target_table = summary_payload.get("target_table") or summary_payload.get("table")
-            top_n_raw = summary_payload.get("top_n")
-            try:
-                top_n = int(float(top_n_raw)) if top_n_raw is not None else None
-            except Exception:
-                top_n = None
-        else:
-            target_table = None
-            top_n = None
-        table_display = str(target_table or "Unknown table")
-        run_id_value = str(run.get("run_id") or "")
-        short_id = run_id_value[:8] if run_id_value else "—"
-        top_n_suffix = f" (Top {top_n})" if isinstance(top_n, (int, float)) else ""
-        return f"{run_at_display} — {table_display}{top_n_suffix} — {short_id}"
-
     saved_profiles_enabled = bool(session and meta_db and meta_schema)
     saved_profile_runs: List[Dict[str, Any]] = []
     if saved_profiles_enabled:
-        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema)
+        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema, limit=200)
         if not saved_profile_runs:
             st.info(
                 "No saved profiles found (or metadata tables haven’t been created yet). "
                 "Run and save a profile first."
             )
-
-    saved_run_lookup: Dict[str, str] = {}
-    saved_run_labels: List[str] = []
-    for run in saved_profile_runs:
-        run_id_value = run.get("run_id")
-        if not run_id_value:
-            continue
-        run_id_str = str(run_id_value)
-        label = _format_saved_run_label(run)
-        saved_run_lookup[label] = run_id_str
-        saved_run_labels.append(label)
+    dropdown_runs: List[Dict[str, Any]] = [run for run in saved_profile_runs if run.get("run_id")]
 
     controls = st.columns(3)
     suggested_pct = 10.0
@@ -734,19 +703,20 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             step=1,
             help=ui_strings.PROFILE_TOP_N_HELP.format(max_top_n=MAX_TOP_N),
         )
+    load_selected_run: Optional[Dict[str, Any]] = None
     load_selected_run_id: Optional[str] = None
     load_button_clicked = False
     with controls[2]:
-        if saved_run_labels:
-            load_options = [ui_strings.PROFILE_LOAD_SELECT_PLACEHOLDER] + saved_run_labels
-            selected_option = st.selectbox(
+        if dropdown_runs:
+            load_selected_run = st.selectbox(
                 ui_strings.PROFILE_LOAD_SELECT_LABEL,
-                options=load_options,
+                options=dropdown_runs,
+                format_func=_label_for_profile_entry,
                 key=ui_keys.PROFILE_LOAD_SELECT,
                 disabled=not saved_profiles_enabled,
+                index=None,
+                placeholder=ui_strings.PROFILE_LOAD_SELECT_PLACEHOLDER,
             )
-            if selected_option in saved_run_lookup:
-                load_selected_run_id = saved_run_lookup[selected_option]
         else:
             st.selectbox(
                 ui_strings.PROFILE_LOAD_SELECT_LABEL,
@@ -754,6 +724,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 key=ui_keys.PROFILE_LOAD_SELECT,
                 disabled=True,
             )
+        if load_selected_run and load_selected_run.get("run_id") is not None:
+            load_selected_run_id = str(load_selected_run.get("run_id"))
         load_button_clicked = st.button(
             ui_strings.PROFILE_LOAD_BUTTON_LABEL,
             key=ui_keys.PROFILE_LOAD_BUTTON,
@@ -761,7 +733,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         )
         if not saved_profiles_enabled:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_DISABLED)
-        elif not saved_run_labels:
+        elif not dropdown_runs:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_EMPTY)
 
     if load_button_clicked:


### PR DESCRIPTION
- add a helper to read saved profiling runs and build user-friendly labels from stored metadata
- update the profiling view to drive the saved profile selectbox from the new helper and label builder
- refresh mirrored snapshot files

------
https://chatgpt.com/codex/tasks/task_e_69088c4494548324914d208d21cb31f2