### PR TITLE
Task R5 – Fix rule admin rerun error

### DIFF
--- a/snapshots/views/rule_admin_view.p
+++ b/snapshots/views/rule_admin_view.p
@@ -199,7 +199,6 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
                             active=bool(active_value),
                         )
                         st.success(f"Rule {rule_id} updated.")
-                        st.experimental_rerun()
                     except Exception as exc:
                         st.error(f"Unable to update rule {rule_id}: {exc}")
 
@@ -260,7 +259,6 @@ def _render_create_form(session: Session, table_name: str) -> None:
                     )
                     st.session_state["rule_admin_create_mode"] = False
                     st.success(f"Rule {rule_id} created.")
-                    st.experimental_rerun()
                 except Exception as exc:
                     st.error(f"Unable to create rule: {exc}")
 

--- a/views/rule_admin_view.py
+++ b/views/rule_admin_view.py
@@ -199,7 +199,6 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
                             active=bool(active_value),
                         )
                         st.success(f"Rule {rule_id} updated.")
-                        st.experimental_rerun()
                     except Exception as exc:
                         st.error(f"Unable to update rule {rule_id}: {exc}")
 
@@ -260,7 +259,6 @@ def _render_create_form(session: Session, table_name: str) -> None:
                     )
                     st.session_state["rule_admin_create_mode"] = False
                     st.success(f"Rule {rule_id} created.")
-                    st.experimental_rerun()
                 except Exception as exc:
                     st.error(f"Unable to create rule: {exc}")
 


### PR DESCRIPTION
- remove deprecated `st.experimental_rerun` calls from the rule admin view and rely on Streamlit form reruns after create/update
- regenerate the `/snapshots` mirror to reflect the updated view

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db200ab948324aef811cd74308576)