### PR TITLE
PROFILING-A32 Debug: show canonical FQN and store result in panel

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1761,6 +1761,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         diagnostics_response = profile_list_response or list_saved_profiles(
             current_table_fqn
         )
+        if not isinstance(diagnostics_response, dict):
+            diagnostics_response = {}
         store_verification = verify_profiles_store()
         store_ok = bool(store_verification.get("ok"))
         store_err = store_verification.get("err")

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1761,6 +1761,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         diagnostics_response = profile_list_response or list_saved_profiles(
             current_table_fqn
         )
+        if not isinstance(diagnostics_response, dict):
+            diagnostics_response = {}
         store_verification = verify_profiles_store()
         store_ok = bool(store_verification.get("ok"))
         store_err = store_verification.get("err")


### PR DESCRIPTION
- Guard the profiling diagnostics response to ensure debug rendering proceeds when the list call returns a non-dict payload.
- Preserve the debug panel output of the canonical FQN and profiles store verification details.

------
https://chatgpt.com/codex/tasks/task_e_690c5fde09c08324bed91865391815a3