### PR TITLE
PROFILING-A8: Robust timestamp handling for saved profiles

### DIFF
--- a/snapshots/utils/state.p
+++ b/snapshots/utils/state.p
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List, MutableMapping, Sequence
 
 import streamlit as st
 
@@ -20,6 +20,109 @@ def _json_default(value: Any) -> Any:
     if isinstance(value, Decimal):
         return float(value)
     return str(value)
+
+
+_PROFILE_TIMESTAMP_FIELDS = frozenset({"created_at", "createdTs", "created"})
+
+
+def _normalize_timestamp_value(value: Any) -> str:
+    """Return an ISO 8601 string for timestamp-like values."""
+
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+def _normalize_profile_payload(value: Any) -> Any:
+    """Recursively normalise timestamp fields within saved profile payloads."""
+
+    if isinstance(value, MutableMapping):
+        return {
+            key: (
+                _normalize_timestamp_value(inner)
+                if key in _PROFILE_TIMESTAMP_FIELDS
+                else _normalize_profile_payload(inner)
+            )
+            for key, inner in value.items()
+        }
+    if isinstance(value, list):
+        return [_normalize_profile_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_normalize_profile_payload(item) for item in value)
+    if isinstance(value, set):
+        return {_normalize_profile_payload(item) for item in value}
+    return value
+
+
+def normalize_saved_profile(profile: Any) -> Dict[str, Any]:
+    """Return a saved profile payload with timestamp fields serialised to strings."""
+
+    if isinstance(profile, str):
+        try:
+            parsed = json.loads(profile)
+        except Exception:
+            return {}
+        profile = parsed
+
+    normalized = _normalize_profile_payload(profile)
+    if isinstance(normalized, MutableMapping):
+        return dict(normalized)
+    return {}
+
+
+def normalize_saved_profiles(profiles: Any) -> List[Dict[str, Any]]:
+    """Return a normalised sequence of saved profile payloads."""
+
+    if isinstance(profiles, str):
+        try:
+            parsed = json.loads(profiles)
+        except Exception:
+            return []
+        profiles = parsed
+
+    iterable: Iterable[Any]
+    if isinstance(profiles, MutableMapping):
+        container = profiles.get("runs")
+        if isinstance(container, MutableMapping):
+            iterable = container.values()
+        elif isinstance(container, Sequence) and not isinstance(
+            container, (str, bytes, bytearray)
+        ):
+            iterable = container
+        elif container is not None:
+            iterable = [container]
+        else:
+            container = profiles.get("items")
+            if isinstance(container, MutableMapping):
+                iterable = container.values()
+            elif isinstance(container, Sequence) and not isinstance(
+                container, (str, bytes, bytearray)
+            ):
+                iterable = container
+            elif container is not None:
+                iterable = [container]
+            elif any(
+                key in profiles
+                for key in ("run_id", "summary", "created", "created_at", "createdTs")
+            ):
+                iterable = [profiles]
+            else:
+                iterable = profiles.values()
+    elif isinstance(profiles, Sequence) and not isinstance(profiles, (str, bytes, bytearray)):
+        iterable = profiles
+    else:
+        return []
+
+    normalized_runs = []
+    for item in iterable:
+        normalized = normalize_saved_profile(item)
+        if normalized:
+            normalized_runs.append(normalized)
+    return normalized_runs
 
 
 _json_dumps_original = json.dumps

--- a/utils/state.py
+++ b/utils/state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List, MutableMapping, Sequence
 
 import streamlit as st
 
@@ -20,6 +20,109 @@ def _json_default(value: Any) -> Any:
     if isinstance(value, Decimal):
         return float(value)
     return str(value)
+
+
+_PROFILE_TIMESTAMP_FIELDS = frozenset({"created_at", "createdTs", "created"})
+
+
+def _normalize_timestamp_value(value: Any) -> str:
+    """Return an ISO 8601 string for timestamp-like values."""
+
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+def _normalize_profile_payload(value: Any) -> Any:
+    """Recursively normalise timestamp fields within saved profile payloads."""
+
+    if isinstance(value, MutableMapping):
+        return {
+            key: (
+                _normalize_timestamp_value(inner)
+                if key in _PROFILE_TIMESTAMP_FIELDS
+                else _normalize_profile_payload(inner)
+            )
+            for key, inner in value.items()
+        }
+    if isinstance(value, list):
+        return [_normalize_profile_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_normalize_profile_payload(item) for item in value)
+    if isinstance(value, set):
+        return {_normalize_profile_payload(item) for item in value}
+    return value
+
+
+def normalize_saved_profile(profile: Any) -> Dict[str, Any]:
+    """Return a saved profile payload with timestamp fields serialised to strings."""
+
+    if isinstance(profile, str):
+        try:
+            parsed = json.loads(profile)
+        except Exception:
+            return {}
+        profile = parsed
+
+    normalized = _normalize_profile_payload(profile)
+    if isinstance(normalized, MutableMapping):
+        return dict(normalized)
+    return {}
+
+
+def normalize_saved_profiles(profiles: Any) -> List[Dict[str, Any]]:
+    """Return a normalised sequence of saved profile payloads."""
+
+    if isinstance(profiles, str):
+        try:
+            parsed = json.loads(profiles)
+        except Exception:
+            return []
+        profiles = parsed
+
+    iterable: Iterable[Any]
+    if isinstance(profiles, MutableMapping):
+        container = profiles.get("runs")
+        if isinstance(container, MutableMapping):
+            iterable = container.values()
+        elif isinstance(container, Sequence) and not isinstance(
+            container, (str, bytes, bytearray)
+        ):
+            iterable = container
+        elif container is not None:
+            iterable = [container]
+        else:
+            container = profiles.get("items")
+            if isinstance(container, MutableMapping):
+                iterable = container.values()
+            elif isinstance(container, Sequence) and not isinstance(
+                container, (str, bytes, bytearray)
+            ):
+                iterable = container
+            elif container is not None:
+                iterable = [container]
+            elif any(
+                key in profiles
+                for key in ("run_id", "summary", "created", "created_at", "createdTs")
+            ):
+                iterable = [profiles]
+            else:
+                iterable = profiles.values()
+    elif isinstance(profiles, Sequence) and not isinstance(profiles, (str, bytes, bytearray)):
+        iterable = profiles
+    else:
+        return []
+
+    normalized_runs = []
+    for item in iterable:
+        normalized = normalize_saved_profile(item)
+        if normalized:
+            normalized_runs.append(normalized)
+    return normalized_runs
 
 
 _json_dumps_original = json.dumps


### PR DESCRIPTION
PROFILING-A8 Robust timestamp handling for saved profiles

- add helpers to normalize saved profile timestamp fields and tolerate diverse payload shapes
- expose utilities that parse individual or collections of saved profile payloads into ISO-formatted structures

------
https://chatgpt.com/codex/tasks/task_e_690a17c7b0948324a3f13c57a6b1ea2c