### PR TITLE
Add guard for missing matplotlib in sampling chart

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -261,15 +261,18 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
 
     remainder_rows = max(total_rows - sample_rows, 0)
 
-    import matplotlib.pyplot as plt
+    try:
+        import matplotlib.pyplot as plt
 
-    fig, ax = plt.subplots()
-    ax.pie(
-        [sample_rows, remainder_rows],
-        labels=["Sample", "Remainder"],
-        autopct="%1.1f%%",
-    )
-    st.pyplot(fig)
+        fig, ax = plt.subplots()
+        ax.pie(
+            [sample_rows, remainder_rows],
+            labels=["Sample", "Remainder"],
+            autopct="%1.1f%%",
+        )
+        st.pyplot(fig)
+    except ModuleNotFoundError:
+        st.info("Sampling pie chart is unavailable (matplotlib not found in this environment).")
 
 
 def _classification_source_badge(source: Any) -> str:

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -261,15 +261,18 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
 
     remainder_rows = max(total_rows - sample_rows, 0)
 
-    import matplotlib.pyplot as plt
+    try:
+        import matplotlib.pyplot as plt
 
-    fig, ax = plt.subplots()
-    ax.pie(
-        [sample_rows, remainder_rows],
-        labels=["Sample", "Remainder"],
-        autopct="%1.1f%%",
-    )
-    st.pyplot(fig)
+        fig, ax = plt.subplots()
+        ax.pie(
+            [sample_rows, remainder_rows],
+            labels=["Sample", "Remainder"],
+            autopct="%1.1f%%",
+        )
+        st.pyplot(fig)
+    except ModuleNotFoundError:
+        st.info("Sampling pie chart is unavailable (matplotlib not found in this environment).")
 
 
 def _classification_source_badge(source: Any) -> str:


### PR DESCRIPTION
- add ModuleNotFoundError handling around sampling pie chart rendering to keep the page stable when matplotlib is unavailable
- update mirrored snapshot files

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692014a48eec8324b0f434e32463ced2)