### PR TITLE
Fix matplotlib imports for Profiling v2 page

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-
-import matplotlib.pyplot as plt
 import pandas as pd
 import streamlit as st
 
@@ -262,6 +260,8 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
         sample_rows = sample_est_rows if sample_est_rows is not None else 0
 
     remainder_rows = max(total_rows - sample_rows, 0)
+
+    import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots()
     ax.pie(

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-
-import matplotlib.pyplot as plt
 import pandas as pd
 import streamlit as st
 
@@ -262,6 +260,8 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
         sample_rows = sample_est_rows if sample_est_rows is not None else 0
 
     remainder_rows = max(total_rows - sample_rows, 0)
+
+    import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots()
     ax.pie(


### PR DESCRIPTION
- Move matplotlib import into the Profiling v2 sampling chart to avoid module import errors on startup
- Update mirrored snapshot files

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692012c556188324998dc4efd182e6bc)