### PR TITLE
APP-A94 Freeze active_view while profiling

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -68,7 +68,8 @@ if "active_view" not in st.session_state:
     st.session_state["active_view"] = "home"  # or your desired start view
     logging.info("route:init %s", st.session_state["active_view"])
 
-if st.session_state.get("freeze_view"):
+st.session_state.setdefault("freeze_view", False)
+if st.session_state["freeze_view"]:
     st.session_state["active_view"] = "profile"
 
 if "_last_query_page" not in st.session_state:

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -754,8 +754,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         )
 
         st.session_state.setdefault("busy_profiling", False)
-        st.session_state.setdefault("busy_saving", False)
         st.session_state.setdefault("freeze_view", False)
+        st.session_state.setdefault("busy_saving", False)
 
         _ensure_last_profile_state_defaults()
 
@@ -1195,7 +1195,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         current_editor_fqn = st.session_state.get("editor_target_fqn") or ""
 
         run_clicked = bool(run_requested)
-        if run_clicked and not st.session_state["busy_profiling"]:
+        if run_clicked and not st.session_state.get("busy_profiling", False):
             st.session_state["busy_profiling"] = True
             st.session_state["freeze_view"] = True
             busy_profiling = True

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -68,7 +68,8 @@ if "active_view" not in st.session_state:
     st.session_state["active_view"] = "home"  # or your desired start view
     logging.info("route:init %s", st.session_state["active_view"])
 
-if st.session_state.get("freeze_view"):
+st.session_state.setdefault("freeze_view", False)
+if st.session_state["freeze_view"]:
     st.session_state["active_view"] = "profile"
 
 if "_last_query_page" not in st.session_state:

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -754,8 +754,8 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         )
 
         st.session_state.setdefault("busy_profiling", False)
-        st.session_state.setdefault("busy_saving", False)
         st.session_state.setdefault("freeze_view", False)
+        st.session_state.setdefault("busy_saving", False)
 
         _ensure_last_profile_state_defaults()
 
@@ -1195,7 +1195,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
         current_editor_fqn = st.session_state.get("editor_target_fqn") or ""
 
         run_clicked = bool(run_requested)
-        if run_clicked and not st.session_state["busy_profiling"]:
+        if run_clicked and not st.session_state.get("busy_profiling", False):
             st.session_state["busy_profiling"] = True
             st.session_state["freeze_view"] = True
             busy_profiling = True


### PR DESCRIPTION
- Ensure the profile view initialises and reads the `freeze_view` state alongside `busy_profiling` when starting a run.
- Keep the Streamlit router pinned to the profile view by defaulting and checking the freeze flag before dispatch.
- Mirror updated Python sources into the snapshot directory.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cb4e500083248f58095a0adafcbd)