### PR TITLE
PROFILING-S7R Freeze route during run; sticky error; debounce

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -63,11 +63,6 @@ if "active_view" not in st.session_state:
     st.session_state["active_view"] = "home"  # or your desired start view
     logging.info("route:init %s", st.session_state["active_view"])
 
-st.session_state.setdefault("freeze_view", False)
-
-if st.session_state.get("freeze_view"):
-    st.session_state["active_view"] = "profile"
-
 if "_last_query_page" not in st.session_state:
     st.session_state["_last_query_page"] = st.session_state["active_view"]
 
@@ -140,6 +135,11 @@ CHECKS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 # RUN_RESULTS_TBL already defined above
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
+
+st.session_state.setdefault("freeze_view", False)
+
+if st.session_state.get("freeze_view"):
+    st.session_state["active_view"] = "profile"
 
 # Simple rerun telemetry (replaces old _RERUN_TELEMETRY_LINE)
 st.session_state.setdefault("_rerun_count", 0)

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1213,12 +1213,12 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 nonlocal profile_result, stored_profile_result, loaded_run_id
                 nonlocal busy_profiling
 
-                fqn = st.session_state.get("editor_target_fqn") or ""
+                fqn = (st.session_state.get("editor_target_fqn") or "").strip()
                 if not fqn:
                     st.warning("Select a table first.")
                     return
 
-                if st.session_state.get("busy_profiling", False):
+                if st.session_state.get("busy_profiling"):
                     return
 
                 st.session_state["busy_profiling"] = True
@@ -1237,7 +1237,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         stored_profile_result = None
                         return
 
-                    target_fqn = selected_fqn or fqn
+                    target_fqn = (selected_fqn or fqn).strip()
                     if not target_fqn:
                         st.warning(ui_strings.PROFILE_RUN_WARNING_NO_TABLE)
                         st.session_state[LAST_PROFILE_ERROR_STATE] = None
@@ -1292,7 +1292,13 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                                 "err": "Unexpected profiling response.",
                             }
 
-                        if not res.get("ok"):
+                        if res.get("ok"):
+                            summary_raw = (res.get("summary") or {})
+                            column_rows = list(res.get("column_rows") or [])
+                            st.session_state[LAST_PROFILE_SUMMARY_STATE] = summary_raw
+                            st.session_state[LAST_PROFILE_ROWS_STATE] = column_rows
+                            st.session_state[LAST_PROFILE_ERROR_STATE] = None
+                        else:
                             error_message = res.get("err") or (
                                 "Profiling failed — see debug panel for details."
                             )
@@ -1320,11 +1326,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                             return
 
                         summary_raw = (
-                            res.get("summary") if isinstance(res, dict) else {}
-                        ) or {}
+                            st.session_state.get(LAST_PROFILE_SUMMARY_STATE) or {}
+                        )
                         column_rows = (
-                            res.get("column_rows") if isinstance(res, dict) else []
-                        ) or []
+                            st.session_state.get(LAST_PROFILE_ROWS_STATE) or []
+                        )
 
                         duration = time.time() - start
                         rows_profiled = int(
@@ -1351,8 +1357,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         summary_payload["columns"] = len(profiles)
 
                         st.session_state[LAST_PROFILE_SUMMARY_STATE] = summary_payload
-                        st.session_state[LAST_PROFILE_ROWS_STATE] = column_rows
-                        st.session_state[LAST_PROFILE_ERROR_STATE] = None
                         st.session_state[LAST_PROFILE_TARGET_STATE] = str(
                             target_fqn
                         )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -63,11 +63,6 @@ if "active_view" not in st.session_state:
     st.session_state["active_view"] = "home"  # or your desired start view
     logging.info("route:init %s", st.session_state["active_view"])
 
-st.session_state.setdefault("freeze_view", False)
-
-if st.session_state.get("freeze_view"):
-    st.session_state["active_view"] = "profile"
-
 if "_last_query_page" not in st.session_state:
     st.session_state["_last_query_page"] = st.session_state["active_view"]
 
@@ -140,6 +135,11 @@ CHECKS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 # RUN_RESULTS_TBL already defined above
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
+
+st.session_state.setdefault("freeze_view", False)
+
+if st.session_state.get("freeze_view"):
+    st.session_state["active_view"] = "profile"
 
 # Simple rerun telemetry (replaces old _RERUN_TELEMETRY_LINE)
 st.session_state.setdefault("_rerun_count", 0)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1213,12 +1213,12 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                 nonlocal profile_result, stored_profile_result, loaded_run_id
                 nonlocal busy_profiling
 
-                fqn = st.session_state.get("editor_target_fqn") or ""
+                fqn = (st.session_state.get("editor_target_fqn") or "").strip()
                 if not fqn:
                     st.warning("Select a table first.")
                     return
 
-                if st.session_state.get("busy_profiling", False):
+                if st.session_state.get("busy_profiling"):
                     return
 
                 st.session_state["busy_profiling"] = True
@@ -1237,7 +1237,7 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         stored_profile_result = None
                         return
 
-                    target_fqn = selected_fqn or fqn
+                    target_fqn = (selected_fqn or fqn).strip()
                     if not target_fqn:
                         st.warning(ui_strings.PROFILE_RUN_WARNING_NO_TABLE)
                         st.session_state[LAST_PROFILE_ERROR_STATE] = None
@@ -1292,7 +1292,13 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                                 "err": "Unexpected profiling response.",
                             }
 
-                        if not res.get("ok"):
+                        if res.get("ok"):
+                            summary_raw = (res.get("summary") or {})
+                            column_rows = list(res.get("column_rows") or [])
+                            st.session_state[LAST_PROFILE_SUMMARY_STATE] = summary_raw
+                            st.session_state[LAST_PROFILE_ROWS_STATE] = column_rows
+                            st.session_state[LAST_PROFILE_ERROR_STATE] = None
+                        else:
                             error_message = res.get("err") or (
                                 "Profiling failed — see debug panel for details."
                             )
@@ -1320,11 +1326,11 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                             return
 
                         summary_raw = (
-                            res.get("summary") if isinstance(res, dict) else {}
-                        ) or {}
+                            st.session_state.get(LAST_PROFILE_SUMMARY_STATE) or {}
+                        )
                         column_rows = (
-                            res.get("column_rows") if isinstance(res, dict) else []
-                        ) or []
+                            st.session_state.get(LAST_PROFILE_ROWS_STATE) or []
+                        )
 
                         duration = time.time() - start
                         rows_profiled = int(
@@ -1351,8 +1357,6 @@ def render_profile(session, meta_db: str, meta_schema: str) -> None:  # noqa: AR
                         summary_payload["columns"] = len(profiles)
 
                         st.session_state[LAST_PROFILE_SUMMARY_STATE] = summary_payload
-                        st.session_state[LAST_PROFILE_ROWS_STATE] = column_rows
-                        st.session_state[LAST_PROFILE_ERROR_STATE] = None
                         st.session_state[LAST_PROFILE_TARGET_STATE] = str(
                             target_fqn
                         )


### PR DESCRIPTION
- Prevent navigation away from the Profile view while a profiling run is in progress and ignore rapid re-tries.
- Persist profiling outcomes and errors into session state so inline messaging stays visible after failures.
- Refresh mirrored Python snapshots.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f6f045c883249be91f58e7959dcd)