### PR TITLE
PROFILING-S5 View hygiene (no implicit clears/reruns)

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -965,7 +965,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                                     run_id=selected_run_id
                                 )
                             )
-                            st.rerun()
 
         load_selected_run_id: Optional[str] = None
         load_button_clicked = False
@@ -1188,7 +1187,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         if clear_loaded:
             st.session_state.pop(ui_keys.PROFILE_LOADED_RUN_ID, None)
             loaded_run_id = None
-            st.rerun()
 
         inline_error_placeholder = st.empty()
 

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -965,7 +965,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                                     run_id=selected_run_id
                                 )
                             )
-                            st.rerun()
 
         load_selected_run_id: Optional[str] = None
         load_button_clicked = False
@@ -1188,7 +1187,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         if clear_loaded:
             st.session_state.pop(ui_keys.PROFILE_LOADED_RUN_ID, None)
             loaded_run_id = None
-            st.rerun()
 
         inline_error_placeholder = st.empty()
 


### PR DESCRIPTION
PROFILING-S5 View hygiene (no implicit clears/reruns)
- Removed reruns triggered after loading or clearing saved profiles so view state persists naturally.
- Updated snapshot mirror.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691383f170b48324b2f274ac166bc017)