### PR TITLE
A2.1 – Fix DQ_PROFILE_RUN column mapping in Profiling v2

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -202,16 +202,15 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
 
     sql = f"""
         SELECT
-            RUN_ID,
+            PROFILE_RUN_ID AS RUN_ID,
             TABLE_FQN,
-            PROFILED_AT,
-            ROW_COUNT,
-            SAMPLE_PERCENT,
+            STARTED_AT,
+            FINISHED_AT,
             STATUS,
-            DURATION_SECONDS
+            DETAILS
         FROM {PROFILE_RUN_TABLE}
         WHERE TABLE_FQN = ?
-        ORDER BY PROFILED_AT DESC
+        ORDER BY STARTED_AT DESC
         LIMIT {max(1, limit)}
     """
     return _execute_sql(session, sql, params=[normalized]).to_pandas()

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -202,16 +202,15 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
 
     sql = f"""
         SELECT
-            RUN_ID,
+            PROFILE_RUN_ID AS RUN_ID,
             TABLE_FQN,
-            PROFILED_AT,
-            ROW_COUNT,
-            SAMPLE_PERCENT,
+            STARTED_AT,
+            FINISHED_AT,
             STATUS,
-            DURATION_SECONDS
+            DETAILS
         FROM {PROFILE_RUN_TABLE}
         WHERE TABLE_FQN = ?
-        ORDER BY PROFILED_AT DESC
+        ORDER BY STARTED_AT DESC
         LIMIT {max(1, limit)}
     """
     return _execute_sql(session, sql, params=[normalized]).to_pandas()


### PR DESCRIPTION
- Update `fetch_recent_runs` to read `PROFILE_RUN_ID` (aliased back to `RUN_ID`) and the available timestamp/detail columns from `ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_PROFILE_RUN`.
- Refresh the mirrored snapshot for `services/profiling_v2.py`. 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691618033b9c83248aa91563cfc7209d)