### PR TITLE
PROFILING-A66F — Fix timeout setter (no params, validated literal)

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -41,9 +41,18 @@ def _get_session():
 
 
 def _with_extended_timeout(seconds: int):
+    try:
+        timeout = int(seconds)
+    except (TypeError, ValueError):
+        timeout = 0
+
+    if timeout < 1:
+        timeout = 1
+    if timeout > 3600:
+        timeout = 3600
+
     _get_session().sql(
-        "ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ?",
-        params=[seconds],
+        f"ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = {timeout}"
     ).collect()
 
 

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -41,9 +41,18 @@ def _get_session():
 
 
 def _with_extended_timeout(seconds: int):
+    try:
+        timeout = int(seconds)
+    except (TypeError, ValueError):
+        timeout = 0
+
+    if timeout < 1:
+        timeout = 1
+    if timeout > 3600:
+        timeout = 3600
+
     _get_session().sql(
-        "ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ?",
-        params=[seconds],
+        f"ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = {timeout}"
     ).collect()
 
 


### PR DESCRIPTION
- clamp the session timeout value to an acceptable range before issuing ALTER SESSION
- send the STATEMENT_TIMEOUT_IN_SECONDS value as a sanitized literal instead of a bound parameter
- refresh mirrored snapshot for services/profiling.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913389b8bf08324b02a890e4cf8ebad)