### PR TITLE
Remove experimental rerun from rule admin view

### DIFF
--- a/snapshots/views/rule_admin_view.p
+++ b/snapshots/views/rule_admin_view.p
@@ -329,7 +329,7 @@ def _render_rule_list(
     if st.button("Create new rule", key="create_new_rule"):
         st.session_state["dq_rules_mode"] = "create_new"
         st.session_state["dq_rules_selected_uid"] = None
-        st.experimental_rerun()
+        st.stop()
 
     search = st.text_input(
         "Search rules", value=st.session_state["dq_rules_search"], key="dq_rules_search"
@@ -386,7 +386,7 @@ def _render_rule_list(
                 if st.button("Edit", key=f"edit_rule_{rule_uid}"):
                     st.session_state["dq_rules_mode"] = "edit_existing"
                     st.session_state["dq_rules_selected_uid"] = rule_uid
-                    st.experimental_rerun()
+                    st.stop()
             with col_delete:
                 if st.button("Delete", key=f"delete_rule_{rule_uid}"):
                     _delete_rule(session, table_name, rule_uid)
@@ -430,7 +430,7 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
     if mode != "list":
         st.session_state["dq_rules_mode"] = "list"
         st.session_state["dq_rules_selected_uid"] = None
-        st.experimental_rerun()
+        st.stop()
 
     try:
         rules_df = _load_rules(session, table_name)
@@ -443,7 +443,7 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
         if st.button("Create first rule", key="create_first_rule"):
             st.session_state["dq_rules_mode"] = "create_new"
             st.session_state["dq_rules_selected_uid"] = None
-            st.experimental_rerun()
+            st.stop()
         return
 
     _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)

--- a/views/rule_admin_view.py
+++ b/views/rule_admin_view.py
@@ -329,7 +329,7 @@ def _render_rule_list(
     if st.button("Create new rule", key="create_new_rule"):
         st.session_state["dq_rules_mode"] = "create_new"
         st.session_state["dq_rules_selected_uid"] = None
-        st.experimental_rerun()
+        st.stop()
 
     search = st.text_input(
         "Search rules", value=st.session_state["dq_rules_search"], key="dq_rules_search"
@@ -386,7 +386,7 @@ def _render_rule_list(
                 if st.button("Edit", key=f"edit_rule_{rule_uid}"):
                     st.session_state["dq_rules_mode"] = "edit_existing"
                     st.session_state["dq_rules_selected_uid"] = rule_uid
-                    st.experimental_rerun()
+                    st.stop()
             with col_delete:
                 if st.button("Delete", key=f"delete_rule_{rule_uid}"):
                     _delete_rule(session, table_name, rule_uid)
@@ -430,7 +430,7 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
     if mode != "list":
         st.session_state["dq_rules_mode"] = "list"
         st.session_state["dq_rules_selected_uid"] = None
-        st.experimental_rerun()
+        st.stop()
 
     try:
         rules_df = _load_rules(session, table_name)
@@ -443,7 +443,7 @@ def render_rule_admin(session: Optional[Session], metadata_db: str, metadata_sch
         if st.button("Create first rule", key="create_first_rule"):
             st.session_state["dq_rules_mode"] = "create_new"
             st.session_state["dq_rules_selected_uid"] = None
-            st.experimental_rerun()
+            st.stop()
         return
 
     _render_rule_list(session=session, table_name=table_name, rules_df=rules_df)


### PR DESCRIPTION
- replace st.experimental_rerun calls in the rule admin view with session_state updates plus st.stop()
- keep validation handling unchanged while routing uses st.stop()
- update snapshot mirror


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f539debfc8324951fcde71699f120)