### PR TITLE
PROFILING-A55 Set PROFILES_TABLE_FQN to final table

### DIFF
--- a/snapshots/utils/config.p
+++ b/snapshots/utils/config.p
@@ -6,4 +6,15 @@ from .configs import *  # noqa
 PROFILES_TABLE_FQN = "ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_SAVED_PROFILES"
 """Central source of truth for saved profiles table."""
 
-__all__ = [*globals().get("__all__", []), "PROFILES_TABLE_FQN"]
+ALLOW_CREATE_PROFILES_TABLE = False
+"""DDL is managed manually; do not auto-create the profiles table."""
+
+PROFILES_TABLE_GRANT_SELECT_TO = None
+"""No automatic grants are applied to the profiles table."""
+
+__all__ = [
+    *globals().get("__all__", []),
+    "PROFILES_TABLE_FQN",
+    "ALLOW_CREATE_PROFILES_TABLE",
+    "PROFILES_TABLE_GRANT_SELECT_TO",
+]

--- a/utils/config.py
+++ b/utils/config.py
@@ -6,4 +6,15 @@ from .configs import *  # noqa
 PROFILES_TABLE_FQN = "ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_SAVED_PROFILES"
 """Central source of truth for saved profiles table."""
 
-__all__ = [*globals().get("__all__", []), "PROFILES_TABLE_FQN"]
+ALLOW_CREATE_PROFILES_TABLE = False
+"""DDL is managed manually; do not auto-create the profiles table."""
+
+PROFILES_TABLE_GRANT_SELECT_TO = None
+"""No automatic grants are applied to the profiles table."""
+
+__all__ = [
+    *globals().get("__all__", []),
+    "PROFILES_TABLE_FQN",
+    "ALLOW_CREATE_PROFILES_TABLE",
+    "PROFILES_TABLE_GRANT_SELECT_TO",
+]


### PR DESCRIPTION
PROFILING-A55 Set PROFILES_TABLE_FQN to final table

- Point PROFILES_TABLE_FQN at ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_SAVED_PROFILES and disable auto DDL/grants for profiles table
- Regenerated snapshots mirror

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e8e0e1b88324bc4f8be7ce8df302)