### PR TITLE
Task A5 – Basic logging and robustness for Profiling v2

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -46,6 +46,13 @@ def _execute_sql(session: Any, sql: str, params: Optional[Iterable[Any]] = None)
     return stmt
 
 
+def _friendly_error_message(exc: Exception) -> str:
+    message = str(exc).strip()
+    if not message:
+        return exc.__class__.__name__
+    return message
+
+
 def run_profiling_v2(session: Any, table_fqn: str) -> None:
     """Execute the Profiling v2 stored procedure for *table_fqn*."""
 
@@ -57,10 +64,9 @@ def run_profiling_v2(session: Any, table_fqn: str) -> None:
     try:
         _execute_sql(session, f"CALL {PROFILE_PROC}(?)", params=[normalized]).collect()
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:proc_failed target=%s", normalized)
-        raise ProfilingError(
-            f"Profiling failed for {normalized}. Check Snowflake logs for details."
-        ) from exc
+        raise ProfilingError(f"Profiling run failed: {message}") from exc
 
 
 # Backwards compatibility for earlier callers/tests.
@@ -86,7 +92,11 @@ def get_table_profile_summary(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
     sql = f"SELECT * FROM {TABLE_SUMMARY_VIEW} WHERE TABLE_FQN = ?"
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:summary_fetch_failed target=%s", normalized)
+        return pd.DataFrame()
 
 
 def fetch_table_summary(session: Any, table_fqn: str) -> Dict[str, Any]:
@@ -116,7 +126,11 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME
     """
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:column_features_failed target=%s", normalized)
+        return pd.DataFrame()
 
 
 def fetch_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
@@ -138,7 +152,13 @@ def get_column_classification(session: Any, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, SOURCE DESC, CLASSIFIED_AT DESC
     """
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception(
+            "profiling_v2:column_classification_failed target=%s", normalized
+        )
+        return pd.DataFrame()
 
 
 def fetch_column_classifications(session: Any, table_fqn: str) -> pd.DataFrame:
@@ -160,7 +180,11 @@ def get_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, RULE_ID
     """
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:suggested_checks_failed target=%s", normalized)
+        return pd.DataFrame()
 
 
 def fetch_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -46,6 +46,13 @@ def _execute_sql(session: Any, sql: str, params: Optional[Iterable[Any]] = None)
     return stmt
 
 
+def _friendly_error_message(exc: Exception) -> str:
+    message = str(exc).strip()
+    if not message:
+        return exc.__class__.__name__
+    return message
+
+
 def run_profiling_v2(session: Any, table_fqn: str) -> None:
     """Execute the Profiling v2 stored procedure for *table_fqn*."""
 
@@ -57,10 +64,9 @@ def run_profiling_v2(session: Any, table_fqn: str) -> None:
     try:
         _execute_sql(session, f"CALL {PROFILE_PROC}(?)", params=[normalized]).collect()
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:proc_failed target=%s", normalized)
-        raise ProfilingError(
-            f"Profiling failed for {normalized}. Check Snowflake logs for details."
-        ) from exc
+        raise ProfilingError(f"Profiling run failed: {message}") from exc
 
 
 # Backwards compatibility for earlier callers/tests.
@@ -86,7 +92,11 @@ def get_table_profile_summary(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
     sql = f"SELECT * FROM {TABLE_SUMMARY_VIEW} WHERE TABLE_FQN = ?"
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:summary_fetch_failed target=%s", normalized)
+        return pd.DataFrame()
 
 
 def fetch_table_summary(session: Any, table_fqn: str) -> Dict[str, Any]:
@@ -116,7 +126,11 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME
     """
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:column_features_failed target=%s", normalized)
+        return pd.DataFrame()
 
 
 def fetch_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
@@ -138,7 +152,13 @@ def get_column_classification(session: Any, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, SOURCE DESC, CLASSIFIED_AT DESC
     """
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception(
+            "profiling_v2:column_classification_failed target=%s", normalized
+        )
+        return pd.DataFrame()
 
 
 def fetch_column_classifications(session: Any, table_fqn: str) -> pd.DataFrame:
@@ -160,7 +180,11 @@ def get_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, RULE_ID
     """
-    return _fetch_dataframe(session, sql, params=[normalized])
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:suggested_checks_failed target=%s", normalized)
+        return pd.DataFrame()
 
 
 def fetch_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:

--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -44,6 +44,12 @@ PROFILE_V2_RUNS_SUBHEADER = "Recent profiling runs"
 PROFILE_V2_RUNS_EMPTY = "No profiling runs have been logged yet."
 PROFILE_V2_VALUE_UNKNOWN = "—"
 PROFILE_V2_DEBUG_EXPANDER = "Debug · Profiling payload"
+PROFILE_V2_DEBUG_STATUS_HEADER = "Profiling status"
+PROFILE_V2_DEBUG_LAST_TABLE = "Last profiled table"
+PROFILE_V2_DEBUG_LAST_RUN_ID = "Last profile run ID"
+PROFILE_V2_DEBUG_FEATURE_ROWS = "Column feature rows"
+PROFILE_V2_DEBUG_CLASS_ROWS = "Classification rows"
+PROFILE_V2_DEBUG_SUGGESTION_ROWS = "Suggestion rows"
 
 # Config preview strings
 CONFIG_PREVIEW_CONTRACT_VIOLATION_FRAME = (

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -170,6 +170,53 @@ def _resolve_helpers(profiling_helpers: Optional[Any]):
     return profiling_helpers or profiling_service
 
 
+def _extract_last_run_id(run_history: pd.DataFrame) -> Optional[str]:
+    if not isinstance(run_history, pd.DataFrame) or run_history.empty:
+        return None
+    if "RUN_ID" not in run_history.columns:
+        return None
+    ordered = run_history
+    if "PROFILED_AT" in ordered.columns:
+        ordered = ordered.sort_values(by="PROFILED_AT", ascending=False)
+    latest = ordered.iloc[0]
+    run_id = latest.get("RUN_ID")
+    return str(run_id) if run_id is not None else None
+
+
+def _render_debug_section(data: _ProfilingData, target_fqn: str) -> None:
+    if not DEBUG_PROFILING:
+        return
+
+    last_table = st.session_state.get("profile_last_table") or target_fqn
+    if not last_table:
+        last_table = ui_strings.PROFILE_V2_VALUE_UNKNOWN
+    last_run_id = (
+        st.session_state.get("profile_last_run_id")
+        or _extract_last_run_id(data.recent_runs)
+        or ui_strings.PROFILE_V2_VALUE_UNKNOWN
+    )
+    feature_rows = int(len(data.column_features.index)) if isinstance(data.column_features, pd.DataFrame) else 0
+    class_rows = int(len(data.column_classification.index)) if isinstance(data.column_classification, pd.DataFrame) else 0
+    suggestion_rows = int(len(data.suggested_checks.index)) if isinstance(data.suggested_checks, pd.DataFrame) else 0
+    debug_payload = {
+        "summary": data.summary,
+        "column_features": data.column_features.to_dict("records"),
+        "column_classification": data.column_classification.to_dict("records"),
+        "suggested_checks": data.suggested_checks.to_dict("records"),
+        "recent_runs": data.recent_runs.to_dict("records"),
+    }
+    with st.expander(ui_strings.PROFILE_V2_DEBUG_EXPANDER, expanded=False):
+        st.markdown(f"**{ui_strings.PROFILE_V2_DEBUG_STATUS_HEADER}**")
+        status_cols = st.columns(2)
+        status_cols[0].metric(ui_strings.PROFILE_V2_DEBUG_LAST_TABLE, last_table)
+        status_cols[1].metric(ui_strings.PROFILE_V2_DEBUG_LAST_RUN_ID, last_run_id)
+        row_cols = st.columns(3)
+        row_cols[0].metric(ui_strings.PROFILE_V2_DEBUG_FEATURE_ROWS, feature_rows)
+        row_cols[1].metric(ui_strings.PROFILE_V2_DEBUG_CLASS_ROWS, class_rows)
+        row_cols[2].metric(ui_strings.PROFILE_V2_DEBUG_SUGGESTION_ROWS, suggestion_rows)
+        st.json(debug_payload)
+
+
 def _load_metadata(
     helpers: Any,
     session: Any,
@@ -345,6 +392,8 @@ def render_profile(
                 )
             else:
                 st.session_state["profile_data_nonce"] += 1
+                st.session_state["profile_last_table"] = target_fqn
+                st.session_state["profile_last_run_id"] = None
                 status_placeholder.success(
                     ui_strings.PROFILE_V2_RUN_SUCCESS.format(table=target_fqn)
                 )
@@ -367,6 +416,9 @@ def render_profile(
     with st.spinner(ui_strings.PROFILE_V2_LOAD_SPINNER):
         data = _load_metadata(helpers, session, target_fqn)
 
+    st.session_state["profile_last_table"] = target_fqn
+    st.session_state["profile_last_run_id"] = _extract_last_run_id(data.recent_runs)
+
     _render_summary(data.summary, data.column_features)
 
     tab_titles = [
@@ -386,13 +438,4 @@ def render_profile(
     with tabs[3]:
         _render_run_history_tab(data.recent_runs)
 
-    if DEBUG_PROFILING:
-        debug_payload = {
-            "summary": data.summary,
-            "column_features": data.column_features.to_dict("records"),
-            "column_classification": data.column_classification.to_dict("records"),
-            "suggested_checks": data.suggested_checks.to_dict("records"),
-            "recent_runs": data.recent_runs.to_dict("records"),
-        }
-        with st.expander(ui_strings.PROFILE_V2_DEBUG_EXPANDER, expanded=False):
-            st.json(debug_payload)
+    _render_debug_section(data, target_fqn)

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -44,6 +44,12 @@ PROFILE_V2_RUNS_SUBHEADER = "Recent profiling runs"
 PROFILE_V2_RUNS_EMPTY = "No profiling runs have been logged yet."
 PROFILE_V2_VALUE_UNKNOWN = "—"
 PROFILE_V2_DEBUG_EXPANDER = "Debug · Profiling payload"
+PROFILE_V2_DEBUG_STATUS_HEADER = "Profiling status"
+PROFILE_V2_DEBUG_LAST_TABLE = "Last profiled table"
+PROFILE_V2_DEBUG_LAST_RUN_ID = "Last profile run ID"
+PROFILE_V2_DEBUG_FEATURE_ROWS = "Column feature rows"
+PROFILE_V2_DEBUG_CLASS_ROWS = "Classification rows"
+PROFILE_V2_DEBUG_SUGGESTION_ROWS = "Suggestion rows"
 
 # Config preview strings
 CONFIG_PREVIEW_CONTRACT_VIOLATION_FRAME = (

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -170,6 +170,53 @@ def _resolve_helpers(profiling_helpers: Optional[Any]):
     return profiling_helpers or profiling_service
 
 
+def _extract_last_run_id(run_history: pd.DataFrame) -> Optional[str]:
+    if not isinstance(run_history, pd.DataFrame) or run_history.empty:
+        return None
+    if "RUN_ID" not in run_history.columns:
+        return None
+    ordered = run_history
+    if "PROFILED_AT" in ordered.columns:
+        ordered = ordered.sort_values(by="PROFILED_AT", ascending=False)
+    latest = ordered.iloc[0]
+    run_id = latest.get("RUN_ID")
+    return str(run_id) if run_id is not None else None
+
+
+def _render_debug_section(data: _ProfilingData, target_fqn: str) -> None:
+    if not DEBUG_PROFILING:
+        return
+
+    last_table = st.session_state.get("profile_last_table") or target_fqn
+    if not last_table:
+        last_table = ui_strings.PROFILE_V2_VALUE_UNKNOWN
+    last_run_id = (
+        st.session_state.get("profile_last_run_id")
+        or _extract_last_run_id(data.recent_runs)
+        or ui_strings.PROFILE_V2_VALUE_UNKNOWN
+    )
+    feature_rows = int(len(data.column_features.index)) if isinstance(data.column_features, pd.DataFrame) else 0
+    class_rows = int(len(data.column_classification.index)) if isinstance(data.column_classification, pd.DataFrame) else 0
+    suggestion_rows = int(len(data.suggested_checks.index)) if isinstance(data.suggested_checks, pd.DataFrame) else 0
+    debug_payload = {
+        "summary": data.summary,
+        "column_features": data.column_features.to_dict("records"),
+        "column_classification": data.column_classification.to_dict("records"),
+        "suggested_checks": data.suggested_checks.to_dict("records"),
+        "recent_runs": data.recent_runs.to_dict("records"),
+    }
+    with st.expander(ui_strings.PROFILE_V2_DEBUG_EXPANDER, expanded=False):
+        st.markdown(f"**{ui_strings.PROFILE_V2_DEBUG_STATUS_HEADER}**")
+        status_cols = st.columns(2)
+        status_cols[0].metric(ui_strings.PROFILE_V2_DEBUG_LAST_TABLE, last_table)
+        status_cols[1].metric(ui_strings.PROFILE_V2_DEBUG_LAST_RUN_ID, last_run_id)
+        row_cols = st.columns(3)
+        row_cols[0].metric(ui_strings.PROFILE_V2_DEBUG_FEATURE_ROWS, feature_rows)
+        row_cols[1].metric(ui_strings.PROFILE_V2_DEBUG_CLASS_ROWS, class_rows)
+        row_cols[2].metric(ui_strings.PROFILE_V2_DEBUG_SUGGESTION_ROWS, suggestion_rows)
+        st.json(debug_payload)
+
+
 def _load_metadata(
     helpers: Any,
     session: Any,
@@ -345,6 +392,8 @@ def render_profile(
                 )
             else:
                 st.session_state["profile_data_nonce"] += 1
+                st.session_state["profile_last_table"] = target_fqn
+                st.session_state["profile_last_run_id"] = None
                 status_placeholder.success(
                     ui_strings.PROFILE_V2_RUN_SUCCESS.format(table=target_fqn)
                 )
@@ -367,6 +416,9 @@ def render_profile(
     with st.spinner(ui_strings.PROFILE_V2_LOAD_SPINNER):
         data = _load_metadata(helpers, session, target_fqn)
 
+    st.session_state["profile_last_table"] = target_fqn
+    st.session_state["profile_last_run_id"] = _extract_last_run_id(data.recent_runs)
+
     _render_summary(data.summary, data.column_features)
 
     tab_titles = [
@@ -386,13 +438,4 @@ def render_profile(
     with tabs[3]:
         _render_run_history_tab(data.recent_runs)
 
-    if DEBUG_PROFILING:
-        debug_payload = {
-            "summary": data.summary,
-            "column_features": data.column_features.to_dict("records"),
-            "column_classification": data.column_classification.to_dict("records"),
-            "suggested_checks": data.suggested_checks.to_dict("records"),
-            "recent_runs": data.recent_runs.to_dict("records"),
-        }
-        with st.expander(ui_strings.PROFILE_V2_DEBUG_EXPANDER, expanded=False):
-            st.json(debug_payload)
+    _render_debug_section(data, target_fqn)


### PR DESCRIPTION
- Added friendly error handling around DQ_PROFILE_FULL plus logging so failed runs surface clear status in the UI.
- Wrapped all Profiling v2 metadata fetch helpers with defensive logging that returns empty frames when Snowflake queries fail.
- Extended the Profiling view debug expander with last-run context (table, run id, row counts) to help diagnose empty states.
- Mirrored the latest Python changes into the /snapshots .p files.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691614fb2c988324b40d1e75ea42af2d)