### PR TITLE
Task C2 – Split Profiling v2 into two tabs

### DIFF
--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -91,6 +91,9 @@ PROFILE_V2_COLUMNS_RULE_METADATA_NOTE = (
     "rationale by aggregating matches from DQ_SUGGESTED_CHECKS after running "
     "Classify ➜ Suggest."
 )
+PROFILE_V2_CLASSIFICATION_PLACEHOLDER = (
+    "Column classification grid is temporarily unavailable."
+)
 PROFILE_V2_VALUE_UNKNOWN = "—"
 
 # Config preview strings

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -256,6 +256,17 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     )
 
 
+def _render_classification_grid(
+    column_classification: pd.DataFrame,
+    table_fqn: str,
+    helpers: Any,
+    session: Any,
+) -> None:
+    """Placeholder for the upcoming classification grid implementation."""
+
+    st.info(ui_strings.PROFILE_V2_CLASSIFICATION_PLACEHOLDER)
+
+
 def _classification_source_detail(source: Any) -> str:
     normalized = str(source or "").strip().upper()
     if normalized == "MANUAL":
@@ -588,6 +599,18 @@ def render_profile(
 
     _render_last_run_banner(data.recent_runs, target_fqn)
     st.divider()
-    _render_overview_grid(data.overview_grid, target_fqn)
-    st.divider()
-    _render_column_editors(data.column_classification, target_fqn, helpers, session)
+
+    tab_overview, tab_classification = st.tabs(
+        ["Profiling overview", "Column classification"]
+    )
+
+    with tab_overview:
+        _render_overview_grid(data.overview_grid, target_fqn)
+
+    with tab_classification:
+        _render_classification_grid(
+            data.column_classification,
+            target_fqn,
+            helpers,
+            session,
+        )

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -91,6 +91,9 @@ PROFILE_V2_COLUMNS_RULE_METADATA_NOTE = (
     "rationale by aggregating matches from DQ_SUGGESTED_CHECKS after running "
     "Classify ➜ Suggest."
 )
+PROFILE_V2_CLASSIFICATION_PLACEHOLDER = (
+    "Column classification grid is temporarily unavailable."
+)
 PROFILE_V2_VALUE_UNKNOWN = "—"
 
 # Config preview strings

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -256,6 +256,17 @@ def _render_overview_grid(overview: pd.DataFrame, table_fqn: str) -> None:
     )
 
 
+def _render_classification_grid(
+    column_classification: pd.DataFrame,
+    table_fqn: str,
+    helpers: Any,
+    session: Any,
+) -> None:
+    """Placeholder for the upcoming classification grid implementation."""
+
+    st.info(ui_strings.PROFILE_V2_CLASSIFICATION_PLACEHOLDER)
+
+
 def _classification_source_detail(source: Any) -> str:
     normalized = str(source or "").strip().upper()
     if normalized == "MANUAL":
@@ -588,6 +599,18 @@ def render_profile(
 
     _render_last_run_banner(data.recent_runs, target_fqn)
     st.divider()
-    _render_overview_grid(data.overview_grid, target_fqn)
-    st.divider()
-    _render_column_editors(data.column_classification, target_fqn, helpers, session)
+
+    tab_overview, tab_classification = st.tabs(
+        ["Profiling overview", "Column classification"]
+    )
+
+    with tab_overview:
+        _render_overview_grid(data.overview_grid, target_fqn)
+
+    with tab_classification:
+        _render_classification_grid(
+            data.column_classification,
+            target_fqn,
+            helpers,
+            session,
+        )


### PR DESCRIPTION
- Added Streamlit tabs to the Profiling v2 view so the overview grid and upcoming column classification grid live on separate tabs.
- Stubbed a classification grid helper with a placeholder message and mirrored the updated Python snapshots.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d91d16a24832486c490789ac7445c)