### PR TITLE
Codex — A66C: Remove call sites to _with_extended_timeout(...)

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -1888,8 +1888,6 @@ def run_table_profile(
     if not session or not fqn:
         return {}, []
 
-    _with_extended_timeout(600)
-
     db, schema, table = _split_fqn(fqn)
     columns = list_columns(session, db, schema, table)
     if not columns:

--- a/snapshots/services/profiling.p
+++ b/snapshots/services/profiling.p
@@ -1888,8 +1888,6 @@ def run_table_profile(
     if not session or not fqn:
         return {}, []
 
-    _with_extended_timeout(600)
-
     db, schema, table = _split_fqn(fqn)
     columns = list_columns(session, db, schema, table)
     if not columns:


### PR DESCRIPTION
Codex — A66C: Remove call sites to _with_extended_timeout(...)

- Remove the redundant _with_extended_timeout call from run_table_profile so profiling starts without the no-op wrapper.
- Mirror updated services/profiling.py snapshot.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134ee1200c83248d479222422795de)