### PR TITLE
PROFILING-A11 Repair saved profile listing & selection

### DIFF
--- a/snapshots/utils/state.p
+++ b/snapshots/utils/state.p
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Dict, Iterable, List, MutableMapping, Sequence
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
 from uuid import UUID
 
 try:
@@ -22,6 +23,10 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency for tests
     st = _StreamlitStateStub()  # type: ignore[assignment]
 
 _INCLUDE_MAP = "profile_include_map"
+SAVED_PROFILES_STATE = "profile_saved_profiles"
+
+
+logger = logging.getLogger(__name__)
 
 
 def _json_default(value: Any) -> Any:
@@ -139,6 +144,194 @@ def normalize_saved_profiles(profiles: Any) -> List[Dict[str, Any]]:
         if normalized:
             normalized_runs.append(normalized)
     return normalized_runs
+
+
+def _clean_identifier(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().strip('"')
+
+
+def _ensure_iso_timestamp(value: Any) -> str:
+    """Return an ISO-8601-ish string from assorted timestamp inputs."""
+
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day).isoformat()
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    candidate = text
+    if "T" not in candidate and " " in candidate:
+        candidate = candidate.replace(" ", "T", 1)
+    if candidate.endswith("Z"):
+        normalized = candidate[:-1] + "+00:00"
+    else:
+        normalized = candidate
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return text
+    iso_value = parsed.isoformat()
+    if candidate.endswith("Z"):
+        return iso_value.replace("+00:00", "Z")
+    return iso_value
+
+
+def _extract_schema_table(*candidates: Any) -> Tuple[str, str]:
+    schema = ""
+    table = ""
+    for candidate in candidates:
+        if not isinstance(candidate, MutableMapping):
+            continue
+        target = _clean_identifier(
+            candidate.get("target_fqn")
+            or candidate.get("target_table")
+            or candidate.get("target")
+        )
+        if target:
+            parts = [part.strip().strip('"') for part in target.split(".") if part.strip()]
+            if len(parts) >= 2:
+                return parts[-2], parts[-1]
+        schema_value = _clean_identifier(
+            candidate.get("schema")
+            or candidate.get("schema_name")
+            or candidate.get("schemaName")
+            or candidate.get("SCH_NAME")
+        )
+        table_value = _clean_identifier(
+            candidate.get("table_name")
+            or candidate.get("table")
+            or candidate.get("TABLE_NAME")
+            or candidate.get("name")
+        )
+        if schema_value and table_value:
+            return schema_value, table_value
+    return schema, table
+
+
+def _to_mapping(value: Any) -> MutableMapping[str, Any]:
+    if isinstance(value, MutableMapping):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {}
+        if isinstance(parsed, MutableMapping):
+            return parsed
+    return {}
+
+
+def _first_text(*values: Any, default: str = "") -> str:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return default
+
+
+def list_saved_profiles(table_fqn: Optional[str]) -> List[Dict[str, Any]]:
+    """Return normalised saved profile entries for the dropdown."""
+
+    try:
+        stored = st.session_state.get(SAVED_PROFILES_STATE, [])
+        runs = normalize_saved_profiles(stored)
+        if not runs:
+            return []
+
+        filter_schema = ""
+        filter_table = ""
+        if table_fqn:
+            parts = [
+                part.strip().strip('"')
+                for part in str(table_fqn).split(".")
+                if part and str(part).strip()
+            ]
+            if len(parts) >= 2:
+                filter_schema = parts[-2].lower()
+                filter_table = parts[-1].lower()
+
+        entries: List[Dict[str, Any]] = []
+        for run in runs:
+            summary_map = _to_mapping(run.get("summary"))
+            run_id = _first_text(
+                run.get("run_id"),
+                run.get("id"),
+                summary_map.get("run_id"),
+                summary_map.get("id"),
+            )
+            if not run_id:
+                continue
+
+            schema, table = _extract_schema_table(run, summary_map)
+            if filter_schema and filter_table:
+                schema_clean = _clean_identifier(schema)
+                table_clean = _clean_identifier(table)
+                if not (schema_clean and table_clean):
+                    target = _clean_identifier(
+                        run.get("target_fqn") or summary_map.get("target_table")
+                    )
+                    if target:
+                        parts = [
+                            part.strip().strip('"')
+                            for part in target.split(".")
+                            if part.strip()
+                        ]
+                        if len(parts) >= 2:
+                            schema_clean = schema_clean or parts[-2]
+                            table_clean = table_clean or parts[-1]
+                if not (schema_clean and table_clean):
+                    continue
+                if schema_clean.lower() != filter_schema or table_clean.lower() != filter_table:
+                    continue
+
+            name = _first_text(
+                summary_map.get("profile_name"),
+                run.get("profile_name"),
+                summary_map.get("name"),
+                run.get("name"),
+                summary_map.get("target_table"),
+                run.get("target_fqn"),
+                run.get("table_name"),
+                run.get("table"),
+                default="Unnamed",
+            )
+
+            timestamp_value = _first_text(
+                summary_map.get("saved_at"),
+                run.get("saved_at"),
+                summary_map.get("run_at"),
+                run.get("run_at"),
+                summary_map.get("run_at_str"),
+                run.get("run_at_str"),
+                summary_map.get("created_at"),
+                run.get("created_at"),
+                summary_map.get("created"),
+                run.get("created"),
+                summary_map.get("createdTs"),
+                run.get("createdTs"),
+            )
+            timestamp_iso = _ensure_iso_timestamp(timestamp_value)
+
+            entries.append(
+                {
+                    "id": run_id,
+                    "name": name,
+                    "timestamp": timestamp_iso,
+                    "run": run,
+                }
+            )
+        return entries
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to list saved profiles: %s", exc, exc_info=True)
+        return []
 
 
 _json_dumps_original = json.dumps

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -45,8 +45,7 @@ import streamlit as st
 
 from services.profile import build_profile_suggestion
 from services.profiling import (
-    _label_for_profile_entry,
-    list_saved_profiles,
+    list_saved_profiles as fetch_saved_profiles,
     load_profile_run,
     normalize_profile_row,
     run_table_profile,
@@ -63,6 +62,7 @@ from utils.flags import (
     UI_CONTRACT_STRICT,
 )
 from utils.meta import get_table_row_count
+from utils.state import SAVED_PROFILES_STATE, list_saved_profiles
 from views.table_picker import session_cache_token, stateless_table_picker
 
 
@@ -669,79 +669,33 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     saved_profiles_enabled = bool(session and meta_db and meta_schema)
     saved_profile_runs: List[Dict[str, Any]] = []
+    saved_profile_entries: List[Dict[str, Any]] = []
     if saved_profiles_enabled:
-        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema, limit=200)
-        if not saved_profile_runs:
+        saved_profile_runs = fetch_saved_profiles(session, meta_db, meta_schema, limit=200)
+        st.session_state[SAVED_PROFILES_STATE] = saved_profile_runs
+        saved_profile_entries = list_saved_profiles(selected_fqn)
+        if not saved_profile_entries:
             st.info(
                 "No saved profiles found (or metadata tables haven’t been created yet). "
                 "Run and save a profile first."
             )
+    else:
+        st.session_state.pop(SAVED_PROFILES_STATE, None)
 
-    def _normalize_saved_runs(raw_runs: Any) -> List[Dict[str, Any]]:
-        if isinstance(raw_runs, dict):
-            runs_value = raw_runs.get("runs")
-            if isinstance(runs_value, dict):
-                return [entry for entry in runs_value.values() if isinstance(entry, dict)]
-            if isinstance(runs_value, list):
-                return [entry for entry in runs_value if isinstance(entry, dict)]
-            if raw_runs.get("run_id") is not None:
-                return [raw_runs]
-            return []
-        if isinstance(raw_runs, (list, tuple)):
-            return [entry for entry in raw_runs if isinstance(entry, dict)]
-        return []
-
-    def _summary_map(value: Any) -> Dict[str, Any]:
-        if isinstance(value, dict):
-            return value
-        if isinstance(value, str):
-            try:
-                parsed = json.loads(value)
-            except Exception:
-                return {}
-            if isinstance(parsed, dict):
-                return parsed
-        return {}
-
-    dropdown_runs: List[Dict[str, Any]] = []
     dropdown_run_ids: List[str] = []
     dropdown_labels: List[str] = []
-    for run_entry in _normalize_saved_runs(saved_profile_runs):
-        run_id_raw = run_entry.get("run_id")
-        if run_id_raw is None:
+    for entry in saved_profile_entries:
+        run_id = str(entry.get("id", "")).strip()
+        if not run_id:
             continue
-        run_id = str(run_id_raw)
-        summary_map = _summary_map(run_entry.get("summary"))
-        profile_name_value = (
-            summary_map.get("profile_name")
-            or summary_map.get("name")
-            or run_entry.get("profile_name")
-            or run_entry.get("name")
-            or summary_map.get("target_table")
-            or run_entry.get("target_fqn")
-            or summary_map.get("table_name")
-            or run_entry.get("table_name")
-            or run_id
-        )
-        profile_name = str(profile_name_value).strip() or run_id
-        fallback_label = _label_for_profile_entry(run_entry)
-        if fallback_label and profile_name == run_id:
-            profile_name = fallback_label.split("—", 1)[0].strip() or profile_name
-        timestamp_value = (
-            summary_map.get("saved_at")
-            or run_entry.get("saved_at")
-            or summary_map.get("run_at")
-            or run_entry.get("run_at")
-            or summary_map.get("run_at_str")
-            or run_id
-        )
-        if isinstance(timestamp_value, datetime):
-            timestamp_text = timestamp_value.isoformat()
+        timestamp_text = entry.get("timestamp") or ""
+        label_name = entry.get("name") or "Unnamed"
+        if timestamp_text:
+            label = f"{label_name} — {timestamp_text}"
         else:
-            timestamp_text = str(timestamp_value)
-        dropdown_runs.append(run_entry)
+            label = f"{label_name} — {run_id}"
         dropdown_run_ids.append(run_id)
-        dropdown_labels.append(f"{profile_name} — {timestamp_text}")
+        dropdown_labels.append(label)
 
     controls = st.columns(3)
     suggested_pct = 10.0
@@ -797,8 +751,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     load_selected_run_id: Optional[str] = None
     load_button_clicked = False
     with controls[2]:
-        if dropdown_runs:
-            option_indices = list(range(len(dropdown_runs)))
+        if dropdown_labels:
+            option_indices = list(range(len(dropdown_labels)))
 
             def _format_dropdown_option(idx: Optional[int]) -> str:
                 if isinstance(idx, int) and 0 <= idx < len(dropdown_labels):
@@ -833,7 +787,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         )
         if not saved_profiles_enabled:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_DISABLED)
-        elif not dropdown_runs:
+        elif not dropdown_labels:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_EMPTY)
 
     if load_button_clicked:

--- a/utils/state.py
+++ b/utils/state.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Dict, Iterable, List, MutableMapping, Sequence
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
 from uuid import UUID
 
 try:
@@ -22,6 +23,10 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency for tests
     st = _StreamlitStateStub()  # type: ignore[assignment]
 
 _INCLUDE_MAP = "profile_include_map"
+SAVED_PROFILES_STATE = "profile_saved_profiles"
+
+
+logger = logging.getLogger(__name__)
 
 
 def _json_default(value: Any) -> Any:
@@ -139,6 +144,194 @@ def normalize_saved_profiles(profiles: Any) -> List[Dict[str, Any]]:
         if normalized:
             normalized_runs.append(normalized)
     return normalized_runs
+
+
+def _clean_identifier(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().strip('"')
+
+
+def _ensure_iso_timestamp(value: Any) -> str:
+    """Return an ISO-8601-ish string from assorted timestamp inputs."""
+
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day).isoformat()
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    candidate = text
+    if "T" not in candidate and " " in candidate:
+        candidate = candidate.replace(" ", "T", 1)
+    if candidate.endswith("Z"):
+        normalized = candidate[:-1] + "+00:00"
+    else:
+        normalized = candidate
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return text
+    iso_value = parsed.isoformat()
+    if candidate.endswith("Z"):
+        return iso_value.replace("+00:00", "Z")
+    return iso_value
+
+
+def _extract_schema_table(*candidates: Any) -> Tuple[str, str]:
+    schema = ""
+    table = ""
+    for candidate in candidates:
+        if not isinstance(candidate, MutableMapping):
+            continue
+        target = _clean_identifier(
+            candidate.get("target_fqn")
+            or candidate.get("target_table")
+            or candidate.get("target")
+        )
+        if target:
+            parts = [part.strip().strip('"') for part in target.split(".") if part.strip()]
+            if len(parts) >= 2:
+                return parts[-2], parts[-1]
+        schema_value = _clean_identifier(
+            candidate.get("schema")
+            or candidate.get("schema_name")
+            or candidate.get("schemaName")
+            or candidate.get("SCH_NAME")
+        )
+        table_value = _clean_identifier(
+            candidate.get("table_name")
+            or candidate.get("table")
+            or candidate.get("TABLE_NAME")
+            or candidate.get("name")
+        )
+        if schema_value and table_value:
+            return schema_value, table_value
+    return schema, table
+
+
+def _to_mapping(value: Any) -> MutableMapping[str, Any]:
+    if isinstance(value, MutableMapping):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {}
+        if isinstance(parsed, MutableMapping):
+            return parsed
+    return {}
+
+
+def _first_text(*values: Any, default: str = "") -> str:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return default
+
+
+def list_saved_profiles(table_fqn: Optional[str]) -> List[Dict[str, Any]]:
+    """Return normalised saved profile entries for the dropdown."""
+
+    try:
+        stored = st.session_state.get(SAVED_PROFILES_STATE, [])
+        runs = normalize_saved_profiles(stored)
+        if not runs:
+            return []
+
+        filter_schema = ""
+        filter_table = ""
+        if table_fqn:
+            parts = [
+                part.strip().strip('"')
+                for part in str(table_fqn).split(".")
+                if part and str(part).strip()
+            ]
+            if len(parts) >= 2:
+                filter_schema = parts[-2].lower()
+                filter_table = parts[-1].lower()
+
+        entries: List[Dict[str, Any]] = []
+        for run in runs:
+            summary_map = _to_mapping(run.get("summary"))
+            run_id = _first_text(
+                run.get("run_id"),
+                run.get("id"),
+                summary_map.get("run_id"),
+                summary_map.get("id"),
+            )
+            if not run_id:
+                continue
+
+            schema, table = _extract_schema_table(run, summary_map)
+            if filter_schema and filter_table:
+                schema_clean = _clean_identifier(schema)
+                table_clean = _clean_identifier(table)
+                if not (schema_clean and table_clean):
+                    target = _clean_identifier(
+                        run.get("target_fqn") or summary_map.get("target_table")
+                    )
+                    if target:
+                        parts = [
+                            part.strip().strip('"')
+                            for part in target.split(".")
+                            if part.strip()
+                        ]
+                        if len(parts) >= 2:
+                            schema_clean = schema_clean or parts[-2]
+                            table_clean = table_clean or parts[-1]
+                if not (schema_clean and table_clean):
+                    continue
+                if schema_clean.lower() != filter_schema or table_clean.lower() != filter_table:
+                    continue
+
+            name = _first_text(
+                summary_map.get("profile_name"),
+                run.get("profile_name"),
+                summary_map.get("name"),
+                run.get("name"),
+                summary_map.get("target_table"),
+                run.get("target_fqn"),
+                run.get("table_name"),
+                run.get("table"),
+                default="Unnamed",
+            )
+
+            timestamp_value = _first_text(
+                summary_map.get("saved_at"),
+                run.get("saved_at"),
+                summary_map.get("run_at"),
+                run.get("run_at"),
+                summary_map.get("run_at_str"),
+                run.get("run_at_str"),
+                summary_map.get("created_at"),
+                run.get("created_at"),
+                summary_map.get("created"),
+                run.get("created"),
+                summary_map.get("createdTs"),
+                run.get("createdTs"),
+            )
+            timestamp_iso = _ensure_iso_timestamp(timestamp_value)
+
+            entries.append(
+                {
+                    "id": run_id,
+                    "name": name,
+                    "timestamp": timestamp_iso,
+                    "run": run,
+                }
+            )
+        return entries
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to list saved profiles: %s", exc, exc_info=True)
+        return []
 
 
 _json_dumps_original = json.dumps

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -45,8 +45,7 @@ import streamlit as st
 
 from services.profile import build_profile_suggestion
 from services.profiling import (
-    _label_for_profile_entry,
-    list_saved_profiles,
+    list_saved_profiles as fetch_saved_profiles,
     load_profile_run,
     normalize_profile_row,
     run_table_profile,
@@ -63,6 +62,7 @@ from utils.flags import (
     UI_CONTRACT_STRICT,
 )
 from utils.meta import get_table_row_count
+from utils.state import SAVED_PROFILES_STATE, list_saved_profiles
 from views.table_picker import session_cache_token, stateless_table_picker
 
 
@@ -669,79 +669,33 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
 
     saved_profiles_enabled = bool(session and meta_db and meta_schema)
     saved_profile_runs: List[Dict[str, Any]] = []
+    saved_profile_entries: List[Dict[str, Any]] = []
     if saved_profiles_enabled:
-        saved_profile_runs = list_saved_profiles(session, meta_db, meta_schema, limit=200)
-        if not saved_profile_runs:
+        saved_profile_runs = fetch_saved_profiles(session, meta_db, meta_schema, limit=200)
+        st.session_state[SAVED_PROFILES_STATE] = saved_profile_runs
+        saved_profile_entries = list_saved_profiles(selected_fqn)
+        if not saved_profile_entries:
             st.info(
                 "No saved profiles found (or metadata tables haven’t been created yet). "
                 "Run and save a profile first."
             )
+    else:
+        st.session_state.pop(SAVED_PROFILES_STATE, None)
 
-    def _normalize_saved_runs(raw_runs: Any) -> List[Dict[str, Any]]:
-        if isinstance(raw_runs, dict):
-            runs_value = raw_runs.get("runs")
-            if isinstance(runs_value, dict):
-                return [entry for entry in runs_value.values() if isinstance(entry, dict)]
-            if isinstance(runs_value, list):
-                return [entry for entry in runs_value if isinstance(entry, dict)]
-            if raw_runs.get("run_id") is not None:
-                return [raw_runs]
-            return []
-        if isinstance(raw_runs, (list, tuple)):
-            return [entry for entry in raw_runs if isinstance(entry, dict)]
-        return []
-
-    def _summary_map(value: Any) -> Dict[str, Any]:
-        if isinstance(value, dict):
-            return value
-        if isinstance(value, str):
-            try:
-                parsed = json.loads(value)
-            except Exception:
-                return {}
-            if isinstance(parsed, dict):
-                return parsed
-        return {}
-
-    dropdown_runs: List[Dict[str, Any]] = []
     dropdown_run_ids: List[str] = []
     dropdown_labels: List[str] = []
-    for run_entry in _normalize_saved_runs(saved_profile_runs):
-        run_id_raw = run_entry.get("run_id")
-        if run_id_raw is None:
+    for entry in saved_profile_entries:
+        run_id = str(entry.get("id", "")).strip()
+        if not run_id:
             continue
-        run_id = str(run_id_raw)
-        summary_map = _summary_map(run_entry.get("summary"))
-        profile_name_value = (
-            summary_map.get("profile_name")
-            or summary_map.get("name")
-            or run_entry.get("profile_name")
-            or run_entry.get("name")
-            or summary_map.get("target_table")
-            or run_entry.get("target_fqn")
-            or summary_map.get("table_name")
-            or run_entry.get("table_name")
-            or run_id
-        )
-        profile_name = str(profile_name_value).strip() or run_id
-        fallback_label = _label_for_profile_entry(run_entry)
-        if fallback_label and profile_name == run_id:
-            profile_name = fallback_label.split("—", 1)[0].strip() or profile_name
-        timestamp_value = (
-            summary_map.get("saved_at")
-            or run_entry.get("saved_at")
-            or summary_map.get("run_at")
-            or run_entry.get("run_at")
-            or summary_map.get("run_at_str")
-            or run_id
-        )
-        if isinstance(timestamp_value, datetime):
-            timestamp_text = timestamp_value.isoformat()
+        timestamp_text = entry.get("timestamp") or ""
+        label_name = entry.get("name") or "Unnamed"
+        if timestamp_text:
+            label = f"{label_name} — {timestamp_text}"
         else:
-            timestamp_text = str(timestamp_value)
-        dropdown_runs.append(run_entry)
+            label = f"{label_name} — {run_id}"
         dropdown_run_ids.append(run_id)
-        dropdown_labels.append(f"{profile_name} — {timestamp_text}")
+        dropdown_labels.append(label)
 
     controls = st.columns(3)
     suggested_pct = 10.0
@@ -797,8 +751,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     load_selected_run_id: Optional[str] = None
     load_button_clicked = False
     with controls[2]:
-        if dropdown_runs:
-            option_indices = list(range(len(dropdown_runs)))
+        if dropdown_labels:
+            option_indices = list(range(len(dropdown_labels)))
 
             def _format_dropdown_option(idx: Optional[int]) -> str:
                 if isinstance(idx, int) and 0 <= idx < len(dropdown_labels):
@@ -833,7 +787,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         )
         if not saved_profiles_enabled:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_DISABLED)
-        elif not dropdown_runs:
+        elif not dropdown_labels:
             st.caption(ui_strings.PROFILE_LOAD_CAPTION_EMPTY)
 
     if load_button_clicked:


### PR DESCRIPTION
PROFILING-A11 Repair saved profile listing & selection
- Normalized saved profile listings with ISO timestamps, stable IDs, and schema/table-aware filtering in session state.
- Updated the profile view dropdown to consume normalized entries and reliably map selections back to saved runs.
- Refreshed mirrored snapshots to capture the adjusted state helpers and profile UI wiring.


------
https://chatgpt.com/codex/tasks/task_e_690c23a3f6c48324ad30002040129758