### PR TITLE
REPO-A91 Snapshot always-on after merge

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,24 @@
+name: snapshot-on-merge
+
+on:
+  push:
+    branches:
+      - V1.3-profiling
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Write build meta
+        run: |
+          echo "$GITHUB_SHA" > snapshots/BUILD_SHA.txt
+          date -u +"%Y-%m-%dT%H:%M:%SZ" > snapshots/BUILD_TIME_UTC.txt
+      - name: Commit snapshot
+        run: |
+          git config user.name "snapshot-bot"
+          git config user.email "snapshot-bot@users.noreply.github.com"
+          git add snapshots/BUILD_SHA.txt snapshots/BUILD_TIME_UTC.txt
+          git commit -m "snapshot: update build meta [skip ci]" || echo "No changes"
+          git push


### PR DESCRIPTION
REPO-A91 — Make snapshot action run regardless of test status

- add snapshot-on-merge workflow triggered on pushes to V1.3-profiling
- ensure snapshot job always updates build metadata even when other jobs fail

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cad9053c8324849c770a6201d11e)