### PR TITLE
Ensure the Profiling v2 layout is still correct after moving matplotlib imports

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -261,18 +261,23 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
 
     remainder_rows = max(total_rows - sample_rows, 0)
 
+    _render_sampling_pie_chart(sample_rows, remainder_rows)
+
+
+def _render_sampling_pie_chart(sample_rows: float, remainder_rows: float) -> None:
     try:
         import matplotlib.pyplot as plt
-
-        fig, ax = plt.subplots()
-        ax.pie(
-            [sample_rows, remainder_rows],
-            labels=["Sample", "Remainder"],
-            autopct="%1.1f%%",
-        )
-        st.pyplot(fig)
     except ModuleNotFoundError:
         st.info("Sampling pie chart is unavailable (matplotlib not found in this environment).")
+        return
+
+    fig, ax = plt.subplots()
+    ax.pie(
+        [sample_rows, remainder_rows],
+        labels=["Sample", "Remainder"],
+        autopct="%1.1f%%",
+    )
+    st.pyplot(fig)
 
 
 def _classification_source_badge(source: Any) -> str:

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -261,18 +261,23 @@ def _render_sampling_summary(run_info: Dict[str, Any]) -> None:
 
     remainder_rows = max(total_rows - sample_rows, 0)
 
+    _render_sampling_pie_chart(sample_rows, remainder_rows)
+
+
+def _render_sampling_pie_chart(sample_rows: float, remainder_rows: float) -> None:
     try:
         import matplotlib.pyplot as plt
-
-        fig, ax = plt.subplots()
-        ax.pie(
-            [sample_rows, remainder_rows],
-            labels=["Sample", "Remainder"],
-            autopct="%1.1f%%",
-        )
-        st.pyplot(fig)
     except ModuleNotFoundError:
         st.info("Sampling pie chart is unavailable (matplotlib not found in this environment).")
+        return
+
+    fig, ax = plt.subplots()
+    ax.pie(
+        [sample_rows, remainder_rows],
+        labels=["Sample", "Remainder"],
+        autopct="%1.1f%%",
+    )
+    st.pyplot(fig)
 
 
 def _classification_source_badge(source: Any) -> str:


### PR DESCRIPTION
- Ensure the sampling summary renders before a dedicated pie chart helper that only consumes computed values
- Mirror updated profiling view snapshot files

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920155fff5083249a8bf40d8e4a95f5)