### PR TITLE
PROFILING-S2B Picker → editor_target_fqn (canonical, reliable)

### DIFF
--- a/snapshots/views/table_picker.p
+++ b/snapshots/views/table_picker.p
@@ -8,9 +8,6 @@ import streamlit as st
 from utils.meta import list_databases, list_schemas, list_tables
 
 
-logger = logging.getLogger(__name__)
-
-
 def session_cache_token(session_obj) -> str:
     """Return a stable identifier for the given Snowpark session."""
 
@@ -85,19 +82,6 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
         a, b, c = [p.strip('"') for p in fqn.split(".")]
         return a, b, c
 
-    def canonicalise_fqn(database: Optional[str], schema: Optional[str], table: Optional[str]) -> str:
-        parts = []
-
-        for value in (database, schema, table):
-            if not value:
-                parts.append("")
-                continue
-            cleaned = str(value).strip().strip('"')
-            parts.append(cleaned.upper())
-
-        canonical_parts = [part for part in parts if part]
-        return ".".join(canonical_parts)
-
     pre_db, pre_sch, pre_tbl = split_fqn(preselect_fqn or "")
 
     dbs = _list_databases_cached(session_obj)
@@ -130,9 +114,14 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
     if not tables or tbl_sel == "— none —":
         return db_sel, sch_sel, None, ""
 
-    canonical_fqn = canonicalise_fqn(db_sel, sch_sel, tbl_sel)
-    if canonical_fqn:
-        st.session_state["editor_target_fqn"] = canonical_fqn
-        logger.info("picker:set_fqn %s", canonical_fqn)
+    db = (db_sel or "").strip('"').upper()
+    schema = (sch_sel or "").strip('"').upper()
+    table = (tbl_sel or "").strip('"').upper()
 
-    return db_sel, sch_sel, tbl_sel, canonical_fqn
+    fqn = ""
+    if db and schema and table:
+        fqn = f"{db}.{schema}.{table}"
+        st.session_state["editor_target_fqn"] = fqn
+        logging.info("picker:set_fqn %s", fqn)
+
+    return db_sel, sch_sel, tbl_sel, fqn

--- a/views/table_picker.py
+++ b/views/table_picker.py
@@ -8,9 +8,6 @@ import streamlit as st
 from utils.meta import list_databases, list_schemas, list_tables
 
 
-logger = logging.getLogger(__name__)
-
-
 def session_cache_token(session_obj) -> str:
     """Return a stable identifier for the given Snowpark session."""
 
@@ -85,19 +82,6 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
         a, b, c = [p.strip('"') for p in fqn.split(".")]
         return a, b, c
 
-    def canonicalise_fqn(database: Optional[str], schema: Optional[str], table: Optional[str]) -> str:
-        parts = []
-
-        for value in (database, schema, table):
-            if not value:
-                parts.append("")
-                continue
-            cleaned = str(value).strip().strip('"')
-            parts.append(cleaned.upper())
-
-        canonical_parts = [part for part in parts if part]
-        return ".".join(canonical_parts)
-
     pre_db, pre_sch, pre_tbl = split_fqn(preselect_fqn or "")
 
     dbs = _list_databases_cached(session_obj)
@@ -130,9 +114,14 @@ def stateless_table_picker(session_obj, preselect_fqn: Optional[str]):
     if not tables or tbl_sel == "— none —":
         return db_sel, sch_sel, None, ""
 
-    canonical_fqn = canonicalise_fqn(db_sel, sch_sel, tbl_sel)
-    if canonical_fqn:
-        st.session_state["editor_target_fqn"] = canonical_fqn
-        logger.info("picker:set_fqn %s", canonical_fqn)
+    db = (db_sel or "").strip('"').upper()
+    schema = (sch_sel or "").strip('"').upper()
+    table = (tbl_sel or "").strip('"').upper()
 
-    return db_sel, sch_sel, tbl_sel, canonical_fqn
+    fqn = ""
+    if db and schema and table:
+        fqn = f"{db}.{schema}.{table}"
+        st.session_state["editor_target_fqn"] = fqn
+        logging.info("picker:set_fqn %s", fqn)
+
+    return db_sel, sch_sel, tbl_sel, fqn


### PR DESCRIPTION
PROFILING-S2B Picker → editor_target_fqn (canonical, reliable)

- canonicalize database, schema, and table selections when all are chosen and write the FQN to `st.session_state["editor_target_fqn"]`
- log the canonical FQN write operation and update mirrored snapshot

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913869f1158832492b9597ba3269aaa)