### PR TITLE
Ensure profiling overview grid stays column-focused

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -285,6 +285,11 @@ def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
     if not isinstance(overview, pd.DataFrame):
         return pd.DataFrame(columns=_OVERVIEW_INTERNAL_COLUMNS)
     working = overview.copy()
+    extraneous_columns = [
+        column for column in working.columns if column not in _OVERVIEW_INTERNAL_COLUMNS
+    ]
+    if extraneous_columns:
+        working = working.drop(columns=extraneous_columns)
     for column in _OVERVIEW_INTERNAL_COLUMNS:
         if column not in working.columns:
             working[column] = False if column in _OVERVIEW_BOOL_COLUMNS else ""

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -285,6 +285,11 @@ def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
     if not isinstance(overview, pd.DataFrame):
         return pd.DataFrame(columns=_OVERVIEW_INTERNAL_COLUMNS)
     working = overview.copy()
+    extraneous_columns = [
+        column for column in working.columns if column not in _OVERVIEW_INTERNAL_COLUMNS
+    ]
+    if extraneous_columns:
+        working = working.drop(columns=extraneous_columns)
     for column in _OVERVIEW_INTERNAL_COLUMNS:
         if column not in working.columns:
             working[column] = False if column in _OVERVIEW_BOOL_COLUMNS else ""


### PR DESCRIPTION
Ensure the Profiling v2 overview grid remains focused on column-level details and does not duplicate sampling summary metrics.

- Drop non-overview columns before rendering the Profiling v2 grid so sampling metadata stays out of the column table
- Refresh /snapshots mirror after the view change


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69200f12b18c8324b2205949284b6b37)