### PR TITLE
Polish the rule edit/create page UX

### DIFF
--- a/snapshots/views/rule_admin_view.p
+++ b/snapshots/views/rule_admin_view.p
@@ -172,9 +172,12 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                 "ACTIVE": bool(record.get("ACTIVE", True)),
             }
         )
-        st.header(f"Editing rule: {rule_defaults['RULE_ID']}")
+        header_check_type = rule_defaults.get("CHECK_TYPE", "").strip()
+        header_rule_id = rule_defaults.get("RULE_ID", "").strip()
+        header_suffix = f" ({header_check_type})" if header_check_type else ""
+        st.header(f"Editing rule: {header_rule_id}{header_suffix}")
     else:
-        st.header("Create new rule")
+        st.header("Create new data quality rule")
 
     with st.form(key="dq_rule_editor_form"):
         rule_id = st.text_input("Rule ID", value=rule_defaults["RULE_ID"])

--- a/views/rule_admin_view.py
+++ b/views/rule_admin_view.py
@@ -172,9 +172,12 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                 "ACTIVE": bool(record.get("ACTIVE", True)),
             }
         )
-        st.header(f"Editing rule: {rule_defaults['RULE_ID']}")
+        header_check_type = rule_defaults.get("CHECK_TYPE", "").strip()
+        header_rule_id = rule_defaults.get("RULE_ID", "").strip()
+        header_suffix = f" ({header_check_type})" if header_check_type else ""
+        st.header(f"Editing rule: {header_rule_id}{header_suffix}")
     else:
-        st.header("Create new rule")
+        st.header("Create new data quality rule")
 
     with st.form(key="dq_rule_editor_form"):
         rule_id = st.text_input("Rule ID", value=rule_defaults["RULE_ID"])


### PR DESCRIPTION
* Clarify the rule editor header messaging for editing and creation flows.
* Keep back navigation and form actions scoped to the edit/create view.
* Refresh mirrored snapshot artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f37844a2c8324843922784d16ac7d)