### PR TITLE
PROFILING-A61 Fix invalid regex (no lookahead) in checks

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 from services.profile import _is_numeric, _is_temporal, _stringify
 from services.profiles_repo import load_saved_profile_run
 from services.semantics import clamp_confidence, truncate_note
+from utils.checkdefs import _re2_ipv4_pattern
 from utils.meta import _q
 from utils.state import _json_dumps_safe
 
@@ -155,7 +156,7 @@ SEMANTIC_REGEX_PATTERNS: Dict[str, str] = {
     "bic": r"^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$",
     "uuid": r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
     "url": r"^(https?|ftp)://[^\s/$.?#].[^\s]*$",
-    "ipv4": r"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(?!$)|$)){4}$",
+    "ipv4": _re2_ipv4_pattern(),
     "phone_e164": r"^\+[1-9][0-9]{1,14}$",
 }
 

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -15,6 +15,7 @@ from uuid import uuid4
 from services.profile import _is_numeric, _is_temporal, _stringify
 from services.profiles_repo import load_saved_profile_run
 from services.semantics import clamp_confidence, truncate_note
+from utils.checkdefs import _re2_ipv4_pattern
 from utils.meta import _q
 from utils.state import _json_dumps_safe
 
@@ -155,7 +156,7 @@ SEMANTIC_REGEX_PATTERNS: Dict[str, str] = {
     "bic": r"^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$",
     "uuid": r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
     "url": r"^(https?|ftp)://[^\s/$.?#].[^\s]*$",
-    "ipv4": r"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(?!$)|$)){4}$",
+    "ipv4": _re2_ipv4_pattern(),
     "phone_e164": r"^\+[1-9][0-9]{1,14}$",
 }
 

--- a/snapshots/utils/checkdefs.p
+++ b/snapshots/utils/checkdefs.p
@@ -59,7 +59,13 @@ def _q(ident: str) -> str:
     return '.'.join(_quote_identifier(part) for part in parts)
 
 
+# Snowflake uses RE2; no lookahead/lookbehind/backrefs.
 _NUMERIC_RE = re.compile(r"^[+-]?(?:\d+)(?:\.\d+)?$")
+
+
+def _re2_ipv4_pattern() -> str:
+    octet = r"(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])"
+    return rf"^{octet}(?:\\.{octet}){{3}}$"
 
 
 def _format_literal(value: object) -> str:

--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -59,7 +59,13 @@ def _q(ident: str) -> str:
     return '.'.join(_quote_identifier(part) for part in parts)
 
 
+# Snowflake uses RE2; no lookahead/lookbehind/backrefs.
 _NUMERIC_RE = re.compile(r"^[+-]?(?:\d+)(?:\.\d+)?$")
+
+
+def _re2_ipv4_pattern() -> str:
+    octet = r"(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])"
+    return rf"^{octet}(?:\\.{octet}){{3}}$"
 
 
 def _format_literal(value: object) -> str:


### PR DESCRIPTION
PROFILING-A61 Fix invalid regex (no lookahead) in checks

- add a reusable helper that emits a Snowflake RE2-safe IPv4 regex and document the regex limitations
- switch profiling semantic type detection to use the helper-generated pattern and refresh mirrored snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130b45f43c8324b597df73301c2fe0)