### PR TITLE
PROFILING-S2: Canonical editor_target_fqn persistence

### DIFF
--- a/snapshots/views/table_picker.p
+++ b/snapshots/views/table_picker.p
@@ -131,7 +131,7 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
         return db_sel, sch_sel, None, ""
 
     canonical_fqn = canonicalise_fqn(db_sel, sch_sel, tbl_sel)
-    if canonical_fqn and st.session_state.get("editor_target_fqn") != canonical_fqn:
+    if canonical_fqn:
         st.session_state["editor_target_fqn"] = canonical_fqn
         logger.info("picker:set_fqn %s", canonical_fqn)
 

--- a/views/table_picker.py
+++ b/views/table_picker.py
@@ -131,7 +131,7 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
         return db_sel, sch_sel, None, ""
 
     canonical_fqn = canonicalise_fqn(db_sel, sch_sel, tbl_sel)
-    if canonical_fqn and st.session_state.get("editor_target_fqn") != canonical_fqn:
+    if canonical_fqn:
         st.session_state["editor_target_fqn"] = canonical_fqn
         logger.info("picker:set_fqn %s", canonical_fqn)
 


### PR DESCRIPTION
PROFILING-S2 Picker → editor_target_fqn canonical write

- ensure the table picker stores the uppercase database.schema.table identifier in `st.session_state["editor_target_fqn"]` after a valid selection and logs the update
- refresh the mirrored snapshot for the table picker view

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913819c1a6c8324bc03c00184bc8e2b)