### PR TITLE
PROFILING-A68 — Tiny debug caption to confirm route & busy flags

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1763,6 +1763,16 @@ with st.sidebar:
 # and the main content area.
 st.markdown("<div class='sf-hr'></div>", unsafe_allow_html=True)
 
+if DEBUG_PROFILING:
+    st.caption(
+        "🛠 route="
+        f"{st.session_state.get('active_view')} "
+        "busy_prof="
+        f"{st.session_state.get('busy_profiling')} "
+        "busy_save="
+        f"{st.session_state.get('busy_saving')}"
+    )
+
 active_view = st.session_state.get("active_view", "home")
 if active_view == "cfg":
     if st.session_state.get("cfg_mode","list") == "list":

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1815,6 +1815,10 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     canonical_fqn = str(canon_candidate)
 
         with st.expander("Debug · Profiling Diagnostics", expanded=False):
+            if DEBUG_PROFILING:
+                st.caption(
+                    f"last_error={st.session_state.get('profiling_last_error')}"
+                )
             last_error = st.session_state.get("profiling_last_error")
             if last_error:
                 st.text(f"last_error: {last_error}")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1763,6 +1763,16 @@ with st.sidebar:
 # and the main content area.
 st.markdown("<div class='sf-hr'></div>", unsafe_allow_html=True)
 
+if DEBUG_PROFILING:
+    st.caption(
+        "🛠 route="
+        f"{st.session_state.get('active_view')} "
+        "busy_prof="
+        f"{st.session_state.get('busy_profiling')} "
+        "busy_save="
+        f"{st.session_state.get('busy_saving')}"
+    )
+
 active_view = st.session_state.get("active_view", "home")
 if active_view == "cfg":
     if st.session_state.get("cfg_mode","list") == "list":

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1815,6 +1815,10 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     canonical_fqn = str(canon_candidate)
 
         with st.expander("Debug · Profiling Diagnostics", expanded=False):
+            if DEBUG_PROFILING:
+                st.caption(
+                    f"last_error={st.session_state.get('profiling_last_error')}"
+                )
             last_error = st.session_state.get("profiling_last_error")
             if last_error:
                 st.text(f"last_error: {last_error}")


### PR DESCRIPTION
PROFILING-A68 Route/busy caption when DEBUG_PROFILING
- Show a DEBUG_PROFILING caption with current route and busy flags ahead of view dispatch
- Add a DEBUG_PROFILING caption for the most recent profiling error in the profile diagnostics expander
- Refresh mirrored .p snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691351ed27348324aa5c01c43fcabf8a)