### PR TITLE
Codex — A66N: Make _with_extended_timeout a safe no-op in services/profiling.py

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -40,20 +40,9 @@ def _get_session():
     return get_active_session()
 
 
-def _with_extended_timeout(seconds: int):
-    try:
-        timeout = int(seconds)
-    except (TypeError, ValueError):
-        timeout = 0
-
-    if timeout < 1:
-        timeout = 1
-    if timeout > 3600:
-        timeout = 3600
-
-    _get_session().sql(
-        f"ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = {timeout}"
-    ).collect()
+def _with_extended_timeout(seconds: int) -> None:
+    # No-op in SP/UDF/Streamlit-in-Snowflake: ALTER SESSION not permitted.
+    return
 
 
 def _ping():

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -40,20 +40,9 @@ def _get_session():
     return get_active_session()
 
 
-def _with_extended_timeout(seconds: int):
-    try:
-        timeout = int(seconds)
-    except (TypeError, ValueError):
-        timeout = 0
-
-    if timeout < 1:
-        timeout = 1
-    if timeout > 3600:
-        timeout = 3600
-
-    _get_session().sql(
-        f"ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = {timeout}"
-    ).collect()
+def _with_extended_timeout(seconds: int) -> None:
+    # No-op in SP/UDF/Streamlit-in-Snowflake: ALTER SESSION not permitted.
+    return
 
 
 def _ping():


### PR DESCRIPTION
* Make `_with_extended_timeout` a documented no-op to avoid issuing `ALTER SESSION` in profiling contexts.
* Refresh mirrored snapshot for `services/profiling.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133f50e534832497979e43ec103f48)