### PR TITLE
PROFILING-A21 Developer debug flag for profiling

### DIFF
--- a/snapshots/utils/flags.p
+++ b/snapshots/utils/flags.p
@@ -17,6 +17,7 @@ def flag(name: str, default: bool = False) -> bool:
 
 UI_CONTRACT_STRICT = flag("UI_CONTRACT_STRICT", False)
 DEMO_LOCK = flag("DEMO_LOCK", False)
-DEBUG_PROFILING = flag("DEBUG_PROFILING_PAYLOAD", False)
+DEBUG_PROFILING: bool = False
+"""When True, Profile view shows a developer debug expander with diagnostics. Default False to avoid UI changes."""
 PROFILE_INLINE_SELECT = flag("PROFILE_INLINE_SELECT", True)
 PROFILE_TOP_VALUES_NULLS = flag("PROFILE_TOP_VALUES_NULLS", True)

--- a/utils/flags.py
+++ b/utils/flags.py
@@ -17,6 +17,7 @@ def flag(name: str, default: bool = False) -> bool:
 
 UI_CONTRACT_STRICT = flag("UI_CONTRACT_STRICT", False)
 DEMO_LOCK = flag("DEMO_LOCK", False)
-DEBUG_PROFILING = flag("DEBUG_PROFILING_PAYLOAD", False)
+DEBUG_PROFILING: bool = False
+"""When True, Profile view shows a developer debug expander with diagnostics. Default False to avoid UI changes."""
 PROFILE_INLINE_SELECT = flag("PROFILE_INLINE_SELECT", True)
 PROFILE_TOP_VALUES_NULLS = flag("PROFILE_TOP_VALUES_NULLS", True)


### PR DESCRIPTION
- add a developer-only DEBUG_PROFILING flag defaulting to False
- document the debug panel flag for profiling diagnostics
- mirror updated snapshots for utils/flags.py

------
https://chatgpt.com/codex/tasks/task_e_690c37dbb3208324bea16cdc9a1e2140