### PR TITLE
Ensure Profiling v2 view queries DQ_PROFILE_RUN sampling metadata

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -728,6 +728,9 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
     sql = f"""
         SELECT
             PROFILE_RUN_ID AS RUN_ID,
+            DATABASE_NAME,
+            SCHEMA_NAME,
+            TABLE_NAME,
             TABLE_FQN,
             STARTED_AT,
             FINISHED_AT,
@@ -736,7 +739,9 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
             ROW_COUNT,
             SAMPLE_MODE,
             SAMPLE_PERCENT,
-            SAMPLE_EST_ROWS
+            SAMPLE_EST_ROWS,
+            CREATED_AT,
+            UPDATED_AT
         FROM {PROFILE_RUN_TABLE}
         WHERE TABLE_FQN = ?
         ORDER BY STARTED_AT DESC

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -728,6 +728,9 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
     sql = f"""
         SELECT
             PROFILE_RUN_ID AS RUN_ID,
+            DATABASE_NAME,
+            SCHEMA_NAME,
+            TABLE_NAME,
             TABLE_FQN,
             STARTED_AT,
             FINISHED_AT,
@@ -736,7 +739,9 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
             ROW_COUNT,
             SAMPLE_MODE,
             SAMPLE_PERCENT,
-            SAMPLE_EST_ROWS
+            SAMPLE_EST_ROWS,
+            CREATED_AT,
+            UPDATED_AT
         FROM {PROFILE_RUN_TABLE}
         WHERE TABLE_FQN = ?
         ORDER BY STARTED_AT DESC


### PR DESCRIPTION
- Extend DQ_PROFILE_RUN query for recent profiling runs to select sampling metadata columns and audit timestamps.
- Mirror updated Python sources into /snapshots .p files.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692054ea70c88324b29483100e0f502b)