### PR TITLE
P2-A8 – Add user-friendly status + error handling to Profiling v2

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -231,4 +231,8 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
         ORDER BY STARTED_AT DESC
         LIMIT {max(1, limit)}
     """
-    return _execute_sql(session, sql, params=[normalized]).to_pandas()
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:recent_runs_failed target=%s", normalized)
+        return pd.DataFrame()

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -231,4 +231,8 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
         ORDER BY STARTED_AT DESC
         LIMIT {max(1, limit)}
     """
-    return _execute_sql(session, sql, params=[normalized]).to_pandas()
+    try:
+        return _fetch_dataframe(session, sql, params=[normalized])
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        LOGGER.exception("profiling_v2:recent_runs_failed target=%s", normalized)
+        return pd.DataFrame()

--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -22,6 +22,7 @@ PROFILE_V2_LOAD_SPINNER = "Loading profiling metadata..."
 PROFILE_V2_RUN_SPINNER = "Running DQ_PROFILE_FULL for {table}..."
 PROFILE_V2_RUN_ERROR = "Failed to profile table: {error}"
 PROFILE_V2_RUN_SUCCESS = "Profiling completed for {table}."
+PROFILE_V2_METADATA_ERROR = "Failed to load profiling metadata: {error}"
 PROFILE_V2_STATUS_SUBHEADER = "Last profiling run"
 PROFILE_V2_STATUS_EMPTY = "No profiling runs recorded for {table}. Run profiling to populate results."
 PROFILE_V2_STATUS_MESSAGE = (

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -79,6 +79,15 @@ def _merge_column_details(features: pd.DataFrame, classification: pd.DataFrame) 
     return pd.DataFrame.from_records(records) if records else pd.DataFrame()
 
 
+def _truncate_details(value: Any, max_length: int = 500) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1].rstrip() + "\u2026"
+
+
 def _prepare_suggested_checks(df: pd.DataFrame) -> pd.DataFrame:
     if df.empty:
         return df
@@ -174,6 +183,11 @@ def _status_banner(status: str):
     return st.info
 
 
+def _is_failure_status(status: str) -> bool:
+    normalized = (status or "").upper()
+    return normalized in {"FAILED", "ERROR"}
+
+
 def _render_last_run_banner(run_history: pd.DataFrame, target_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_STATUS_SUBHEADER)
     latest = _latest_run_record(run_history)
@@ -199,9 +213,11 @@ def _render_last_run_banner(run_history: pd.DataFrame, target_fqn: str) -> None:
         )
     )
     details = latest.get("DETAILS")
-    if details:
+    if details and _is_failure_status(str(status_value)):
         st.caption(
-            ui_strings.PROFILE_V2_STATUS_DETAILS.format(details=str(details))
+            ui_strings.PROFILE_V2_STATUS_DETAILS.format(
+                details=_truncate_details(details)
+            )
         )
 
 
@@ -351,7 +367,13 @@ def render_profile(
     )
 
     with st.spinner(ui_strings.PROFILE_V2_LOAD_SPINNER):
-        data = _load_metadata(helpers, session, target_fqn)
+        try:
+            data = _load_metadata(helpers, session, target_fqn)
+        except Exception as exc:
+            st.error(
+                ui_strings.PROFILE_V2_METADATA_ERROR.format(error=str(exc))
+            )
+            return
 
     st.session_state["profile_last_table"] = target_fqn
     st.session_state["profile_last_run_id"] = _extract_last_run_id(data.recent_runs)

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -22,6 +22,7 @@ PROFILE_V2_LOAD_SPINNER = "Loading profiling metadata..."
 PROFILE_V2_RUN_SPINNER = "Running DQ_PROFILE_FULL for {table}..."
 PROFILE_V2_RUN_ERROR = "Failed to profile table: {error}"
 PROFILE_V2_RUN_SUCCESS = "Profiling completed for {table}."
+PROFILE_V2_METADATA_ERROR = "Failed to load profiling metadata: {error}"
 PROFILE_V2_STATUS_SUBHEADER = "Last profiling run"
 PROFILE_V2_STATUS_EMPTY = "No profiling runs recorded for {table}. Run profiling to populate results."
 PROFILE_V2_STATUS_MESSAGE = (

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -79,6 +79,15 @@ def _merge_column_details(features: pd.DataFrame, classification: pd.DataFrame) 
     return pd.DataFrame.from_records(records) if records else pd.DataFrame()
 
 
+def _truncate_details(value: Any, max_length: int = 500) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1].rstrip() + "\u2026"
+
+
 def _prepare_suggested_checks(df: pd.DataFrame) -> pd.DataFrame:
     if df.empty:
         return df
@@ -174,6 +183,11 @@ def _status_banner(status: str):
     return st.info
 
 
+def _is_failure_status(status: str) -> bool:
+    normalized = (status or "").upper()
+    return normalized in {"FAILED", "ERROR"}
+
+
 def _render_last_run_banner(run_history: pd.DataFrame, target_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_STATUS_SUBHEADER)
     latest = _latest_run_record(run_history)
@@ -199,9 +213,11 @@ def _render_last_run_banner(run_history: pd.DataFrame, target_fqn: str) -> None:
         )
     )
     details = latest.get("DETAILS")
-    if details:
+    if details and _is_failure_status(str(status_value)):
         st.caption(
-            ui_strings.PROFILE_V2_STATUS_DETAILS.format(details=str(details))
+            ui_strings.PROFILE_V2_STATUS_DETAILS.format(
+                details=_truncate_details(details)
+            )
         )
 
 
@@ -351,7 +367,13 @@ def render_profile(
     )
 
     with st.spinner(ui_strings.PROFILE_V2_LOAD_SPINNER):
-        data = _load_metadata(helpers, session, target_fqn)
+        try:
+            data = _load_metadata(helpers, session, target_fqn)
+        except Exception as exc:
+            st.error(
+                ui_strings.PROFILE_V2_METADATA_ERROR.format(error=str(exc))
+            )
+            return
 
     st.session_state["profile_last_table"] = target_fqn
     st.session_state["profile_last_run_id"] = _extract_last_run_id(data.recent_runs)


### PR DESCRIPTION
- Hardened the Profiling view to show status-aware banners, truncate failure details, and surface metadata load errors without crashing the UI.
- Wrapped DQ_PROFILE_RUN fetching in fault-tolerant logic and refreshed the snapshot mirror outputs.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c40fd677c8324a3f98c76fe1e5bb5)