### PR TITLE
Ensure clean mode-based routing between rule list and rule editor

### DIFF
--- a/snapshots/views/rule_admin_view.p
+++ b/snapshots/views/rule_admin_view.p
@@ -414,7 +414,7 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
     if "dq_rules_mode" not in st.session_state:
         st.session_state["dq_rules_mode"] = "list"
 
-    mode = st.session_state["dq_rules_mode"]
+    mode = st.session_state.get("dq_rules_mode", "list")
 
     if mode == "list":
         try:
@@ -423,13 +423,23 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
             st.error(f"Unable to load rule library: {exc}")
             return
 
+        if rules_df.empty:
+            st.info("No rules found in the library. Create the first rule to get started.")
+            if st.button("Create first rule", key="create_first_rule"):
+                st.session_state["dq_rules_mode"] = "create_new"
+                st.session_state["dq_rules_selected_uid"] = None
+                st.stop()
+            return
+
         _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)
         return
-    if mode in ("edit_existing", "create_new"):
+
+    if mode in {"edit_existing", "create_new"}:
         _render_rule_edit_page(session, metadata_db, metadata_schema)
         return
 
     st.session_state["dq_rules_mode"] = "list"
+    st.session_state["dq_rules_selected_uid"] = None
     try:
         rules_df = _load_rules(session, table_name)
     except Exception as exc:

--- a/views/rule_admin_view.py
+++ b/views/rule_admin_view.py
@@ -414,7 +414,7 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
     if "dq_rules_mode" not in st.session_state:
         st.session_state["dq_rules_mode"] = "list"
 
-    mode = st.session_state["dq_rules_mode"]
+    mode = st.session_state.get("dq_rules_mode", "list")
 
     if mode == "list":
         try:
@@ -423,13 +423,23 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
             st.error(f"Unable to load rule library: {exc}")
             return
 
+        if rules_df.empty:
+            st.info("No rules found in the library. Create the first rule to get started.")
+            if st.button("Create first rule", key="create_first_rule"):
+                st.session_state["dq_rules_mode"] = "create_new"
+                st.session_state["dq_rules_selected_uid"] = None
+                st.stop()
+            return
+
         _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)
         return
-    if mode in ("edit_existing", "create_new"):
+
+    if mode in {"edit_existing", "create_new"}:
         _render_rule_edit_page(session, metadata_db, metadata_schema)
         return
 
     st.session_state["dq_rules_mode"] = "list"
+    st.session_state["dq_rules_selected_uid"] = None
     try:
         rules_df = _load_rules(session, table_name)
     except Exception as exc:


### PR DESCRIPTION
- enforce dq_rules_mode routing defaults and fallback handling for rule admin
- add empty-library messaging with create-first-rule navigation
- update mirrored snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f3622c2288324b5e13325107fd110)