### PR TITLE
Task C1 – Rename sidebar “DQ Rules” to “DQ Rule Library”

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1731,7 +1731,7 @@ with st.sidebar:
         args=("monitor",),
     )
     st.button(
-        "DQ Rules",
+        "DQ Rule Library",
         use_container_width=True,
         type="primary" if view == "rules" else "secondary",
         key="nav_rules",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1731,7 +1731,7 @@ with st.sidebar:
         args=("monitor",),
     )
     st.button(
-        "DQ Rules",
+        "DQ Rule Library",
         use_container_width=True,
         type="primary" if view == "rules" else "secondary",
         key="nav_rules",


### PR DESCRIPTION
Task C1 – Rename sidebar “DQ Rules” to “DQ Rule Library”

* Renamed the sidebar navigation button label to “DQ Rule Library” while keeping routing to the rules view unchanged.
* Updated the mirrored snapshot to capture the revised Streamlit UI text.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d915eeb0c8324ae6f349dcd1dd078)