### PR TITLE
Clean up obsolete patterns and ensure Rule Library view is minimal and predictable.

### DIFF
--- a/snapshots/views/rule_admin_view.p
+++ b/snapshots/views/rule_admin_view.p
@@ -419,6 +419,11 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
 
     mode = st.session_state.get("dq_rules_mode", "list")
 
+    if mode not in {"list", "edit_existing", "create_new"}:
+        mode = "list"
+        st.session_state["dq_rules_mode"] = "list"
+        st.session_state["dq_rules_selected_uid"] = None
+
     if mode == "list":
         try:
             rules_df = _load_rules(session, table_name)
@@ -440,13 +445,3 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
     if mode in {"edit_existing", "create_new"}:
         _render_rule_edit_page(session, metadata_db, metadata_schema)
         return
-
-    st.session_state["dq_rules_mode"] = "list"
-    st.session_state["dq_rules_selected_uid"] = None
-    try:
-        rules_df = _load_rules(session, table_name)
-    except Exception as exc:
-        st.error(f"Unable to load rule library: {exc}")
-        return
-
-    _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)

--- a/views/rule_admin_view.py
+++ b/views/rule_admin_view.py
@@ -419,6 +419,11 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
 
     mode = st.session_state.get("dq_rules_mode", "list")
 
+    if mode not in {"list", "edit_existing", "create_new"}:
+        mode = "list"
+        st.session_state["dq_rules_mode"] = "list"
+        st.session_state["dq_rules_selected_uid"] = None
+
     if mode == "list":
         try:
             rules_df = _load_rules(session, table_name)
@@ -440,13 +445,3 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
     if mode in {"edit_existing", "create_new"}:
         _render_rule_edit_page(session, metadata_db, metadata_schema)
         return
-
-    st.session_state["dq_rules_mode"] = "list"
-    st.session_state["dq_rules_selected_uid"] = None
-    try:
-        rules_df = _load_rules(session, table_name)
-    except Exception as exc:
-        st.error(f"Unable to load rule library: {exc}")
-        return
-
-    _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)


### PR DESCRIPTION
- Normalize rule admin routing to default to the list view when session state contains an unknown mode.
- Update snapshot mirror.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f3857cdd883249e01c68e290a811f)