### PR TITLE
R4 – Integrate dynamic rule system

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -121,14 +121,20 @@ def run_classification_only(session: Any, table_fqn: str) -> None:
 
 
 def run_suggestions_only(session: Any, table_fqn: str) -> None:
-    """Re-run only the suggestion generation stage for *table_fqn*."""
+    """Execute only the DQ_APPLY_RULES stage for *table_fqn*."""
 
-    _run_single_stage(
-        session,
-        table_fqn,
-        SUGGESTIONS_PROC,
-        "Suggestions run failed",
-    )
+    normalized = _normalize_table_fqn(table_fqn)
+    if not normalized:
+        raise ProfilingError("Fully-qualified table name is required")
+
+    LOGGER.info("profiling_v2:call apply_rules target=%s", normalized)
+    try:
+        sql = f"CALL {SUGGESTIONS_PROC}(?)"
+        _execute_sql(session, sql, params=[normalized]).collect()
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        message = _friendly_error_message(exc)
+        LOGGER.exception("profiling_v2:apply_rules_failed target=%s", normalized)
+        raise ProfilingError(f"Suggestions run failed: {message}") from exc
 
 
 def _fetch_dataframe(session: Any, sql: str, params: Optional[Iterable[Any]] = None) -> pd.DataFrame:

--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -131,6 +131,7 @@ def run_suggestions_only(session: Any, table_fqn: str) -> None:
     try:
         sql = f"CALL {SUGGESTIONS_PROC}(?)"
         _execute_sql(session, sql, params=[normalized]).collect()
+        LOGGER.info("profiling_v2:apply_rules_complete target=%s", normalized)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:apply_rules_failed target=%s", normalized)

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -121,14 +121,20 @@ def run_classification_only(session: Any, table_fqn: str) -> None:
 
 
 def run_suggestions_only(session: Any, table_fqn: str) -> None:
-    """Re-run only the suggestion generation stage for *table_fqn*."""
+    """Execute only the DQ_APPLY_RULES stage for *table_fqn*."""
 
-    _run_single_stage(
-        session,
-        table_fqn,
-        SUGGESTIONS_PROC,
-        "Suggestions run failed",
-    )
+    normalized = _normalize_table_fqn(table_fqn)
+    if not normalized:
+        raise ProfilingError("Fully-qualified table name is required")
+
+    LOGGER.info("profiling_v2:call apply_rules target=%s", normalized)
+    try:
+        sql = f"CALL {SUGGESTIONS_PROC}(?)"
+        _execute_sql(session, sql, params=[normalized]).collect()
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        message = _friendly_error_message(exc)
+        LOGGER.exception("profiling_v2:apply_rules_failed target=%s", normalized)
+        raise ProfilingError(f"Suggestions run failed: {message}") from exc
 
 
 def _fetch_dataframe(session: Any, sql: str, params: Optional[Iterable[Any]] = None) -> pd.DataFrame:

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -131,6 +131,7 @@ def run_suggestions_only(session: Any, table_fqn: str) -> None:
     try:
         sql = f"CALL {SUGGESTIONS_PROC}(?)"
         _execute_sql(session, sql, params=[normalized]).collect()
+        LOGGER.info("profiling_v2:apply_rules_complete target=%s", normalized)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:apply_rules_failed target=%s", normalized)

--- a/snapshots/tests/test_profile_view.p
+++ b/snapshots/tests/test_profile_view.p
@@ -31,3 +31,17 @@ def test_prepare_overview_frame_preserves_rule_columns():
     assert prepared.loc["orders_total", "has_suggestion"] is True
 
 
+def test_overview_grid_widget_key_changes_with_nonce():
+    key_first = profile_view._overview_grid_widget_key(
+        "DB.SCHEMA.TABLE",
+        nonce=0,
+    )
+    key_second = profile_view._overview_grid_widget_key(
+        "DB.SCHEMA.TABLE",
+        nonce=1,
+    )
+
+    assert key_first != key_second
+    assert "DB_SCHEMA_TABLE" in key_first
+
+

--- a/snapshots/tests/test_sql_golden.p
+++ b/snapshots/tests/test_sql_golden.p
@@ -63,3 +63,14 @@ def test_get_table_profile_summary_returns_frame():
 def test_get_column_features_returns_empty_when_no_table():
     df = profiling_v2.get_column_features(RecordingSession([]), '')
     assert df.empty
+
+
+def test_run_suggestions_only_calls_apply_rules():
+    session = RecordingSession([None])
+
+    profiling_v2.run_suggestions_only(session, 'DB.SCHEMA.TABLE')
+
+    assert session.calls, "Stored procedure call was not recorded"
+    sql, params = session.calls[0]
+    assert "DQ_APPLY_RULES" in sql
+    assert params == ["DB.SCHEMA.TABLE"]

--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -86,6 +86,11 @@ PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_EMPTY = "No suggested checks for this colum
 PROFILE_V2_COLUMN_DETAIL_ERROR = "Failed to load column details: {error}"
 PROFILE_V2_SUGGESTIONS_SUBHEADER = "Suggested data quality checks"
 PROFILE_V2_SUGGESTIONS_EMPTY = "Run profiling to see suggested checks for this table."
+PROFILE_V2_COLUMNS_RULE_METADATA_NOTE = (
+    "Suggested data quality checks expose rule_id, check_type, severity, and "
+    "rationale by aggregating matches from DQ_SUGGESTED_CHECKS after running "
+    "Classify ➜ Suggest."
+)
 PROFILE_V2_VALUE_UNKNOWN = "—"
 
 # Config preview strings

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -188,6 +188,15 @@ def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
     return working
 
 
+def _overview_grid_widget_key(table_fqn: str, nonce: Optional[int] = None) -> str:
+    """Return a deterministic key for the overview grid widget."""
+
+    if nonce is None:
+        nonce = st.session_state.get("profile_data_nonce", 0)
+    sanitized = table_fqn.replace(".", "_") if table_fqn else "overview"
+    return f"profile_overview_grid_{sanitized}_{nonce or 0}"
+
+
 def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_COLUMNS_SUBHEADER)
     if not isinstance(overview, pd.DataFrame) or overview.empty:
@@ -225,10 +234,10 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     for column in read_only_columns:
         column_config[column] = st.column_config.TextColumn(column, disabled=True)
 
-    table_key = table_fqn.replace(".", "_") if table_fqn else "overview"
+    grid_key = _overview_grid_widget_key(table_fqn)
     edited_df = st.data_editor(
         working[OVERVIEW_GRID_DISPLAY_COLUMNS],
-        key=f"profile_overview_grid_{table_key}",
+        key=grid_key,
         use_container_width=True,
         hide_index=True,
         num_rows="fixed",
@@ -240,6 +249,11 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
             str(index): bool(value)
             for index, value in edited_df["include_in_dq_config"].items()
         }
+
+    st.caption(
+        f"{ui_strings.PROFILE_V2_SUGGESTIONS_SUBHEADER}: "
+        f"{ui_strings.PROFILE_V2_COLUMNS_RULE_METADATA_NOTE}"
+    )
 
 
 def _classification_source_detail(source: Any) -> str:

--- a/tests/test_profile_view.py
+++ b/tests/test_profile_view.py
@@ -31,3 +31,17 @@ def test_prepare_overview_frame_preserves_rule_columns():
     assert prepared.loc["orders_total", "has_suggestion"] is True
 
 
+def test_overview_grid_widget_key_changes_with_nonce():
+    key_first = profile_view._overview_grid_widget_key(
+        "DB.SCHEMA.TABLE",
+        nonce=0,
+    )
+    key_second = profile_view._overview_grid_widget_key(
+        "DB.SCHEMA.TABLE",
+        nonce=1,
+    )
+
+    assert key_first != key_second
+    assert "DB_SCHEMA_TABLE" in key_first
+
+

--- a/tests/test_sql_golden.py
+++ b/tests/test_sql_golden.py
@@ -63,3 +63,14 @@ def test_get_table_profile_summary_returns_frame():
 def test_get_column_features_returns_empty_when_no_table():
     df = profiling_v2.get_column_features(RecordingSession([]), '')
     assert df.empty
+
+
+def test_run_suggestions_only_calls_apply_rules():
+    session = RecordingSession([None])
+
+    profiling_v2.run_suggestions_only(session, 'DB.SCHEMA.TABLE')
+
+    assert session.calls, "Stored procedure call was not recorded"
+    sql, params = session.calls[0]
+    assert "DQ_APPLY_RULES" in sql
+    assert params == ["DB.SCHEMA.TABLE"]

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -86,6 +86,11 @@ PROFILE_V2_COLUMN_DETAIL_SUGGESTIONS_EMPTY = "No suggested checks for this colum
 PROFILE_V2_COLUMN_DETAIL_ERROR = "Failed to load column details: {error}"
 PROFILE_V2_SUGGESTIONS_SUBHEADER = "Suggested data quality checks"
 PROFILE_V2_SUGGESTIONS_EMPTY = "Run profiling to see suggested checks for this table."
+PROFILE_V2_COLUMNS_RULE_METADATA_NOTE = (
+    "Suggested data quality checks expose rule_id, check_type, severity, and "
+    "rationale by aggregating matches from DQ_SUGGESTED_CHECKS after running "
+    "Classify ➜ Suggest."
+)
 PROFILE_V2_VALUE_UNKNOWN = "—"
 
 # Config preview strings

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -188,6 +188,15 @@ def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
     return working
 
 
+def _overview_grid_widget_key(table_fqn: str, nonce: Optional[int] = None) -> str:
+    """Return a deterministic key for the overview grid widget."""
+
+    if nonce is None:
+        nonce = st.session_state.get("profile_data_nonce", 0)
+    sanitized = table_fqn.replace(".", "_") if table_fqn else "overview"
+    return f"profile_overview_grid_{sanitized}_{nonce or 0}"
+
+
 def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     st.subheader(ui_strings.PROFILE_V2_COLUMNS_SUBHEADER)
     if not isinstance(overview, pd.DataFrame) or overview.empty:
@@ -225,10 +234,10 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     for column in read_only_columns:
         column_config[column] = st.column_config.TextColumn(column, disabled=True)
 
-    table_key = table_fqn.replace(".", "_") if table_fqn else "overview"
+    grid_key = _overview_grid_widget_key(table_fqn)
     edited_df = st.data_editor(
         working[OVERVIEW_GRID_DISPLAY_COLUMNS],
-        key=f"profile_overview_grid_{table_key}",
+        key=grid_key,
         use_container_width=True,
         hide_index=True,
         num_rows="fixed",
@@ -240,6 +249,11 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
             str(index): bool(value)
             for index, value in edited_df["include_in_dq_config"].items()
         }
+
+    st.caption(
+        f"{ui_strings.PROFILE_V2_SUGGESTIONS_SUBHEADER}: "
+        f"{ui_strings.PROFILE_V2_COLUMNS_RULE_METADATA_NOTE}"
+    )
 
 
 def _classification_source_detail(source: Any) -> str:


### PR DESCRIPTION
R4 – Integrate dynamic rule system end-to-end with profiling
- call the new DQ_APPLY_RULES procedure from the suggestions-only rerun helper and back it with a unit test
- refresh the profiling overview grid with nonce-aware widget keys plus a caption that highlights aggregated rule_id/check_type/severity/rationale metadata
- document the new rule metadata caption in `ui/strings.py` and mirror the snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbbdd516c832498550318a7b8241b)