### PR TITLE
Add sampling pie chart to sampling summary

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+import matplotlib.pyplot as plt
 import pandas as pd
 import streamlit as st
 
@@ -249,6 +250,26 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
         f"**Sample used:** {_format_count(sample_est_rows_display)} rows (~{_format_percent(sample_percent_display)})"
     )
     st.markdown(f"**Sampling mode:** {sample_mode_display}")
+
+    total_rows = row_count
+    if total_rows is None or total_rows <= 0:
+        st.info("Sampling chart unavailable: table row count missing.")
+        return
+
+    if sample_mode == "FULL":
+        sample_rows = total_rows
+    else:
+        sample_rows = sample_est_rows if sample_est_rows is not None else 0
+
+    remainder_rows = max(total_rows - sample_rows, 0)
+
+    fig, ax = plt.subplots()
+    ax.pie(
+        [sample_rows, remainder_rows],
+        labels=["Sample", "Remainder"],
+        autopct="%1.1f%%",
+    )
+    st.pyplot(fig)
 
 
 def _classification_source_badge(source: Any) -> str:

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+import matplotlib.pyplot as plt
 import pandas as pd
 import streamlit as st
 
@@ -249,6 +250,26 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
         f"**Sample used:** {_format_count(sample_est_rows_display)} rows (~{_format_percent(sample_percent_display)})"
     )
     st.markdown(f"**Sampling mode:** {sample_mode_display}")
+
+    total_rows = row_count
+    if total_rows is None or total_rows <= 0:
+        st.info("Sampling chart unavailable: table row count missing.")
+        return
+
+    if sample_mode == "FULL":
+        sample_rows = total_rows
+    else:
+        sample_rows = sample_est_rows if sample_est_rows is not None else 0
+
+    remainder_rows = max(total_rows - sample_rows, 0)
+
+    fig, ax = plt.subplots()
+    ax.pie(
+        [sample_rows, remainder_rows],
+        labels=["Sample", "Remainder"],
+        autopct="%1.1f%%",
+    )
+    st.pyplot(fig)
 
 
 def _classification_source_badge(source: Any) -> str:


### PR DESCRIPTION
- add a matplotlib pie chart under the sampling summary showing sampled vs remaining rows
- guard rendering when row counts are missing and treat full scans as fully sampled
- update the snapshot mirror

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69200e49b0088324ab594c253c6902e6)