### PR TITLE
P2-B2 – Simplify Profiling v2 UI to a single overview grid

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import streamlit as st
@@ -17,9 +17,8 @@ from views.table_picker import stateless_table_picker
 class _ProfilingData:
     """Container for profiling metadata used by the UI."""
 
-    column_features: pd.DataFrame
+    overview_grid: pd.DataFrame
     column_classification: pd.DataFrame
-    suggested_checks: pd.DataFrame
     recent_runs: pd.DataFrame
 
 
@@ -29,19 +28,6 @@ def _format_timestamp(value: Any) -> str:
     if hasattr(value, "strftime"):
         return value.strftime("%Y-%m-%d %H:%M:%S")
     return str(value)
-
-
-def _stringify_params(value: Any) -> str:
-    if value is None:
-        return "{}"
-    if isinstance(value, str):
-        return value
-    try:
-        import json
-
-        return json.dumps(value, sort_keys=True)
-    except Exception:
-        return str(value)
 
 
 def _latest_classifications(class_df: pd.DataFrame) -> Dict[str, Dict[str, Any]]:
@@ -61,30 +47,6 @@ def _latest_classifications(class_df: pd.DataFrame) -> Dict[str, Dict[str, Any]]
     return result
 
 
-def _merge_column_details(features: pd.DataFrame, classification: pd.DataFrame) -> pd.DataFrame:
-    if features.empty:
-        return features
-    class_lookup = _latest_classifications(classification)
-    records: List[Dict[str, Any]] = []
-    feature_records = features.to_dict("records")
-    for record in feature_records:
-        merged = dict(record)
-        column_name = str(record.get("COLUMN_NAME", ""))
-        class_record = class_lookup.get(column_name)
-        if class_record:
-            for key in (
-                "CONTENT_TYPE",
-                "SEMANTIC_ROLE",
-                "SOURCE",
-                "CONFIDENCE",
-                "CLASSIFIED_AT",
-            ):
-                if key in class_record:
-                    merged[key] = class_record.get(key)
-        records.append(merged)
-    return pd.DataFrame.from_records(records) if records else pd.DataFrame()
-
-
 def _truncate_details(value: Any, max_length: int = 500) -> str:
     text = str(value or "").strip()
     if not text:
@@ -92,53 +54,6 @@ def _truncate_details(value: Any, max_length: int = 500) -> str:
     if len(text) <= max_length:
         return text
     return text[: max_length - 1].rstrip() + "\u2026"
-
-
-def _prepare_suggested_checks(df: pd.DataFrame) -> pd.DataFrame:
-    if df.empty:
-        return df
-    working = df.copy()
-    if "PARAMS" in working.columns:
-        working["PARAMS"] = working["PARAMS"].map(_stringify_params)
-    desired_order: List[str] = [
-        "COLUMN_NAME",
-        "RULE_ID",
-        "CHECK_TYPE",
-        "SEVERITY",
-        "PARAMS",
-        "RATIONALE",
-        "SUGGESTED_BY",
-        "SUGGESTED_AT",
-    ]
-    existing = [col for col in desired_order if col in working.columns]
-    trailing = [col for col in working.columns if col not in existing]
-    return working[existing + trailing]
-
-
-def _prepare_columns_grid(features: pd.DataFrame, classification: pd.DataFrame) -> pd.DataFrame:
-    merged = _merge_column_details(features, classification)
-    if merged.empty:
-        return merged
-    desired_order: List[str] = [
-        "COLUMN_NAME",
-        "DATA_TYPE",
-        "NULL_RATIO",
-        "DISTINCT_RATIO",
-        "MIN_VALUE",
-        "MAX_VALUE",
-        "CONTENT_TYPE",
-        "SEMANTIC_ROLE",
-        "SOURCE",
-        "CONFIDENCE",
-        "CLASSIFIED_AT",
-    ]
-    working = merged.copy()
-    for column in desired_order:
-        if column not in working.columns:
-            working[column] = None
-    if "COLUMN_NAME" in working.columns:
-        working = working.sort_values(by="COLUMN_NAME")
-    return working[desired_order]
 
 
 def _calculate_duration_seconds(started: Any, finished: Any) -> Optional[float]:
@@ -238,294 +153,73 @@ def _classification_source_badge(source: Any) -> str:
     return ui_strings.PROFILE_V2_COLUMNS_SOURCE_UNKNOWN
 
 
-def _render_columns_grid(
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-    table_fqn: str,
-    helpers: Any,
-    session: Any,
-) -> None:
+def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_COLUMNS_SUBHEADER)
-    prepared = _prepare_columns_grid(features, classification)
-    if prepared.empty:
+    if not isinstance(overview, pd.DataFrame) or overview.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EMPTY)
-        _render_column_detail_panel(
-            prepared,
-            features,
-            classification,
-            suggestions,
-            table_fqn,
-            helpers,
-            session,
-        )
         return
-    working = prepared.copy()
-    if "SOURCE" in working.columns:
-        working["CLASSIFICATION_SOURCE"] = working["SOURCE"].map(
-            _classification_source_badge
-        )
-    else:
-        working["CLASSIFICATION_SOURCE"] = ui_strings.PROFILE_V2_COLUMNS_SOURCE_UNKNOWN
-    display_columns: List[str] = [
-        "COLUMN_NAME",
-        "DATA_TYPE",
-        "NULL_RATIO",
-        "DISTINCT_RATIO",
-        "MIN_VALUE",
-        "MAX_VALUE",
-        "CONTENT_TYPE",
-        "SEMANTIC_ROLE",
-        "CLASSIFICATION_SOURCE",
-        "CONFIDENCE",
-        "CLASSIFIED_AT",
+
+    working = overview.copy()
+    working.index = working["column_name"].astype(str)
+    columns_to_display = [
+        "column_name",
+        "data_type",
+        "null_info",
+        "distinct_info",
+        "min_value",
+        "max_value",
+        "length_info",
+        "rule_id",
+        "check_type",
+        "severity",
+        "rationale",
+        "include_in_dq_config",
     ]
-    existing = [col for col in display_columns if col in working.columns]
-    grid_col, detail_col = st.columns((3, 2))
-    with grid_col:
-        st.dataframe(working[existing], use_container_width=True, hide_index=True)
-    with detail_col:
-        _render_column_detail_panel(
-            working,
-            features,
-            classification,
-            suggestions,
-            table_fqn,
-            helpers,
-            session,
+    bool_columns = {"has_suggestion", "include_in_dq_config"}
+    for column in columns_to_display + ["has_suggestion"]:
+        if column not in working.columns:
+            working[column] = False if column in bool_columns else ""
+
+    dq_selection = st.session_state.setdefault("dq_config_selection", {})
+    table_selection: Dict[str, bool] = dq_selection.setdefault(table_fqn, {})
+    include_col_index = working.columns.get_loc("include_in_dq_config")
+    for idx, column_name in enumerate(working.index):
+        stored_value = table_selection.get(column_name)
+        if stored_value is None:
+            stored_value = bool(working.iat[idx, include_col_index])
+        working.iat[idx, include_col_index] = bool(stored_value)
+
+    highlight_mask = working["has_suggestion"].fillna(False).astype(bool)
+    working.loc[highlight_mask, "column_name"] = (
+        "💡 " + working.loc[highlight_mask, "column_name"].astype(str)
+    )
+
+    column_config = {
+        "include_in_dq_config": st.column_config.CheckboxColumn(
+            "include_in_dq_config",
+            help="Include this column when generating DQ configs.",
+            default=False,
         )
-    _render_column_editors(working, table_fqn, helpers, session)
-
-
-def _render_column_detail_panel(
-    prepared_grid: pd.DataFrame,
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-    table_fqn: str,
-    helpers: Any,
-    session: Any,
-) -> None:
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_HEADER}**")
-    column_names: List[str] = []
-    if isinstance(prepared_grid, pd.DataFrame) and not prepared_grid.empty:
-        if "COLUMN_NAME" in prepared_grid.columns:
-            column_names = [
-                str(value).strip()
-                for value in prepared_grid["COLUMN_NAME"].tolist()
-                if str(value or "").strip()
-            ]
-    placeholder_option = ui_strings.PROFILE_V2_COLUMN_DETAIL_SELECT_PLACEHOLDER
-    options: List[str] = [placeholder_option, *column_names]
-    stored_selection = st.session_state.get(
-        "profile_column_detail_selection", placeholder_option
-    )
-    if stored_selection not in options:
-        stored_selection = placeholder_option
-    selection = st.selectbox(
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_SELECT_LABEL,
-        options,
-        index=options.index(stored_selection),
-    )
-    st.session_state["profile_column_detail_selection"] = selection
-    if selection == placeholder_option:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_PLACEHOLDER)
-        return
-    detail_data, helper_error = _load_column_detail_payload(
-        helpers,
-        session,
-        table_fqn,
-        selection,
-        features,
-        classification,
-        suggestions,
-    )
-    if helper_error:
-        st.warning(ui_strings.PROFILE_V2_COLUMN_DETAIL_ERROR.format(error=helper_error))
-    if not detail_data:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_PLACEHOLDER)
-        return
-    st.markdown(f"**{table_fqn} – {selection}**")
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_FEATURES_HEADER}**")
-    _render_detail_key_values(
-        detail_data.get("features") or {},
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_FEATURES_EMPTY,
-    )
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_HEADER}**")
-    _render_detail_classification(detail_data.get("classification") or {})
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_HEADER}**")
-    _render_detail_suggestions(detail_data.get("suggested_checks") or [])
-
-
-def _load_column_detail_payload(
-    helpers: Any,
-    session: Any,
-    table_fqn: str,
-    column_name: str,
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-) -> Tuple[Dict[str, Any], Optional[str]]:
-    detail_fn = getattr(helpers, "get_column_detail", None)
-    helper_error: Optional[str] = None
-    detail_data: Dict[str, Any] = {}
-    if callable(detail_fn):
-        try:
-            detail_data = detail_fn(session, table_fqn, column_name)
-        except Exception as exc:  # pragma: no cover - Streamlit runtime feedback only
-            helper_error = str(exc)
-    if not detail_data:
-        detail_data = _build_column_detail_from_frames(
-            features,
-            classification,
-            suggestions,
-            table_fqn,
-            column_name,
-        )
-    return detail_data, helper_error
-
-
-def _build_column_detail_from_frames(
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-    table_fqn: str,
-    column_name: str,
-) -> Dict[str, Any]:
-    column = str(column_name or "").strip()
-    if not column:
-        return {}
-    feature_record = _lookup_feature_record(features, column)
-    classification_record = _lookup_classification_record(classification, column)
-    suggestion_records = _lookup_suggestion_records(suggestions, column)
-    feature_fields = (
-        "DATA_TYPE",
-        "ROW_COUNT",
-        "NULL_COUNT",
-        "NULL_RATIO",
-        "DISTINCT_COUNT",
-        "DISTINCT_RATIO",
-        "MIN_VALUE",
-        "MAX_VALUE",
-        "AVG_LENGTH",
-        "MAX_LENGTH",
-    )
-    classification_fields = (
-        "CONTENT_TYPE",
-        "SEMANTIC_ROLE",
-        "SOURCE",
-        "CONFIDENCE",
-        "CLASSIFIED_AT",
-    )
-    return {
-        "table_fqn": table_fqn,
-        "column_name": column,
-        "features": {
-            key: feature_record.get(key)
-            for key in feature_fields
-            if key in feature_record
-        },
-        "classification": {
-            key: classification_record.get(key)
-            for key in classification_fields
-            if key in classification_record
-        },
-        "suggested_checks": [
-            {
-                "RULE_ID": record.get("RULE_ID"),
-                "CHECK_TYPE": record.get("CHECK_TYPE"),
-                "SEVERITY": record.get("SEVERITY"),
-                "PARAMETERS": record.get("PARAMS", record.get("PARAMETERS")),
-                "RATIONALE": record.get("RATIONALE"),
-            }
-            for record in suggestion_records
-        ],
     }
+    read_only_columns = [column for column in columns_to_display if column != "include_in_dq_config"]
+    for column in read_only_columns:
+        column_config[column] = st.column_config.TextColumn(column, disabled=True)
 
-
-def _lookup_feature_record(features: pd.DataFrame, column_name: str) -> Dict[str, Any]:
-    if not isinstance(features, pd.DataFrame) or features.empty:
-        return {}
-    if "COLUMN_NAME" not in features.columns:
-        return {}
-    folded = features["COLUMN_NAME"].astype(str).str.strip().str.casefold()
-    matches = features.loc[folded == column_name.casefold()]
-    if matches.empty:
-        return {}
-    return matches.iloc[0].to_dict()
-
-
-def _lookup_classification_record(
-    classification: pd.DataFrame, column_name: str
-) -> Dict[str, Any]:
-    latest = _latest_classifications(classification)
-    if not latest:
-        return {}
-    normalized = str(column_name or "").strip()
-    record = latest.get(normalized)
-    if record:
-        return record
-    folded = normalized.casefold()
-    for key, value in latest.items():
-        if str(key or "").strip().casefold() == folded:
-            return value
-    return {}
-
-
-def _lookup_suggestion_records(
-    suggestions: pd.DataFrame, column_name: str
-) -> List[Dict[str, Any]]:
-    if not isinstance(suggestions, pd.DataFrame) or suggestions.empty:
-        return []
-    if "COLUMN_NAME" not in suggestions.columns:
-        return []
-    folded = suggestions["COLUMN_NAME"].astype(str).str.strip().str.casefold()
-    matches = suggestions.loc[folded == column_name.casefold()]
-    if matches.empty:
-        return []
-    return matches.to_dict("records")
-
-
-def _render_detail_key_values(values: Dict[str, Any], empty_message: str) -> None:
-    items = list(values.items())
-    if not items:
-        st.info(empty_message)
-        return
-    for start in range(0, len(items), 2):
-        cols = st.columns(2)
-        for offset, (key, value) in enumerate(items[start : start + 2]):
-            cols[offset].markdown(
-                f"**{key}**\n\n{_format_detail_value(value)}"
-            )
-
-
-def _render_detail_classification(classification: Dict[str, Any]) -> None:
-    if not classification:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_EMPTY)
-        return
-    content = classification.get("CONTENT_TYPE")
-    semantic = classification.get("SEMANTIC_ROLE")
-    st.write(
-        f"**{ui_strings.PROFILE_V2_COLUMN_CONTENT_LABEL}:** "
-        f"{_format_detail_value(content)}"
+    table_key = table_fqn.replace(".", "_") if table_fqn else "overview"
+    edited_df = st.data_editor(
+        working[columns_to_display],
+        key=f"profile_overview_grid_{table_key}",
+        use_container_width=True,
+        hide_index=True,
+        num_rows="fixed",
+        column_config=column_config,
     )
-    st.write(
-        f"**{ui_strings.PROFILE_V2_COLUMN_SEMANTIC_LABEL}:** "
-        f"{_format_detail_value(semantic)}"
-    )
-    confidence = _format_detail_value(classification.get("CONFIDENCE"))
-    classified_at = _format_timestamp(classification.get("CLASSIFIED_AT"))
-    st.caption(
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_STATUS.format(
-            confidence=confidence,
-            classified_at=classified_at,
-        )
-    )
-    st.caption(
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_SOURCE.format(
-            source=_classification_source_detail(classification.get("SOURCE")),
-        )
-    )
+
+    if isinstance(edited_df, pd.DataFrame) and "include_in_dq_config" in edited_df.columns:
+        dq_selection[table_fqn] = {
+            str(index): bool(value)
+            for index, value in edited_df["include_in_dq_config"].items()
+        }
 
 
 def _classification_source_detail(source: Any) -> str:
@@ -539,48 +233,27 @@ def _classification_source_detail(source: Any) -> str:
     return ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_UNKNOWN
 
 
-def _render_detail_suggestions(records: List[Dict[str, Any]]) -> None:
-    if not records:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_EMPTY)
-        return
-    df = pd.DataFrame(records)
-    if df.empty:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_EMPTY)
-        return
-    if "PARAMETERS" in df.columns:
-        df["PARAMETERS"] = df["PARAMETERS"].map(_stringify_params)
-    st.dataframe(df, use_container_width=True, hide_index=True)
-
-
-def _format_detail_value(value: Any) -> str:
-    if value is None:
-        return ui_strings.PROFILE_V2_VALUE_UNKNOWN
-    if isinstance(value, (int, float)):
-        if pd.isna(value):
-            return ui_strings.PROFILE_V2_VALUE_UNKNOWN
-        return str(value)
-    text = str(value).strip()
-    if not text:
-        return ui_strings.PROFILE_V2_VALUE_UNKNOWN
-    return text
-
-
 def _render_column_editors(
-    prepared: pd.DataFrame,
+    classification: pd.DataFrame,
     table_fqn: str,
     helpers: Any,
     session: Any,
 ) -> None:
-    if prepared.empty:
+    if not isinstance(classification, pd.DataFrame) or classification.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_EMPTY)
         return
+    latest_records = _latest_classifications(classification)
+    if latest_records:
+        working = pd.DataFrame.from_records(latest_records.values())
+    else:
+        working = classification.copy()
     save_fn = getattr(helpers, "save_manual_classification", None)
     if not callable(save_fn):
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_UNAVAILABLE)
         return
     st.markdown(f"**{ui_strings.PROFILE_V2_COLUMNS_EDIT_HEADER}**")
     st.caption(ui_strings.PROFILE_V2_COLUMNS_EDIT_HELP)
-    for record in prepared.to_dict("records"):
+    for record in working.to_dict("records"):
         _render_column_editor_form(record, table_fqn, session, save_fn)
 
 
@@ -684,15 +357,6 @@ def _handle_manual_classification_save(
     st.experimental_rerun()
 
 
-def _render_suggested_checks_grid(suggested_checks: pd.DataFrame) -> None:
-    st.subheader(ui_strings.PROFILE_V2_SUGGESTIONS_SUBHEADER)
-    prepared = _prepare_suggested_checks(suggested_checks)
-    if prepared.empty:
-        st.info(ui_strings.PROFILE_V2_SUGGESTIONS_EMPTY)
-        return
-    st.dataframe(prepared, use_container_width=True, hide_index=True)
-
-
 def _resolve_helpers(profiling_helpers: Optional[Any]):
     return profiling_helpers or profiling_service
 
@@ -717,10 +381,10 @@ def _load_metadata(
     session: Any,
     table_fqn: str,
 ) -> _ProfilingData:
-    column_features_fn = getattr(helpers, "get_column_features", None)
-    column_features = (
-        column_features_fn(session, table_fqn)
-        if callable(column_features_fn)
+    overview_fn = getattr(helpers, "get_overview_grid", None)
+    overview_grid = (
+        overview_fn(session, table_fqn)
+        if callable(overview_fn)
         else pd.DataFrame()
     )
     effective_class_fn = getattr(helpers, "get_effective_classification", None)
@@ -733,18 +397,11 @@ def _load_metadata(
             if callable(column_class_fn)
             else pd.DataFrame()
         )
-    suggested_checks_fn = getattr(helpers, "get_suggested_checks", None)
-    suggested_checks = (
-        suggested_checks_fn(session, table_fqn)
-        if callable(suggested_checks_fn)
-        else pd.DataFrame()
-    )
     run_history_fn = getattr(helpers, "fetch_recent_runs", None)
     recent_runs = run_history_fn(session, table_fqn) if callable(run_history_fn) else pd.DataFrame()
     return _ProfilingData(
-        column_features=column_features if isinstance(column_features, pd.DataFrame) else pd.DataFrame(),
+        overview_grid=overview_grid if isinstance(overview_grid, pd.DataFrame) else pd.DataFrame(),
         column_classification=column_classification if isinstance(column_classification, pd.DataFrame) else pd.DataFrame(),
-        suggested_checks=suggested_checks if isinstance(suggested_checks, pd.DataFrame) else pd.DataFrame(),
         recent_runs=recent_runs if isinstance(recent_runs, pd.DataFrame) else pd.DataFrame(),
     )
 
@@ -896,13 +553,6 @@ def render_profile(
 
     _render_last_run_banner(data.recent_runs, target_fqn)
     st.divider()
-    _render_columns_grid(
-        data.column_features,
-        data.column_classification,
-        data.suggested_checks,
-        target_fqn,
-        helpers,
-        session,
-    )
+    _render_overview_grid(data.overview_grid, target_fqn)
     st.divider()
-    _render_suggested_checks_grid(data.suggested_checks)
+    _render_column_editors(data.column_classification, target_fqn, helpers, session)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import streamlit as st
@@ -17,9 +17,8 @@ from views.table_picker import stateless_table_picker
 class _ProfilingData:
     """Container for profiling metadata used by the UI."""
 
-    column_features: pd.DataFrame
+    overview_grid: pd.DataFrame
     column_classification: pd.DataFrame
-    suggested_checks: pd.DataFrame
     recent_runs: pd.DataFrame
 
 
@@ -29,19 +28,6 @@ def _format_timestamp(value: Any) -> str:
     if hasattr(value, "strftime"):
         return value.strftime("%Y-%m-%d %H:%M:%S")
     return str(value)
-
-
-def _stringify_params(value: Any) -> str:
-    if value is None:
-        return "{}"
-    if isinstance(value, str):
-        return value
-    try:
-        import json
-
-        return json.dumps(value, sort_keys=True)
-    except Exception:
-        return str(value)
 
 
 def _latest_classifications(class_df: pd.DataFrame) -> Dict[str, Dict[str, Any]]:
@@ -61,30 +47,6 @@ def _latest_classifications(class_df: pd.DataFrame) -> Dict[str, Dict[str, Any]]
     return result
 
 
-def _merge_column_details(features: pd.DataFrame, classification: pd.DataFrame) -> pd.DataFrame:
-    if features.empty:
-        return features
-    class_lookup = _latest_classifications(classification)
-    records: List[Dict[str, Any]] = []
-    feature_records = features.to_dict("records")
-    for record in feature_records:
-        merged = dict(record)
-        column_name = str(record.get("COLUMN_NAME", ""))
-        class_record = class_lookup.get(column_name)
-        if class_record:
-            for key in (
-                "CONTENT_TYPE",
-                "SEMANTIC_ROLE",
-                "SOURCE",
-                "CONFIDENCE",
-                "CLASSIFIED_AT",
-            ):
-                if key in class_record:
-                    merged[key] = class_record.get(key)
-        records.append(merged)
-    return pd.DataFrame.from_records(records) if records else pd.DataFrame()
-
-
 def _truncate_details(value: Any, max_length: int = 500) -> str:
     text = str(value or "").strip()
     if not text:
@@ -92,53 +54,6 @@ def _truncate_details(value: Any, max_length: int = 500) -> str:
     if len(text) <= max_length:
         return text
     return text[: max_length - 1].rstrip() + "\u2026"
-
-
-def _prepare_suggested_checks(df: pd.DataFrame) -> pd.DataFrame:
-    if df.empty:
-        return df
-    working = df.copy()
-    if "PARAMS" in working.columns:
-        working["PARAMS"] = working["PARAMS"].map(_stringify_params)
-    desired_order: List[str] = [
-        "COLUMN_NAME",
-        "RULE_ID",
-        "CHECK_TYPE",
-        "SEVERITY",
-        "PARAMS",
-        "RATIONALE",
-        "SUGGESTED_BY",
-        "SUGGESTED_AT",
-    ]
-    existing = [col for col in desired_order if col in working.columns]
-    trailing = [col for col in working.columns if col not in existing]
-    return working[existing + trailing]
-
-
-def _prepare_columns_grid(features: pd.DataFrame, classification: pd.DataFrame) -> pd.DataFrame:
-    merged = _merge_column_details(features, classification)
-    if merged.empty:
-        return merged
-    desired_order: List[str] = [
-        "COLUMN_NAME",
-        "DATA_TYPE",
-        "NULL_RATIO",
-        "DISTINCT_RATIO",
-        "MIN_VALUE",
-        "MAX_VALUE",
-        "CONTENT_TYPE",
-        "SEMANTIC_ROLE",
-        "SOURCE",
-        "CONFIDENCE",
-        "CLASSIFIED_AT",
-    ]
-    working = merged.copy()
-    for column in desired_order:
-        if column not in working.columns:
-            working[column] = None
-    if "COLUMN_NAME" in working.columns:
-        working = working.sort_values(by="COLUMN_NAME")
-    return working[desired_order]
 
 
 def _calculate_duration_seconds(started: Any, finished: Any) -> Optional[float]:
@@ -238,294 +153,73 @@ def _classification_source_badge(source: Any) -> str:
     return ui_strings.PROFILE_V2_COLUMNS_SOURCE_UNKNOWN
 
 
-def _render_columns_grid(
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-    table_fqn: str,
-    helpers: Any,
-    session: Any,
-) -> None:
+def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_COLUMNS_SUBHEADER)
-    prepared = _prepare_columns_grid(features, classification)
-    if prepared.empty:
+    if not isinstance(overview, pd.DataFrame) or overview.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EMPTY)
-        _render_column_detail_panel(
-            prepared,
-            features,
-            classification,
-            suggestions,
-            table_fqn,
-            helpers,
-            session,
-        )
         return
-    working = prepared.copy()
-    if "SOURCE" in working.columns:
-        working["CLASSIFICATION_SOURCE"] = working["SOURCE"].map(
-            _classification_source_badge
-        )
-    else:
-        working["CLASSIFICATION_SOURCE"] = ui_strings.PROFILE_V2_COLUMNS_SOURCE_UNKNOWN
-    display_columns: List[str] = [
-        "COLUMN_NAME",
-        "DATA_TYPE",
-        "NULL_RATIO",
-        "DISTINCT_RATIO",
-        "MIN_VALUE",
-        "MAX_VALUE",
-        "CONTENT_TYPE",
-        "SEMANTIC_ROLE",
-        "CLASSIFICATION_SOURCE",
-        "CONFIDENCE",
-        "CLASSIFIED_AT",
+
+    working = overview.copy()
+    working.index = working["column_name"].astype(str)
+    columns_to_display = [
+        "column_name",
+        "data_type",
+        "null_info",
+        "distinct_info",
+        "min_value",
+        "max_value",
+        "length_info",
+        "rule_id",
+        "check_type",
+        "severity",
+        "rationale",
+        "include_in_dq_config",
     ]
-    existing = [col for col in display_columns if col in working.columns]
-    grid_col, detail_col = st.columns((3, 2))
-    with grid_col:
-        st.dataframe(working[existing], use_container_width=True, hide_index=True)
-    with detail_col:
-        _render_column_detail_panel(
-            working,
-            features,
-            classification,
-            suggestions,
-            table_fqn,
-            helpers,
-            session,
+    bool_columns = {"has_suggestion", "include_in_dq_config"}
+    for column in columns_to_display + ["has_suggestion"]:
+        if column not in working.columns:
+            working[column] = False if column in bool_columns else ""
+
+    dq_selection = st.session_state.setdefault("dq_config_selection", {})
+    table_selection: Dict[str, bool] = dq_selection.setdefault(table_fqn, {})
+    include_col_index = working.columns.get_loc("include_in_dq_config")
+    for idx, column_name in enumerate(working.index):
+        stored_value = table_selection.get(column_name)
+        if stored_value is None:
+            stored_value = bool(working.iat[idx, include_col_index])
+        working.iat[idx, include_col_index] = bool(stored_value)
+
+    highlight_mask = working["has_suggestion"].fillna(False).astype(bool)
+    working.loc[highlight_mask, "column_name"] = (
+        "💡 " + working.loc[highlight_mask, "column_name"].astype(str)
+    )
+
+    column_config = {
+        "include_in_dq_config": st.column_config.CheckboxColumn(
+            "include_in_dq_config",
+            help="Include this column when generating DQ configs.",
+            default=False,
         )
-    _render_column_editors(working, table_fqn, helpers, session)
-
-
-def _render_column_detail_panel(
-    prepared_grid: pd.DataFrame,
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-    table_fqn: str,
-    helpers: Any,
-    session: Any,
-) -> None:
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_HEADER}**")
-    column_names: List[str] = []
-    if isinstance(prepared_grid, pd.DataFrame) and not prepared_grid.empty:
-        if "COLUMN_NAME" in prepared_grid.columns:
-            column_names = [
-                str(value).strip()
-                for value in prepared_grid["COLUMN_NAME"].tolist()
-                if str(value or "").strip()
-            ]
-    placeholder_option = ui_strings.PROFILE_V2_COLUMN_DETAIL_SELECT_PLACEHOLDER
-    options: List[str] = [placeholder_option, *column_names]
-    stored_selection = st.session_state.get(
-        "profile_column_detail_selection", placeholder_option
-    )
-    if stored_selection not in options:
-        stored_selection = placeholder_option
-    selection = st.selectbox(
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_SELECT_LABEL,
-        options,
-        index=options.index(stored_selection),
-    )
-    st.session_state["profile_column_detail_selection"] = selection
-    if selection == placeholder_option:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_PLACEHOLDER)
-        return
-    detail_data, helper_error = _load_column_detail_payload(
-        helpers,
-        session,
-        table_fqn,
-        selection,
-        features,
-        classification,
-        suggestions,
-    )
-    if helper_error:
-        st.warning(ui_strings.PROFILE_V2_COLUMN_DETAIL_ERROR.format(error=helper_error))
-    if not detail_data:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_PLACEHOLDER)
-        return
-    st.markdown(f"**{table_fqn} – {selection}**")
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_FEATURES_HEADER}**")
-    _render_detail_key_values(
-        detail_data.get("features") or {},
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_FEATURES_EMPTY,
-    )
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_HEADER}**")
-    _render_detail_classification(detail_data.get("classification") or {})
-    st.markdown(f"**{ui_strings.PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_HEADER}**")
-    _render_detail_suggestions(detail_data.get("suggested_checks") or [])
-
-
-def _load_column_detail_payload(
-    helpers: Any,
-    session: Any,
-    table_fqn: str,
-    column_name: str,
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-) -> Tuple[Dict[str, Any], Optional[str]]:
-    detail_fn = getattr(helpers, "get_column_detail", None)
-    helper_error: Optional[str] = None
-    detail_data: Dict[str, Any] = {}
-    if callable(detail_fn):
-        try:
-            detail_data = detail_fn(session, table_fqn, column_name)
-        except Exception as exc:  # pragma: no cover - Streamlit runtime feedback only
-            helper_error = str(exc)
-    if not detail_data:
-        detail_data = _build_column_detail_from_frames(
-            features,
-            classification,
-            suggestions,
-            table_fqn,
-            column_name,
-        )
-    return detail_data, helper_error
-
-
-def _build_column_detail_from_frames(
-    features: pd.DataFrame,
-    classification: pd.DataFrame,
-    suggestions: pd.DataFrame,
-    table_fqn: str,
-    column_name: str,
-) -> Dict[str, Any]:
-    column = str(column_name or "").strip()
-    if not column:
-        return {}
-    feature_record = _lookup_feature_record(features, column)
-    classification_record = _lookup_classification_record(classification, column)
-    suggestion_records = _lookup_suggestion_records(suggestions, column)
-    feature_fields = (
-        "DATA_TYPE",
-        "ROW_COUNT",
-        "NULL_COUNT",
-        "NULL_RATIO",
-        "DISTINCT_COUNT",
-        "DISTINCT_RATIO",
-        "MIN_VALUE",
-        "MAX_VALUE",
-        "AVG_LENGTH",
-        "MAX_LENGTH",
-    )
-    classification_fields = (
-        "CONTENT_TYPE",
-        "SEMANTIC_ROLE",
-        "SOURCE",
-        "CONFIDENCE",
-        "CLASSIFIED_AT",
-    )
-    return {
-        "table_fqn": table_fqn,
-        "column_name": column,
-        "features": {
-            key: feature_record.get(key)
-            for key in feature_fields
-            if key in feature_record
-        },
-        "classification": {
-            key: classification_record.get(key)
-            for key in classification_fields
-            if key in classification_record
-        },
-        "suggested_checks": [
-            {
-                "RULE_ID": record.get("RULE_ID"),
-                "CHECK_TYPE": record.get("CHECK_TYPE"),
-                "SEVERITY": record.get("SEVERITY"),
-                "PARAMETERS": record.get("PARAMS", record.get("PARAMETERS")),
-                "RATIONALE": record.get("RATIONALE"),
-            }
-            for record in suggestion_records
-        ],
     }
+    read_only_columns = [column for column in columns_to_display if column != "include_in_dq_config"]
+    for column in read_only_columns:
+        column_config[column] = st.column_config.TextColumn(column, disabled=True)
 
-
-def _lookup_feature_record(features: pd.DataFrame, column_name: str) -> Dict[str, Any]:
-    if not isinstance(features, pd.DataFrame) or features.empty:
-        return {}
-    if "COLUMN_NAME" not in features.columns:
-        return {}
-    folded = features["COLUMN_NAME"].astype(str).str.strip().str.casefold()
-    matches = features.loc[folded == column_name.casefold()]
-    if matches.empty:
-        return {}
-    return matches.iloc[0].to_dict()
-
-
-def _lookup_classification_record(
-    classification: pd.DataFrame, column_name: str
-) -> Dict[str, Any]:
-    latest = _latest_classifications(classification)
-    if not latest:
-        return {}
-    normalized = str(column_name or "").strip()
-    record = latest.get(normalized)
-    if record:
-        return record
-    folded = normalized.casefold()
-    for key, value in latest.items():
-        if str(key or "").strip().casefold() == folded:
-            return value
-    return {}
-
-
-def _lookup_suggestion_records(
-    suggestions: pd.DataFrame, column_name: str
-) -> List[Dict[str, Any]]:
-    if not isinstance(suggestions, pd.DataFrame) or suggestions.empty:
-        return []
-    if "COLUMN_NAME" not in suggestions.columns:
-        return []
-    folded = suggestions["COLUMN_NAME"].astype(str).str.strip().str.casefold()
-    matches = suggestions.loc[folded == column_name.casefold()]
-    if matches.empty:
-        return []
-    return matches.to_dict("records")
-
-
-def _render_detail_key_values(values: Dict[str, Any], empty_message: str) -> None:
-    items = list(values.items())
-    if not items:
-        st.info(empty_message)
-        return
-    for start in range(0, len(items), 2):
-        cols = st.columns(2)
-        for offset, (key, value) in enumerate(items[start : start + 2]):
-            cols[offset].markdown(
-                f"**{key}**\n\n{_format_detail_value(value)}"
-            )
-
-
-def _render_detail_classification(classification: Dict[str, Any]) -> None:
-    if not classification:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_EMPTY)
-        return
-    content = classification.get("CONTENT_TYPE")
-    semantic = classification.get("SEMANTIC_ROLE")
-    st.write(
-        f"**{ui_strings.PROFILE_V2_COLUMN_CONTENT_LABEL}:** "
-        f"{_format_detail_value(content)}"
+    table_key = table_fqn.replace(".", "_") if table_fqn else "overview"
+    edited_df = st.data_editor(
+        working[columns_to_display],
+        key=f"profile_overview_grid_{table_key}",
+        use_container_width=True,
+        hide_index=True,
+        num_rows="fixed",
+        column_config=column_config,
     )
-    st.write(
-        f"**{ui_strings.PROFILE_V2_COLUMN_SEMANTIC_LABEL}:** "
-        f"{_format_detail_value(semantic)}"
-    )
-    confidence = _format_detail_value(classification.get("CONFIDENCE"))
-    classified_at = _format_timestamp(classification.get("CLASSIFIED_AT"))
-    st.caption(
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_STATUS.format(
-            confidence=confidence,
-            classified_at=classified_at,
-        )
-    )
-    st.caption(
-        ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_SOURCE.format(
-            source=_classification_source_detail(classification.get("SOURCE")),
-        )
-    )
+
+    if isinstance(edited_df, pd.DataFrame) and "include_in_dq_config" in edited_df.columns:
+        dq_selection[table_fqn] = {
+            str(index): bool(value)
+            for index, value in edited_df["include_in_dq_config"].items()
+        }
 
 
 def _classification_source_detail(source: Any) -> str:
@@ -539,48 +233,27 @@ def _classification_source_detail(source: Any) -> str:
     return ui_strings.PROFILE_V2_COLUMN_DETAIL_CLASSIFICATION_UNKNOWN
 
 
-def _render_detail_suggestions(records: List[Dict[str, Any]]) -> None:
-    if not records:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_EMPTY)
-        return
-    df = pd.DataFrame(records)
-    if df.empty:
-        st.info(ui_strings.PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_EMPTY)
-        return
-    if "PARAMETERS" in df.columns:
-        df["PARAMETERS"] = df["PARAMETERS"].map(_stringify_params)
-    st.dataframe(df, use_container_width=True, hide_index=True)
-
-
-def _format_detail_value(value: Any) -> str:
-    if value is None:
-        return ui_strings.PROFILE_V2_VALUE_UNKNOWN
-    if isinstance(value, (int, float)):
-        if pd.isna(value):
-            return ui_strings.PROFILE_V2_VALUE_UNKNOWN
-        return str(value)
-    text = str(value).strip()
-    if not text:
-        return ui_strings.PROFILE_V2_VALUE_UNKNOWN
-    return text
-
-
 def _render_column_editors(
-    prepared: pd.DataFrame,
+    classification: pd.DataFrame,
     table_fqn: str,
     helpers: Any,
     session: Any,
 ) -> None:
-    if prepared.empty:
+    if not isinstance(classification, pd.DataFrame) or classification.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_EMPTY)
         return
+    latest_records = _latest_classifications(classification)
+    if latest_records:
+        working = pd.DataFrame.from_records(latest_records.values())
+    else:
+        working = classification.copy()
     save_fn = getattr(helpers, "save_manual_classification", None)
     if not callable(save_fn):
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_UNAVAILABLE)
         return
     st.markdown(f"**{ui_strings.PROFILE_V2_COLUMNS_EDIT_HEADER}**")
     st.caption(ui_strings.PROFILE_V2_COLUMNS_EDIT_HELP)
-    for record in prepared.to_dict("records"):
+    for record in working.to_dict("records"):
         _render_column_editor_form(record, table_fqn, session, save_fn)
 
 
@@ -684,15 +357,6 @@ def _handle_manual_classification_save(
     st.experimental_rerun()
 
 
-def _render_suggested_checks_grid(suggested_checks: pd.DataFrame) -> None:
-    st.subheader(ui_strings.PROFILE_V2_SUGGESTIONS_SUBHEADER)
-    prepared = _prepare_suggested_checks(suggested_checks)
-    if prepared.empty:
-        st.info(ui_strings.PROFILE_V2_SUGGESTIONS_EMPTY)
-        return
-    st.dataframe(prepared, use_container_width=True, hide_index=True)
-
-
 def _resolve_helpers(profiling_helpers: Optional[Any]):
     return profiling_helpers or profiling_service
 
@@ -717,10 +381,10 @@ def _load_metadata(
     session: Any,
     table_fqn: str,
 ) -> _ProfilingData:
-    column_features_fn = getattr(helpers, "get_column_features", None)
-    column_features = (
-        column_features_fn(session, table_fqn)
-        if callable(column_features_fn)
+    overview_fn = getattr(helpers, "get_overview_grid", None)
+    overview_grid = (
+        overview_fn(session, table_fqn)
+        if callable(overview_fn)
         else pd.DataFrame()
     )
     effective_class_fn = getattr(helpers, "get_effective_classification", None)
@@ -733,18 +397,11 @@ def _load_metadata(
             if callable(column_class_fn)
             else pd.DataFrame()
         )
-    suggested_checks_fn = getattr(helpers, "get_suggested_checks", None)
-    suggested_checks = (
-        suggested_checks_fn(session, table_fqn)
-        if callable(suggested_checks_fn)
-        else pd.DataFrame()
-    )
     run_history_fn = getattr(helpers, "fetch_recent_runs", None)
     recent_runs = run_history_fn(session, table_fqn) if callable(run_history_fn) else pd.DataFrame()
     return _ProfilingData(
-        column_features=column_features if isinstance(column_features, pd.DataFrame) else pd.DataFrame(),
+        overview_grid=overview_grid if isinstance(overview_grid, pd.DataFrame) else pd.DataFrame(),
         column_classification=column_classification if isinstance(column_classification, pd.DataFrame) else pd.DataFrame(),
-        suggested_checks=suggested_checks if isinstance(suggested_checks, pd.DataFrame) else pd.DataFrame(),
         recent_runs=recent_runs if isinstance(recent_runs, pd.DataFrame) else pd.DataFrame(),
     )
 
@@ -896,13 +553,6 @@ def render_profile(
 
     _render_last_run_banner(data.recent_runs, target_fqn)
     st.divider()
-    _render_columns_grid(
-        data.column_features,
-        data.column_classification,
-        data.suggested_checks,
-        target_fqn,
-        helpers,
-        session,
-    )
+    _render_overview_grid(data.overview_grid, target_fqn)
     st.divider()
-    _render_suggested_checks_grid(data.suggested_checks)
+    _render_column_editors(data.column_classification, target_fqn, helpers, session)


### PR DESCRIPTION
- replace the split Profiling v2 layout with a single overview grid sourced from `get_overview_grid`
- highlight suggested rows, persist checkbox selections per table in session state, and keep rerun controls wired to refresh the overview
- retain manual classification editors beneath the grid and update snapshot mirrors

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c666e6b6c83249b0e472d9b735f80)