### PR TITLE
PROFILING-A20 Initialize logging globally

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -31,6 +31,17 @@ Forbidden patterns:
 • Do not allow manual editing of the configuration name or target caption formatting.
 """
 
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+    force=True,
+)
+logging.getLogger("snowflake").setLevel(logging.WARNING)
+
 import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -31,6 +31,17 @@ Forbidden patterns:
 • Do not allow manual editing of the configuration name or target caption formatting.
 """
 
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+    force=True,
+)
+logging.getLogger("snowflake").setLevel(logging.WARNING)
+
 import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple


### PR DESCRIPTION
* Initialize logging at INFO level with stdout stream handler in `streamlit_app.py`.
* Reduce Snowflake logger noise by setting its level to WARNING.
* Update mirrored snapshot for `streamlit_app.py`.


------
https://chatgpt.com/codex/tasks/task_e_690c35d59c588324a0482bcf38bbe055