### PR TITLE
APP-A92 Debug build stamp

### DIFF
--- a/snapshots/utils/version.p
+++ b/snapshots/utils/version.p
@@ -1,12 +1,11 @@
-import os
-import pathlib
+import os, pathlib
 
 
-def build_sha() -> str:
+def build_sha():
     p = pathlib.Path("snapshots/BUILD_SHA.txt")
     return p.read_text().strip() if p.exists() else os.getenv("GIT_SHA", "unknown")
 
 
-def build_time() -> str:
+def build_time():
     p = pathlib.Path("snapshots/BUILD_TIME_UTC.txt")
     return p.read_text().strip() if p.exists() else "unknown"

--- a/utils/version.py
+++ b/utils/version.py
@@ -1,12 +1,11 @@
-import os
-import pathlib
+import os, pathlib
 
 
-def build_sha() -> str:
+def build_sha():
     p = pathlib.Path("snapshots/BUILD_SHA.txt")
     return p.read_text().strip() if p.exists() else os.getenv("GIT_SHA", "unknown")
 
 
-def build_time() -> str:
+def build_time():
     p = pathlib.Path("snapshots/BUILD_TIME_UTC.txt")
     return p.read_text().strip() if p.exists() else "unknown"


### PR DESCRIPTION
APP-A92 Debug build stamp
- normalize the version utility imports used for build stamp display
- refresh mirrored snapshots for utils/version


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ecdb227c8324b2fa72600a5c886e)