### PR TITLE
Ensure that no UI from list mode is rendered while in edit mode, and vice versa.

### DIFF
--- a/snapshots/views/rule_admin_view.p
+++ b/snapshots/views/rule_admin_view.p
@@ -423,35 +423,27 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
 
     mode = st.session_state.get("dq_rules_mode", "list")
 
-    if mode == "list":
-        try:
-            rules_df = _load_rules(session, table_name)
-        except Exception as exc:
-            st.error(f"Unable to load rule library: {exc}")
-            return
-
-        if rules_df.empty:
-            st.info("No rules found in the library. Create the first rule to get started.")
-            if st.button("Create first rule", key="create_first_rule"):
-                st.session_state["dq_rules_mode"] = "create_new"
-                st.session_state["dq_rules_selected_uid"] = None
-                st.experimental_rerun()
-            return
-
-        _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)
-        return
-
     if mode in {"edit_existing", "create_new"}:
         _render_rule_edit_page(session, metadata_db, metadata_schema)
         return
 
-    st.session_state["dq_rules_mode"] = "list"
-    st.session_state["dq_rules_selected_uid"] = None
+    if mode != "list":
+        st.session_state["dq_rules_mode"] = "list"
+        st.session_state["dq_rules_selected_uid"] = None
+        st.experimental_rerun()
 
     try:
         rules_df = _load_rules(session, table_name)
     except Exception as exc:
         st.error(f"Unable to load rule library: {exc}")
+        return
+
+    if rules_df.empty:
+        st.info("No rules found in the library. Create the first rule to get started.")
+        if st.button("Create first rule", key="create_first_rule"):
+            st.session_state["dq_rules_mode"] = "create_new"
+            st.session_state["dq_rules_selected_uid"] = None
+            st.experimental_rerun()
         return
 
     _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)

--- a/views/rule_admin_view.py
+++ b/views/rule_admin_view.py
@@ -423,35 +423,27 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
 
     mode = st.session_state.get("dq_rules_mode", "list")
 
-    if mode == "list":
-        try:
-            rules_df = _load_rules(session, table_name)
-        except Exception as exc:
-            st.error(f"Unable to load rule library: {exc}")
-            return
-
-        if rules_df.empty:
-            st.info("No rules found in the library. Create the first rule to get started.")
-            if st.button("Create first rule", key="create_first_rule"):
-                st.session_state["dq_rules_mode"] = "create_new"
-                st.session_state["dq_rules_selected_uid"] = None
-                st.experimental_rerun()
-            return
-
-        _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)
-        return
-
     if mode in {"edit_existing", "create_new"}:
         _render_rule_edit_page(session, metadata_db, metadata_schema)
         return
 
-    st.session_state["dq_rules_mode"] = "list"
-    st.session_state["dq_rules_selected_uid"] = None
+    if mode != "list":
+        st.session_state["dq_rules_mode"] = "list"
+        st.session_state["dq_rules_selected_uid"] = None
+        st.experimental_rerun()
 
     try:
         rules_df = _load_rules(session, table_name)
     except Exception as exc:
         st.error(f"Unable to load rule library: {exc}")
+        return
+
+    if rules_df.empty:
+        st.info("No rules found in the library. Create the first rule to get started.")
+        if st.button("Create first rule", key="create_first_rule"):
+            st.session_state["dq_rules_mode"] = "create_new"
+            st.session_state["dq_rules_selected_uid"] = None
+            st.experimental_rerun()
         return
 
     _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)


### PR DESCRIPTION
- Enforced exclusive branching in rule admin view so list and edit modes render independently
- Added rerun fallback for unexpected modes while preserving empty-library handling and creation entry points
- Updated mirrored snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f455c64388324ae475a9a22b3c6de)