### PR TITLE
PROFILING-A60 Verify row exists after save_profile

### DIFF
--- a/snapshots/utils/state.p
+++ b/snapshots/utils/state.p
@@ -765,13 +765,10 @@ def save_profile(table_fqn: str, name: Optional[str], payload: Any) -> Dict[str,
     )
     params = [run_id, canon, profile_name, payload_json]
 
+    session = _get_session()
+
     try:
-        _get_session().sql(sql, params=params).collect()
-        logger.info(
-            "Saved profile payload",
-            extra={"op": "save_profile", "id": run_id, "fqn": canon},
-        )
-        return {"ok": True, "id": run_id}
+        session.sql(sql, params=params).collect()
     except Exception as exc:  # pragma: no cover - defensive
         err_msg = str(exc) or "profile_save_failed"
         logger.error(
@@ -780,6 +777,34 @@ def save_profile(table_fqn: str, name: Optional[str], payload: Any) -> Dict[str,
             exc_info=True,
         )
         return {"ok": False, "err": err_msg}
+
+    verify_sql = (
+        f"SELECT 1 FROM {PROFILES_TABLE_FQN} WHERE ID = ? LIMIT 1"
+    )
+
+    try:
+        verification_rows = session.sql(verify_sql, params=[run_id]).collect()
+    except Exception as exc:  # pragma: no cover - defensive
+        err_msg = str(exc) or "save_verify_failed"
+        logger.error(
+            "Failed to verify saved profile",
+            extra={**context, "err": err_msg},
+            exc_info=True,
+        )
+        return {"ok": False, "err": "save_verify_failed"}
+
+    if not verification_rows:
+        logger.error(
+            "Saved profile verification failed",
+            extra={**context, "err": "save_verify_failed"},
+        )
+        return {"ok": False, "err": "save_verify_failed"}
+
+    logger.info(
+        "Saved profile payload",
+        extra={"op": "save_profile", "id": run_id, "fqn": canon},
+    )
+    return {"ok": True, "id": run_id}
 
 
 

--- a/utils/state.py
+++ b/utils/state.py
@@ -765,13 +765,10 @@ def save_profile(table_fqn: str, name: Optional[str], payload: Any) -> Dict[str,
     )
     params = [run_id, canon, profile_name, payload_json]
 
+    session = _get_session()
+
     try:
-        _get_session().sql(sql, params=params).collect()
-        logger.info(
-            "Saved profile payload",
-            extra={"op": "save_profile", "id": run_id, "fqn": canon},
-        )
-        return {"ok": True, "id": run_id}
+        session.sql(sql, params=params).collect()
     except Exception as exc:  # pragma: no cover - defensive
         err_msg = str(exc) or "profile_save_failed"
         logger.error(
@@ -780,6 +777,34 @@ def save_profile(table_fqn: str, name: Optional[str], payload: Any) -> Dict[str,
             exc_info=True,
         )
         return {"ok": False, "err": err_msg}
+
+    verify_sql = (
+        f"SELECT 1 FROM {PROFILES_TABLE_FQN} WHERE ID = ? LIMIT 1"
+    )
+
+    try:
+        verification_rows = session.sql(verify_sql, params=[run_id]).collect()
+    except Exception as exc:  # pragma: no cover - defensive
+        err_msg = str(exc) or "save_verify_failed"
+        logger.error(
+            "Failed to verify saved profile",
+            extra={**context, "err": err_msg},
+            exc_info=True,
+        )
+        return {"ok": False, "err": "save_verify_failed"}
+
+    if not verification_rows:
+        logger.error(
+            "Saved profile verification failed",
+            extra={**context, "err": "save_verify_failed"},
+        )
+        return {"ok": False, "err": "save_verify_failed"}
+
+    logger.info(
+        "Saved profile payload",
+        extra={"op": "save_profile", "id": run_id, "fqn": canon},
+    )
+    return {"ok": True, "id": run_id}
 
 
 


### PR DESCRIPTION
PROFILING-A60 Verify row exists after save_profile

- Add a post-insert verification query so save_profile only reports success when the inserted row is readable.
- Log verification failures and surface a save_verify_failed response when the row is missing or unreadable.
- Refresh the mirrored snapshot for utils/state.py.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130c604548832489a1c295541e37e7)