### PR TITLE
PROFILING-T4: Hygiene sweep for FQN clears / reruns

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -254,7 +254,8 @@ def open_config_editor(
     """Switch to the configuration editor with the given selection."""
     st.session_state["cfg_mode"] = "edit"
     st.session_state["selected_config_id"] = config_id
-    st.session_state["editor_target_fqn"] = target_fqn
+    if target_fqn is not None:
+        st.session_state["editor_target_fqn"] = target_fqn
     st.rerun()
 
 
@@ -1670,6 +1671,7 @@ def render_docs() -> None:
 
 # ---------- Sidebar + routing ----------
 state = get_state()
+st.session_state.setdefault("editor_target_fqn", None)
 query_page = _get_page_from_query_params()
 last_query_page = st.session_state.get("_last_query_page")
 if query_page and query_page != last_query_page:
@@ -1691,8 +1693,7 @@ if (
     and page_state_value != st.session_state.get("active_view")
 ):
     navigate_to(page_state_value)
-if "cfg_mode" not in st.session_state:
-    st.session_state["cfg_mode"] = "list"
+st.session_state.setdefault("cfg_mode", "list")
 view = st.session_state.get("active_view", "home")
 with st.sidebar:
     st.header("Zeus DQ")

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -753,10 +753,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             json.dumps(editor_target_fqn or ""),
         )
 
-        if "busy_profiling" not in st.session_state:
-            st.session_state["busy_profiling"] = False
-        if "busy_saving" not in st.session_state:
-            st.session_state["busy_saving"] = False
+        st.session_state.setdefault("busy_profiling", False)
+        st.session_state.setdefault("busy_saving", False)
 
         _ensure_last_profile_state_defaults()
 
@@ -870,8 +868,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         if st.session_state.get(sample_target_key) != selected_fqn:
             st.session_state[sample_target_key] = selected_fqn
             st.session_state[sample_pct_state_key] = float(suggested_pct)
-        elif sample_pct_state_key not in st.session_state:
-            st.session_state[sample_pct_state_key] = float(suggested_pct)
+        else:
+            st.session_state.setdefault(sample_pct_state_key, float(suggested_pct))
 
         approx_rows = None
         if row_count is not None and suggested_pct > 0:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -254,7 +254,8 @@ def open_config_editor(
     """Switch to the configuration editor with the given selection."""
     st.session_state["cfg_mode"] = "edit"
     st.session_state["selected_config_id"] = config_id
-    st.session_state["editor_target_fqn"] = target_fqn
+    if target_fqn is not None:
+        st.session_state["editor_target_fqn"] = target_fqn
     st.rerun()
 
 
@@ -1670,6 +1671,7 @@ def render_docs() -> None:
 
 # ---------- Sidebar + routing ----------
 state = get_state()
+st.session_state.setdefault("editor_target_fqn", None)
 query_page = _get_page_from_query_params()
 last_query_page = st.session_state.get("_last_query_page")
 if query_page and query_page != last_query_page:
@@ -1691,8 +1693,7 @@ if (
     and page_state_value != st.session_state.get("active_view")
 ):
     navigate_to(page_state_value)
-if "cfg_mode" not in st.session_state:
-    st.session_state["cfg_mode"] = "list"
+st.session_state.setdefault("cfg_mode", "list")
 view = st.session_state.get("active_view", "home")
 with st.sidebar:
     st.header("Zeus DQ")

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -753,10 +753,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
             json.dumps(editor_target_fqn or ""),
         )
 
-        if "busy_profiling" not in st.session_state:
-            st.session_state["busy_profiling"] = False
-        if "busy_saving" not in st.session_state:
-            st.session_state["busy_saving"] = False
+        st.session_state.setdefault("busy_profiling", False)
+        st.session_state.setdefault("busy_saving", False)
 
         _ensure_last_profile_state_defaults()
 
@@ -870,8 +868,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         if st.session_state.get(sample_target_key) != selected_fqn:
             st.session_state[sample_target_key] = selected_fqn
             st.session_state[sample_pct_state_key] = float(suggested_pct)
-        elif sample_pct_state_key not in st.session_state:
-            st.session_state[sample_pct_state_key] = float(suggested_pct)
+        else:
+            st.session_state.setdefault(sample_pct_state_key, float(suggested_pct))
 
         approx_rows = None
         if row_count is not None and suggested_pct > 0:


### PR DESCRIPTION
Task Name: PROFILING-T4 Hygiene sweep for FQN clears / reruns

- Guarded editor_target_fqn updates when opening the config editor and ensured the key is initialized once via setdefault.
- Used setdefault for profile view busy flags and sample defaults to avoid resetting state each render.
- Rebuilt snapshot mirrors for updated Streamlit view logic.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138dc9d85c83248496d2db0040e63b)