### PR TITLE
PROFILING-A73 Guard empty FQN on profiling run

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1155,11 +1155,15 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             try:
                 st.session_state.pop(ui_keys.PROFILE_LOADED_RUN_ID, None)
                 loaded_run_id = None
+                editor_target_fqn = st.session_state.get("editor_target_fqn")
                 if not session:
                     _record_last_profile_error(
                         ui_strings.PROFILE_RUN_ERROR_NO_SESSION
                     )
                     profile_result = None
+                elif not editor_target_fqn:
+                    st.warning("Select a table first.")
+                    st.session_state[LAST_PROFILE_ERROR_STATE] = None
                 elif not selected_fqn:
                     st.warning(ui_strings.PROFILE_RUN_WARNING_NO_TABLE)
                     st.session_state[LAST_PROFILE_ERROR_STATE] = None

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1155,11 +1155,15 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             try:
                 st.session_state.pop(ui_keys.PROFILE_LOADED_RUN_ID, None)
                 loaded_run_id = None
+                editor_target_fqn = st.session_state.get("editor_target_fqn")
                 if not session:
                     _record_last_profile_error(
                         ui_strings.PROFILE_RUN_ERROR_NO_SESSION
                     )
                     profile_result = None
+                elif not editor_target_fqn:
+                    st.warning("Select a table first.")
+                    st.session_state[LAST_PROFILE_ERROR_STATE] = None
                 elif not selected_fqn:
                     st.warning(ui_strings.PROFILE_RUN_WARNING_NO_TABLE)
                     st.session_state[LAST_PROFILE_ERROR_STATE] = None


### PR DESCRIPTION
PROFILING-A73 Guard empty FQN on profiling run

- Guard the profiling run path to require a selected editor_target_fqn and surface a warning when missing.
- Refresh the mirrored profile view snapshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913724c40048324895856a1101bd70f)