### PR TITLE
APP-A92: Add debug version stamp

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -125,10 +125,14 @@ from services.state import get_state, set_state
 from utils.checkdefs import build_rule_for_column_check, build_rule_for_table_check
 from utils.configs import get_metadata_namespace, get_proc_name
 from utils.flags import DEBUG_PROFILING
+from utils.version import build_sha, build_time
 from views import profile_view
 from views.table_picker import stateless_table_picker, session_cache_token
 from views.docs_view import render_docs as render_docs_view
 from views.config_editor import render_row_count_preview
+
+if DEBUG_PROFILING:
+    st.caption(f"🧩 build={build_sha()} time={build_time()}")
 
 METADATA_DB, METADATA_SCHEMA = get_metadata_namespace()
 PROC_NAME = get_proc_name()

--- a/snapshots/utils/version.p
+++ b/snapshots/utils/version.p
@@ -1,0 +1,12 @@
+import os
+import pathlib
+
+
+def build_sha() -> str:
+    p = pathlib.Path("snapshots/BUILD_SHA.txt")
+    return p.read_text().strip() if p.exists() else os.getenv("GIT_SHA", "unknown")
+
+
+def build_time() -> str:
+    p = pathlib.Path("snapshots/BUILD_TIME_UTC.txt")
+    return p.read_text().strip() if p.exists() else "unknown"

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -64,6 +64,7 @@ from utils.flags import (
     UI_CONTRACT_STRICT,
 )
 from utils.meta import get_table_row_count
+from utils.version import build_sha, build_time
 from utils.state import (
     SAVED_PROFILES_STATE,
     list_saved_profiles,
@@ -2285,6 +2286,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         canonical_fqn = str(canon_candidate)
 
             with st.expander("Debug · Profiling Diagnostics", expanded=False):
+                st.caption(f"🧩 build={build_sha()} time={build_time()}")
                 debug_fqn_override = st.text_input(
                     "DB.SCHEMA.TABLE",
                     key="profile_debug_fqn_override",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -125,10 +125,14 @@ from services.state import get_state, set_state
 from utils.checkdefs import build_rule_for_column_check, build_rule_for_table_check
 from utils.configs import get_metadata_namespace, get_proc_name
 from utils.flags import DEBUG_PROFILING
+from utils.version import build_sha, build_time
 from views import profile_view
 from views.table_picker import stateless_table_picker, session_cache_token
 from views.docs_view import render_docs as render_docs_view
 from views.config_editor import render_row_count_preview
+
+if DEBUG_PROFILING:
+    st.caption(f"🧩 build={build_sha()} time={build_time()}")
 
 METADATA_DB, METADATA_SCHEMA = get_metadata_namespace()
 PROC_NAME = get_proc_name()

--- a/utils/version.py
+++ b/utils/version.py
@@ -1,0 +1,12 @@
+import os
+import pathlib
+
+
+def build_sha() -> str:
+    p = pathlib.Path("snapshots/BUILD_SHA.txt")
+    return p.read_text().strip() if p.exists() else os.getenv("GIT_SHA", "unknown")
+
+
+def build_time() -> str:
+    p = pathlib.Path("snapshots/BUILD_TIME_UTC.txt")
+    return p.read_text().strip() if p.exists() else "unknown"

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -64,6 +64,7 @@ from utils.flags import (
     UI_CONTRACT_STRICT,
 )
 from utils.meta import get_table_row_count
+from utils.version import build_sha, build_time
 from utils.state import (
     SAVED_PROFILES_STATE,
     list_saved_profiles,
@@ -2285,6 +2286,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         canonical_fqn = str(canon_candidate)
 
             with st.expander("Debug · Profiling Diagnostics", expanded=False):
+                st.caption(f"🧩 build={build_sha()} time={build_time()}")
                 debug_fqn_override = st.text_input(
                     "DB.SCHEMA.TABLE",
                     key="profile_debug_fqn_override",


### PR DESCRIPTION
APP-A92 — App debug version stamp (prove deployed code)
- add a utils.version helper to expose build sha and timestamp from snapshot files
- render the debug-only build stamp in the main Streamlit app header when profiling is enabled
- echo the same stamp in the profile view diagnostics expander and update mirrored snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cb11fd0c832498462b8005a3e2b6)