### PR TITLE
PROFILING-A81 Picker → session_state wiring

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1638,7 +1638,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                     )
                 ]
 
-            grid_columns = [
+            grid_columns = ["Include"] + [
                 column
                 for column in ui_strings.PROFILE_GRID_COLUMNS
                 if column != "Select"

--- a/snapshots/views/table_picker.p
+++ b/snapshots/views/table_picker.p
@@ -131,8 +131,8 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
         return db_sel, sch_sel, None, ""
 
     canonical_fqn = canonicalise_fqn(db_sel, sch_sel, tbl_sel)
-    if canonical_fqn:
+    if canonical_fqn and st.session_state.get("editor_target_fqn") != canonical_fqn:
         st.session_state["editor_target_fqn"] = canonical_fqn
-        logger.info("stateless_table_picker.editor_target_fqn=%s", canonical_fqn)
+        logger.info("picker:set_fqn %s", canonical_fqn)
 
     return db_sel, sch_sel, tbl_sel, canonical_fqn

--- a/views/table_picker.py
+++ b/views/table_picker.py
@@ -131,8 +131,8 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
         return db_sel, sch_sel, None, ""
 
     canonical_fqn = canonicalise_fqn(db_sel, sch_sel, tbl_sel)
-    if canonical_fqn:
+    if canonical_fqn and st.session_state.get("editor_target_fqn") != canonical_fqn:
         st.session_state["editor_target_fqn"] = canonical_fqn
-        logger.info("stateless_table_picker.editor_target_fqn=%s", canonical_fqn)
+        logger.info("picker:set_fqn %s", canonical_fqn)
 
     return db_sel, sch_sel, tbl_sel, canonical_fqn


### PR DESCRIPTION
- ensure the table picker records a canonical DB.SCHEMA.TABLE in `editor_target_fqn` when the selection completes and logs the update
- refresh mirrored snapshots to match the picker changes

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69137c4113f883249fc269444dc2a213)