### PR TITLE
PROFILING-A13: Adapt view to list_saved_profiles return schema

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -673,11 +673,21 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     if saved_profiles_enabled:
         saved_profile_runs = fetch_saved_profiles(session, meta_db, meta_schema, limit=200)
         st.session_state[SAVED_PROFILES_STATE] = saved_profile_runs
-        saved_profile_entries = list_saved_profiles(selected_fqn)
-        if not saved_profile_entries:
-            st.info(
-                "No saved profiles found (or metadata tables haven’t been created yet). "
-                "Run and save a profile first."
+        profile_list_response = list_saved_profiles(selected_fqn)
+        if profile_list_response.get("ok"):
+            saved_profile_entries = profile_list_response.get("items", [])
+            if not saved_profile_entries:
+                st.info(
+                    "No saved profiles found (or metadata tables haven’t been created yet). "
+                    "Run and save a profile first."
+                )
+        else:
+            logging.warning(
+                "Saved profile listing failed",
+                extra={
+                    "table_fqn": selected_fqn or "",
+                    "err": profile_list_response.get("err"),
+                },
             )
     else:
         st.session_state.pop(SAVED_PROFILES_STATE, None)
@@ -688,10 +698,14 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         run_id = str(entry.get("id", "")).strip()
         if not run_id:
             continue
-        timestamp_text = entry.get("timestamp") or ""
         label_name = entry.get("name") or "Unnamed"
-        if timestamp_text:
-            label = f"{label_name} — {timestamp_text}"
+        created_at_iso = (
+            entry.get("created_at_iso")
+            or entry.get("timestamp")
+            or ""
+        )
+        if created_at_iso:
+            label = f"{label_name} — {created_at_iso}"
         else:
             label = f"{label_name} — {run_id}"
         dropdown_run_ids.append(run_id)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -673,11 +673,21 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
     if saved_profiles_enabled:
         saved_profile_runs = fetch_saved_profiles(session, meta_db, meta_schema, limit=200)
         st.session_state[SAVED_PROFILES_STATE] = saved_profile_runs
-        saved_profile_entries = list_saved_profiles(selected_fqn)
-        if not saved_profile_entries:
-            st.info(
-                "No saved profiles found (or metadata tables haven’t been created yet). "
-                "Run and save a profile first."
+        profile_list_response = list_saved_profiles(selected_fqn)
+        if profile_list_response.get("ok"):
+            saved_profile_entries = profile_list_response.get("items", [])
+            if not saved_profile_entries:
+                st.info(
+                    "No saved profiles found (or metadata tables haven’t been created yet). "
+                    "Run and save a profile first."
+                )
+        else:
+            logging.warning(
+                "Saved profile listing failed",
+                extra={
+                    "table_fqn": selected_fqn or "",
+                    "err": profile_list_response.get("err"),
+                },
             )
     else:
         st.session_state.pop(SAVED_PROFILES_STATE, None)
@@ -688,10 +698,14 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         run_id = str(entry.get("id", "")).strip()
         if not run_id:
             continue
-        timestamp_text = entry.get("timestamp") or ""
         label_name = entry.get("name") or "Unnamed"
-        if timestamp_text:
-            label = f"{label_name} — {timestamp_text}"
+        created_at_iso = (
+            entry.get("created_at_iso")
+            or entry.get("timestamp")
+            or ""
+        )
+        if created_at_iso:
+            label = f"{label_name} — {created_at_iso}"
         else:
             label = f"{label_name} — {run_id}"
         dropdown_run_ids.append(run_id)


### PR DESCRIPTION
PROFILING-A13: View wiring to new return schema

- Consume the structured `{ok, items}` response when retrieving saved profiles for the dropdown.
- Log failed lookups while leaving the dropdown empty and maintain existing UI messaging.
- Refresh the mirrored profile view snapshot.


------
https://chatgpt.com/codex/tasks/task_e_690c2f7efb748324a55648e6fd921e0d