### PR TITLE
PROFILING-A64D Change route default

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -50,10 +50,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs"}
-DEFAULT_ACTIVE_VIEW = "profile"
+DEFAULT_ACTIVE_VIEW = "home"
 
 if "active_view" not in st.session_state:
-    default_view = DEFAULT_ACTIVE_VIEW
+    st.session_state["active_view"] = "home"
+    default_view = st.session_state["active_view"]
     try:
         params = dict(st.query_params)  # type: ignore[attr-defined]
     except Exception:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -50,10 +50,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs"}
-DEFAULT_ACTIVE_VIEW = "profile"
+DEFAULT_ACTIVE_VIEW = "home"
 
 if "active_view" not in st.session_state:
-    default_view = DEFAULT_ACTIVE_VIEW
+    st.session_state["active_view"] = "home"
+    default_view = st.session_state["active_view"]
     try:
         params = dict(st.query_params)  # type: ignore[attr-defined]
     except Exception:


### PR DESCRIPTION
PROFILING-A64D Change route default

- Set the initial `active_view` session state to `home` when missing while preserving existing routing safeguards.
- Refresh the mirrored snapshot for `streamlit_app.py`.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69137db5e32c8324ad467dcb6caf0627)