### PR TITLE
PROFILING-A61b: IPv4 regex param binding safeguards

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -1,13 +1,40 @@
 # services/runner.py
-from typing import Dict, Any, List
+import json
+from typing import Any, Dict, List, Sequence
+from utils.checkdefs import _RULE_PARAMS_KEY
 from utils.meta import DQCheck, DQConfig
 
 AGG_PREFIX = "AGG:"
+
+
+def _extract_rule_params(check: DQCheck) -> Sequence[Any]:
+    if not check.params_json:
+        return ()
+    try:
+        parsed = json.loads(check.params_json)
+    except Exception:
+        return ()
+    if not isinstance(parsed, dict):
+        return ()
+    params = parsed.get(_RULE_PARAMS_KEY, ())
+    if params is None:
+        return ()
+    if isinstance(params, (list, tuple)):
+        return tuple(params)
+    return (params,)
+
+
+def _sql_with_params(session, sql: str, params: Sequence[Any]):
+    if params:
+        return session.sql(sql, params=tuple(params))
+    return session.sql(sql)
+
 
 def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
     results: Dict[str, Any] = {"config_id": cfg.config_id, "checks": []}
     for chk in checks:
         rule = (chk.rule_expr or '').strip()
+        rule_params = _extract_rule_params(chk)
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()
             if sql:
@@ -25,7 +52,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
                 while sql and sql[-1] in {'"', "'"}:
                     sql = sql[:-1].rstrip()
             try:
-                df = session.sql(sql)
+                df = _sql_with_params(session, sql, rule_params)
             except Exception as exc:
                 raise RuntimeError(f"Failed to execute aggregate check SQL: {exc}\nSQL:\n{sql}") from exc
             r = df.collect()[0]
@@ -42,7 +69,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
         else:
             failure_sql = f"SELECT COUNT(*) AS FAILURES FROM {chk.table_fqn} WHERE NOT ({rule})"
             try:
-                df = session.sql(failure_sql)
+                df = _sql_with_params(session, failure_sql, rule_params)
             except Exception as exc:
                 raise RuntimeError(f"Failed to execute row check SQL: {exc}\nSQL:\n{failure_sql}") from exc
             failures = int(df.collect()[0][0])
@@ -52,7 +79,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
                     f"SELECT * FROM {chk.table_fqn} WHERE NOT ({rule}) LIMIT {int(chk.sample_rows)}"
                 )
                 try:
-                    s_df = session.sql(sample_sql)
+                    s_df = _sql_with_params(session, sample_sql, rule_params)
                 except Exception as exc:
                     raise RuntimeError(f"Failed to fetch sample rows using SQL: {exc}\nSQL:\n{sample_sql}") from exc
                 sample = [r.asDict() if hasattr(r, 'asDict') else dict(r) for r in s_df.collect()]

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -1,13 +1,40 @@
 # services/runner.py
-from typing import Dict, Any, List
+import json
+from typing import Any, Dict, List, Sequence
+from utils.checkdefs import _RULE_PARAMS_KEY
 from utils.meta import DQCheck, DQConfig
 
 AGG_PREFIX = "AGG:"
+
+
+def _extract_rule_params(check: DQCheck) -> Sequence[Any]:
+    if not check.params_json:
+        return ()
+    try:
+        parsed = json.loads(check.params_json)
+    except Exception:
+        return ()
+    if not isinstance(parsed, dict):
+        return ()
+    params = parsed.get(_RULE_PARAMS_KEY, ())
+    if params is None:
+        return ()
+    if isinstance(params, (list, tuple)):
+        return tuple(params)
+    return (params,)
+
+
+def _sql_with_params(session, sql: str, params: Sequence[Any]):
+    if params:
+        return session.sql(sql, params=tuple(params))
+    return session.sql(sql)
+
 
 def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
     results: Dict[str, Any] = {"config_id": cfg.config_id, "checks": []}
     for chk in checks:
         rule = (chk.rule_expr or '').strip()
+        rule_params = _extract_rule_params(chk)
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()
             if sql:
@@ -25,7 +52,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
                 while sql and sql[-1] in {'"', "'"}:
                     sql = sql[:-1].rstrip()
             try:
-                df = session.sql(sql)
+                df = _sql_with_params(session, sql, rule_params)
             except Exception as exc:
                 raise RuntimeError(f"Failed to execute aggregate check SQL: {exc}\nSQL:\n{sql}") from exc
             r = df.collect()[0]
@@ -42,7 +69,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
         else:
             failure_sql = f"SELECT COUNT(*) AS FAILURES FROM {chk.table_fqn} WHERE NOT ({rule})"
             try:
-                df = session.sql(failure_sql)
+                df = _sql_with_params(session, failure_sql, rule_params)
             except Exception as exc:
                 raise RuntimeError(f"Failed to execute row check SQL: {exc}\nSQL:\n{failure_sql}") from exc
             failures = int(df.collect()[0][0])
@@ -52,7 +79,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
                     f"SELECT * FROM {chk.table_fqn} WHERE NOT ({rule}) LIMIT {int(chk.sample_rows)}"
                 )
                 try:
-                    s_df = session.sql(sample_sql)
+                    s_df = _sql_with_params(session, sample_sql, rule_params)
                 except Exception as exc:
                     raise RuntimeError(f"Failed to fetch sample rows using SQL: {exc}\nSQL:\n{sample_sql}") from exc
                 sample = [r.asDict() if hasattr(r, 'asDict') else dict(r) for r in s_df.collect()]

--- a/snapshots/utils/checkdefs.p
+++ b/snapshots/utils/checkdefs.p
@@ -1,4 +1,6 @@
 import re
+from dataclasses import dataclass
+from typing import Iterator, Tuple
 
 
 SUPPORTED_COLUMN_CHECKS = ["UNIQUE","NULL_COUNT","MIN_MAX","WHITESPACE","FORMAT_DISTRIBUTION","VALUE_DISTRIBUTION"]
@@ -11,6 +13,19 @@ _WRAPPING_DELIMS = {
     '`': '`',
     '[': ']',
 }
+
+_RULE_PARAMS_KEY = "__rule_params__"
+
+
+@dataclass(frozen=True)
+class RuleExpr:
+    sql: str
+    is_aggregate: bool
+    params: Tuple[object, ...] = ()
+
+    def __iter__(self) -> Iterator[object]:
+        yield self.sql
+        yield self.is_aggregate
 
 
 def _strip_wrapping_delimiters(value: str) -> str:
@@ -96,6 +111,10 @@ def build_rule_for_column_check(fqn: str, col: str, ctype: str, params: dict):
     colq = f'"{col}"'
     # return row predicate SQL, is_agg=False
     ctype = (ctype or "").upper()
+    if params is None:
+        params = {}
+    else:
+        params.pop(_RULE_PARAMS_KEY, None)
     if ctype == "UNIQUE":
         ignore_nulls = bool(params.get("ignore_nulls", True))
         if ignore_nulls:
@@ -121,18 +140,27 @@ def build_rule_for_column_check(fqn: str, col: str, ctype: str, params: dict):
         return f"({colq} IS NOT NULL AND LENGTH(TRIM({colq})) > 0)", False
     if ctype == "FORMAT_DISTRIBUTION":
         regex = params.get("regex", ".*")
-        return f"({colq} IS NULL OR {colq} RLIKE '{regex}')", False
+        if regex in (None, ""):
+            regex = ".*"
+        if not isinstance(regex, str):
+            regex = str(regex)
+        params[_RULE_PARAMS_KEY] = [regex]
+        return RuleExpr(f"({colq} IS NULL OR REGEXP_LIKE({colq}, ?))", False, (regex,))
     if ctype == "VALUE_DISTRIBUTION":
         allowed_csv = params.get("allowed_values_csv", "")
         values = [v.strip() for v in allowed_csv.split(",") if v.strip() != ""]
-        if not values: return "(TRUE)", False
+        if not values:
+            params.pop(_RULE_PARAMS_KEY, None)
+            return RuleExpr("(TRUE)", False)
         quoted_values = []
         for raw in values:
             sanitized = raw.replace("'", "''")
             quoted_values.append("'" + sanitized + "'")
         quoted = ", ".join(quoted_values)
-        return f"({colq} IN ({quoted}))", False
-    return "(TRUE)", False
+        params.pop(_RULE_PARAMS_KEY, None)
+        return RuleExpr(f"({colq} IN ({quoted}))", False)
+    params.pop(_RULE_PARAMS_KEY, None)
+    return RuleExpr("(TRUE)", False)
 
 
 def build_rule_for_table_check(fqn: str, ttype: str, params: dict):

--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -1,4 +1,6 @@
 import re
+from dataclasses import dataclass
+from typing import Iterator, Tuple
 
 
 SUPPORTED_COLUMN_CHECKS = ["UNIQUE","NULL_COUNT","MIN_MAX","WHITESPACE","FORMAT_DISTRIBUTION","VALUE_DISTRIBUTION"]
@@ -11,6 +13,19 @@ _WRAPPING_DELIMS = {
     '`': '`',
     '[': ']',
 }
+
+_RULE_PARAMS_KEY = "__rule_params__"
+
+
+@dataclass(frozen=True)
+class RuleExpr:
+    sql: str
+    is_aggregate: bool
+    params: Tuple[object, ...] = ()
+
+    def __iter__(self) -> Iterator[object]:
+        yield self.sql
+        yield self.is_aggregate
 
 
 def _strip_wrapping_delimiters(value: str) -> str:
@@ -96,6 +111,10 @@ def build_rule_for_column_check(fqn: str, col: str, ctype: str, params: dict):
     colq = f'"{col}"'
     # return row predicate SQL, is_agg=False
     ctype = (ctype or "").upper()
+    if params is None:
+        params = {}
+    else:
+        params.pop(_RULE_PARAMS_KEY, None)
     if ctype == "UNIQUE":
         ignore_nulls = bool(params.get("ignore_nulls", True))
         if ignore_nulls:
@@ -121,18 +140,27 @@ def build_rule_for_column_check(fqn: str, col: str, ctype: str, params: dict):
         return f"({colq} IS NOT NULL AND LENGTH(TRIM({colq})) > 0)", False
     if ctype == "FORMAT_DISTRIBUTION":
         regex = params.get("regex", ".*")
-        return f"({colq} IS NULL OR {colq} RLIKE '{regex}')", False
+        if regex in (None, ""):
+            regex = ".*"
+        if not isinstance(regex, str):
+            regex = str(regex)
+        params[_RULE_PARAMS_KEY] = [regex]
+        return RuleExpr(f"({colq} IS NULL OR REGEXP_LIKE({colq}, ?))", False, (regex,))
     if ctype == "VALUE_DISTRIBUTION":
         allowed_csv = params.get("allowed_values_csv", "")
         values = [v.strip() for v in allowed_csv.split(",") if v.strip() != ""]
-        if not values: return "(TRUE)", False
+        if not values:
+            params.pop(_RULE_PARAMS_KEY, None)
+            return RuleExpr("(TRUE)", False)
         quoted_values = []
         for raw in values:
             sanitized = raw.replace("'", "''")
             quoted_values.append("'" + sanitized + "'")
         quoted = ", ".join(quoted_values)
-        return f"({colq} IN ({quoted}))", False
-    return "(TRUE)", False
+        params.pop(_RULE_PARAMS_KEY, None)
+        return RuleExpr(f"({colq} IN ({quoted}))", False)
+    params.pop(_RULE_PARAMS_KEY, None)
+    return RuleExpr("(TRUE)", False)
 
 
 def build_rule_for_table_check(fqn: str, ttype: str, params: dict):


### PR DESCRIPTION
Task Name: PROFILING-A61b IPv4 regex RE2-safe + param binding

- Added a reusable RuleExpr container and parameter tracking for column rules, wiring FORMAT_DISTRIBUTION to bind its regex via REGEXP_LIKE placeholders.
- Updated the runtime executor to read stored rule parameters from check configs and pass them to Snowflake SQL calls, covering aggregates, failure counts, and sampling.
- Refreshed mirrored snapshot files to capture the updated helpers and execution logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691338efe1f083249c46e18b4241282a)