### PR TITLE
P2-A6 – Align profiling_v2 backend with final DQ schema

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -26,13 +26,24 @@ class ProfilingError(RuntimeError):
 
 
 def _normalize_table_fqn(table_fqn: Optional[str]) -> str:
-    if not table_fqn:
+    """Return the table FQN when it is a clean DB.SCHEMA.TABLE string."""
+
+    if table_fqn is None:
         return ""
-    cleaned = str(table_fqn).strip()
-    if not cleaned:
+
+    value = str(table_fqn)
+    if not value:
         return ""
-    cleaned = cleaned.strip('"')
-    return cleaned.upper()
+
+    # Reject inputs with leading/trailing whitespace to avoid mutating the FQN.
+    if value != value.strip():
+        return ""
+
+    parts = value.split(".")
+    if len(parts) != 3 or any(not part for part in parts):
+        return ""
+
+    return value
 
 
 def _require_session(session: Any) -> Any:
@@ -127,7 +138,14 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         ORDER BY COLUMN_NAME
     """
     try:
-        return _fetch_dataframe(session, sql, params=[normalized])
+        df = _fetch_dataframe(session, sql, params=[normalized])
+        if not df.empty:
+            for column in ("MIN_VALUE", "MAX_VALUE"):
+                if column in df.columns:
+                    df[column] = df[column].apply(
+                        lambda value: None if pd.isna(value) else str(value)
+                    )
+        return df
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         LOGGER.exception("profiling_v2:column_features_failed target=%s", normalized)
         return pd.DataFrame()

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -26,13 +26,24 @@ class ProfilingError(RuntimeError):
 
 
 def _normalize_table_fqn(table_fqn: Optional[str]) -> str:
-    if not table_fqn:
+    """Return the table FQN when it is a clean DB.SCHEMA.TABLE string."""
+
+    if table_fqn is None:
         return ""
-    cleaned = str(table_fqn).strip()
-    if not cleaned:
+
+    value = str(table_fqn)
+    if not value:
         return ""
-    cleaned = cleaned.strip('"')
-    return cleaned.upper()
+
+    # Reject inputs with leading/trailing whitespace to avoid mutating the FQN.
+    if value != value.strip():
+        return ""
+
+    parts = value.split(".")
+    if len(parts) != 3 or any(not part for part in parts):
+        return ""
+
+    return value
 
 
 def _require_session(session: Any) -> Any:
@@ -127,7 +138,14 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         ORDER BY COLUMN_NAME
     """
     try:
-        return _fetch_dataframe(session, sql, params=[normalized])
+        df = _fetch_dataframe(session, sql, params=[normalized])
+        if not df.empty:
+            for column in ("MIN_VALUE", "MAX_VALUE"):
+                if column in df.columns:
+                    df[column] = df[column].apply(
+                        lambda value: None if pd.isna(value) else str(value)
+                    )
+        return df
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         LOGGER.exception("profiling_v2:column_features_failed target=%s", normalized)
         return pd.DataFrame()

--- a/snapshots/tests/test_sql_golden.p
+++ b/snapshots/tests/test_sql_golden.p
@@ -31,7 +31,7 @@ class RecordingSession:
 
 def test_run_profiling_v2_invokes_procedure():
     session = RecordingSession([None])
-    profiling_v2.run_profiling_v2(session, 'db.schema.table')
+    profiling_v2.run_profiling_v2(session, 'DB.SCHEMA.TABLE')
 
     assert session.calls, "Stored procedure call was not recorded"
     sql, params = session.calls[0]
@@ -54,7 +54,7 @@ def test_get_table_profile_summary_returns_frame():
     )
     session = RecordingSession([frame])
 
-    summary_frame = profiling_v2.get_table_profile_summary(session, 'db.schema.table')
+    summary_frame = profiling_v2.get_table_profile_summary(session, 'DB.SCHEMA.TABLE')
 
     assert list(summary_frame["ROW_COUNT"]) == [100, 250]
     assert summary_frame.shape == (2, 3)

--- a/tests/test_sql_golden.py
+++ b/tests/test_sql_golden.py
@@ -31,7 +31,7 @@ class RecordingSession:
 
 def test_run_profiling_v2_invokes_procedure():
     session = RecordingSession([None])
-    profiling_v2.run_profiling_v2(session, 'db.schema.table')
+    profiling_v2.run_profiling_v2(session, 'DB.SCHEMA.TABLE')
 
     assert session.calls, "Stored procedure call was not recorded"
     sql, params = session.calls[0]
@@ -54,7 +54,7 @@ def test_get_table_profile_summary_returns_frame():
     )
     session = RecordingSession([frame])
 
-    summary_frame = profiling_v2.get_table_profile_summary(session, 'db.schema.table')
+    summary_frame = profiling_v2.get_table_profile_summary(session, 'DB.SCHEMA.TABLE')
 
     assert list(summary_frame["ROW_COUNT"]) == [100, 250]
     assert summary_frame.shape == (2, 3)


### PR DESCRIPTION
- Validate table_fqn inputs as DB.SCHEMA.TABLE strings and pass them through unchanged to all profiling_v2 queries.
- Treat MIN_VALUE and MAX_VALUE as plain strings in column feature results while continuing to query the fully qualified discovery tables.
- Update the SQL golden tests and mirrored snapshot files to reflect the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3af1fb548324b65d10817bb56a31)