### PR TITLE
P2-B6 – Make sure overview grid displays rule_* and confidence fields

### DIFF
--- a/snapshots/tests/test_profile_view.p
+++ b/snapshots/tests/test_profile_view.p
@@ -1,0 +1,33 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from views import profile_view
+
+
+def test_prepare_overview_frame_preserves_rule_columns():
+    overview = pd.DataFrame(
+        [
+            {
+                "column_name": "orders_total",
+                "data_type": "NUMBER",
+                "rule_id": "RULE_123",
+                "check_type": "NULL_COUNT",
+                "severity": "WARN",
+                "rationale": "Null ratio too high",
+                "confidence": 0.85,
+                "has_suggestion": True,
+                "include_in_dq_config": False,
+            }
+        ]
+    )
+
+    prepared = profile_view._prepare_overview_frame(overview)
+
+    assert list(prepared.columns) == profile_view._OVERVIEW_INTERNAL_COLUMNS
+    assert prepared.loc["orders_total", "rule_id"] == "RULE_123"
+    assert prepared.loc["orders_total", "confidence"] == 0.85
+    assert prepared.loc["orders_total", "include_in_dq_config"] is False
+    assert prepared.loc["orders_total", "has_suggestion"] is True
+
+

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -22,6 +22,28 @@ class _ProfilingData:
     recent_runs: pd.DataFrame
 
 
+OVERVIEW_GRID_DISPLAY_COLUMNS: List[str] = [
+    "include_in_dq_config",
+    "column_name",
+    "data_type",
+    "null_info",
+    "distinct_info",
+    "min_value",
+    "max_value",
+    "length_info",
+    "rule_id",
+    "check_type",
+    "severity",
+    "rationale",
+    "confidence",
+]
+_OVERVIEW_INTERNAL_COLUMNS: List[str] = [
+    *OVERVIEW_GRID_DISPLAY_COLUMNS,
+    "has_suggestion",
+]
+_OVERVIEW_BOOL_COLUMNS = {"has_suggestion", "include_in_dq_config"}
+
+
 def _format_timestamp(value: Any) -> str:
     if value is None:
         return ui_strings.PROFILE_V2_VALUE_UNKNOWN
@@ -153,33 +175,26 @@ def _classification_source_badge(source: Any) -> str:
     return ui_strings.PROFILE_V2_COLUMNS_SOURCE_UNKNOWN
 
 
+def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
+    if not isinstance(overview, pd.DataFrame):
+        return pd.DataFrame(columns=_OVERVIEW_INTERNAL_COLUMNS)
+    working = overview.copy()
+    for column in _OVERVIEW_INTERNAL_COLUMNS:
+        if column not in working.columns:
+            working[column] = False if column in _OVERVIEW_BOOL_COLUMNS else ""
+    working = working[_OVERVIEW_INTERNAL_COLUMNS]
+    working["column_name"] = working["column_name"].astype(str)
+    working.index = working["column_name"].astype(str)
+    return working
+
+
 def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_COLUMNS_SUBHEADER)
     if not isinstance(overview, pd.DataFrame) or overview.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EMPTY)
         return
 
-    working = overview.copy()
-    working.index = working["column_name"].astype(str)
-    columns_to_display = [
-        "include_in_dq_config",
-        "column_name",
-        "data_type",
-        "null_info",
-        "distinct_info",
-        "min_value",
-        "max_value",
-        "length_info",
-        "rule_id",
-        "check_type",
-        "severity",
-        "rationale",
-        "confidence",
-    ]
-    bool_columns = {"has_suggestion", "include_in_dq_config"}
-    for column in columns_to_display + ["has_suggestion"]:
-        if column not in working.columns:
-            working[column] = False if column in bool_columns else ""
+    working = _prepare_overview_frame(overview)
 
     dq_selection = st.session_state.setdefault("dq_config_selection", {})
     table_selection: Dict[str, bool] = dq_selection.setdefault(table_fqn, {})
@@ -203,14 +218,16 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
         )
     }
     read_only_columns = [
-        column for column in columns_to_display if column != "include_in_dq_config"
+        column
+        for column in OVERVIEW_GRID_DISPLAY_COLUMNS
+        if column != "include_in_dq_config"
     ]
     for column in read_only_columns:
         column_config[column] = st.column_config.TextColumn(column, disabled=True)
 
     table_key = table_fqn.replace(".", "_") if table_fqn else "overview"
     edited_df = st.data_editor(
-        working[columns_to_display],
+        working[OVERVIEW_GRID_DISPLAY_COLUMNS],
         key=f"profile_overview_grid_{table_key}",
         use_container_width=True,
         hide_index=True,

--- a/tests/test_profile_view.py
+++ b/tests/test_profile_view.py
@@ -1,0 +1,33 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from views import profile_view
+
+
+def test_prepare_overview_frame_preserves_rule_columns():
+    overview = pd.DataFrame(
+        [
+            {
+                "column_name": "orders_total",
+                "data_type": "NUMBER",
+                "rule_id": "RULE_123",
+                "check_type": "NULL_COUNT",
+                "severity": "WARN",
+                "rationale": "Null ratio too high",
+                "confidence": 0.85,
+                "has_suggestion": True,
+                "include_in_dq_config": False,
+            }
+        ]
+    )
+
+    prepared = profile_view._prepare_overview_frame(overview)
+
+    assert list(prepared.columns) == profile_view._OVERVIEW_INTERNAL_COLUMNS
+    assert prepared.loc["orders_total", "rule_id"] == "RULE_123"
+    assert prepared.loc["orders_total", "confidence"] == 0.85
+    assert prepared.loc["orders_total", "include_in_dq_config"] is False
+    assert prepared.loc["orders_total", "has_suggestion"] is True
+
+

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -22,6 +22,28 @@ class _ProfilingData:
     recent_runs: pd.DataFrame
 
 
+OVERVIEW_GRID_DISPLAY_COLUMNS: List[str] = [
+    "include_in_dq_config",
+    "column_name",
+    "data_type",
+    "null_info",
+    "distinct_info",
+    "min_value",
+    "max_value",
+    "length_info",
+    "rule_id",
+    "check_type",
+    "severity",
+    "rationale",
+    "confidence",
+]
+_OVERVIEW_INTERNAL_COLUMNS: List[str] = [
+    *OVERVIEW_GRID_DISPLAY_COLUMNS,
+    "has_suggestion",
+]
+_OVERVIEW_BOOL_COLUMNS = {"has_suggestion", "include_in_dq_config"}
+
+
 def _format_timestamp(value: Any) -> str:
     if value is None:
         return ui_strings.PROFILE_V2_VALUE_UNKNOWN
@@ -153,33 +175,26 @@ def _classification_source_badge(source: Any) -> str:
     return ui_strings.PROFILE_V2_COLUMNS_SOURCE_UNKNOWN
 
 
+def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
+    if not isinstance(overview, pd.DataFrame):
+        return pd.DataFrame(columns=_OVERVIEW_INTERNAL_COLUMNS)
+    working = overview.copy()
+    for column in _OVERVIEW_INTERNAL_COLUMNS:
+        if column not in working.columns:
+            working[column] = False if column in _OVERVIEW_BOOL_COLUMNS else ""
+    working = working[_OVERVIEW_INTERNAL_COLUMNS]
+    working["column_name"] = working["column_name"].astype(str)
+    working.index = working["column_name"].astype(str)
+    return working
+
+
 def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_COLUMNS_SUBHEADER)
     if not isinstance(overview, pd.DataFrame) or overview.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EMPTY)
         return
 
-    working = overview.copy()
-    working.index = working["column_name"].astype(str)
-    columns_to_display = [
-        "include_in_dq_config",
-        "column_name",
-        "data_type",
-        "null_info",
-        "distinct_info",
-        "min_value",
-        "max_value",
-        "length_info",
-        "rule_id",
-        "check_type",
-        "severity",
-        "rationale",
-        "confidence",
-    ]
-    bool_columns = {"has_suggestion", "include_in_dq_config"}
-    for column in columns_to_display + ["has_suggestion"]:
-        if column not in working.columns:
-            working[column] = False if column in bool_columns else ""
+    working = _prepare_overview_frame(overview)
 
     dq_selection = st.session_state.setdefault("dq_config_selection", {})
     table_selection: Dict[str, bool] = dq_selection.setdefault(table_fqn, {})
@@ -203,14 +218,16 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
         )
     }
     read_only_columns = [
-        column for column in columns_to_display if column != "include_in_dq_config"
+        column
+        for column in OVERVIEW_GRID_DISPLAY_COLUMNS
+        if column != "include_in_dq_config"
     ]
     for column in read_only_columns:
         column_config[column] = st.column_config.TextColumn(column, disabled=True)
 
     table_key = table_fqn.replace(".", "_") if table_fqn else "overview"
     edited_df = st.data_editor(
-        working[columns_to_display],
+        working[OVERVIEW_GRID_DISPLAY_COLUMNS],
         key=f"profile_overview_grid_{table_key}",
         use_container_width=True,
         hide_index=True,


### PR DESCRIPTION
- ensure the profiling overview grid always prepares and displays the rule metadata columns in the required order
- add a regression test that exercises the overview frame preparation helper
- refresh the snapshot mirror to capture the updated python sources

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c78acbc908324ba84605a0f88e0db)