### PR TITLE
Fix profiling Snowflake error handling for DQ_PROFILE_FULL

### DIFF
--- a/sql/DQ_PROFILE_FULL.sql
+++ b/sql/DQ_PROFILE_FULL.sql
@@ -124,7 +124,7 @@ EXCEPTION
     WHEN OTHER THEN
         v_completed_at := CURRENT_TIMESTAMP();
         v_status := 'FAILED';
-        v_error := TRY_CAST(error_message() AS STRING);
+        v_error := SQLERRM;
 
         INSERT INTO ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_PROFILE_RUN (
             TARGET_TABLE,


### PR DESCRIPTION
* replace invalid Snowflake error_message() usage with SQLERRM in DQ_PROFILE_FULL exception handling


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920218d2718832485eb2bbbf8783522)