### PR TITLE
APP-FIX-HARDLOCK

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -34,10 +34,11 @@ Forbidden patterns:
 import logging
 import streamlit as st
 
-# safe inits
+# Safe inits (no rendering)
 st.session_state["_rerun_count"] = st.session_state.get("_rerun_count", 0) + 1
 st.session_state.setdefault("active_view", "home")
-st.session_state.setdefault("page", st.session_state["active_view"])
+st.session_state.setdefault("page", st.session_state["active_view"])  # keep if router uses 'page'
+st.session_state.setdefault("freeze_view", False)
 
 current_view = st.session_state.get("active_view", "home")
 
@@ -74,7 +75,11 @@ if "_last_query_page" not in st.session_state:
 
 def set_view(view: str) -> None:
     """Update the active view explicitly via user navigation."""
+    if st.session_state.get("freeze_view"):
+        logging.info("route:blocked while frozen (wanted=%s)", view)
+        return
     st.session_state["active_view"] = view
+    st.session_state["page"] = view
     logging.info("route:set %s", view)
 
 try:
@@ -136,6 +141,16 @@ CHECKS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 # RUN_RESULTS_TBL already defined above
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
+
+# Hard override during profiling: force Profile view and stop further processing
+if st.session_state.get("freeze_view"):
+    logging.info("dispatch:hard-freeze → profile")
+    st.session_state["active_view"] = "profile"
+    st.session_state["page"] = "profile"  # keep in sync if your router uses 'page'
+    from views.profile_view import render_profile
+
+    render_profile()
+    st.stop()  # halt this rerun so no other routing can change the page
 
 st.caption(
     f"rerun #{st.session_state.get('_rerun_count')} "
@@ -234,7 +249,6 @@ def _get_page_from_query_params() -> Optional[str]:
 def navigate_to(page: str) -> None:
     """Update the current page selection in session state."""
     set_view(page)
-    st.session_state["page"] = page
     st.session_state["_last_query_page"] = page
     try:
         current = dict(st.query_params)  # type: ignore[attr-defined]
@@ -1679,7 +1693,6 @@ if query_page and query_page != last_query_page:
     st.session_state["_last_query_page"] = query_page
     if query_page != st.session_state.get("active_view"):
         set_view(query_page)
-        st.session_state["page"] = query_page
 elif query_page is None:
     if "_last_query_page" not in st.session_state:
         st.session_state["_last_query_page"] = st.session_state.get(

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+import logging
 import pandas as pd
 import streamlit as st
 
 from services import profiling_v2 as profiling_service
 from ui import strings as ui_strings
 from views.table_picker import stateless_table_picker
+
+st.session_state.setdefault("busy_profiling", False)
+st.session_state.setdefault("freeze_view", False)
 
 
 @dataclass
@@ -798,21 +802,42 @@ def render_profile(
     classify_fn = getattr(helpers, "run_classification_only", None)
     suggestions_fn = getattr(helpers, "run_suggestions_only", None)
 
-    if run_clicked and target_fqn:
-        with st.spinner(ui_strings.PROFILE_V2_RUN_SPINNER.format(table=target_fqn)):
+    fqn = (
+        st.session_state.get("editor_target_fqn")
+        or st.session_state.get("profile_target_fqn")
+        or ""
+    )
+
+    if run_clicked:
+        if not fqn:
+            st.warning("Select a table first.")
+        elif not st.session_state["busy_profiling"]:
+            st.session_state["busy_profiling"] = True
+            st.session_state["freeze_view"] = True
             try:
-                helpers.run_profiling_v2(session, target_fqn)
+                with st.spinner(
+                    ui_strings.PROFILE_V2_RUN_SPINNER.format(table=fqn)
+                ):
+                    helpers.run_profiling_v2(session, fqn)
             except Exception as exc:
+                logging.exception("profiling:unhandled")
+                st.session_state["last_profile_err"] = (
+                    f"{type(exc).__name__}: {exc}"
+                )
                 status_placeholder.error(
                     ui_strings.PROFILE_V2_RUN_ERROR.format(error=str(exc))
                 )
             else:
                 st.session_state["profile_data_nonce"] += 1
-                st.session_state["profile_last_table"] = target_fqn
+                st.session_state["profile_last_table"] = fqn
                 st.session_state["profile_last_run_id"] = None
+                st.session_state["last_profile_err"] = None
                 status_placeholder.success(
-                    ui_strings.PROFILE_V2_RUN_SUCCESS.format(table=target_fqn)
+                    ui_strings.PROFILE_V2_RUN_SUCCESS.format(table=fqn)
                 )
+            finally:
+                st.session_state["busy_profiling"] = False
+                st.session_state["freeze_view"] = False
     elif refresh_clicked and target_fqn:
         status_placeholder.info(ui_strings.PROFILE_V2_REFRESH_MESSAGE)
         st.session_state["profile_data_nonce"] += 1
@@ -860,6 +885,10 @@ def render_profile(
                             table=target_fqn
                         )
                     )
+
+    last_profile_err = st.session_state.get("last_profile_err")
+    if last_profile_err:
+        status_placeholder.error(last_profile_err)
 
     if not target_fqn:
         st.info(ui_strings.PROFILE_V2_NO_TARGET)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -34,10 +34,11 @@ Forbidden patterns:
 import logging
 import streamlit as st
 
-# safe inits
+# Safe inits (no rendering)
 st.session_state["_rerun_count"] = st.session_state.get("_rerun_count", 0) + 1
 st.session_state.setdefault("active_view", "home")
-st.session_state.setdefault("page", st.session_state["active_view"])
+st.session_state.setdefault("page", st.session_state["active_view"])  # keep if router uses 'page'
+st.session_state.setdefault("freeze_view", False)
 
 current_view = st.session_state.get("active_view", "home")
 
@@ -74,7 +75,11 @@ if "_last_query_page" not in st.session_state:
 
 def set_view(view: str) -> None:
     """Update the active view explicitly via user navigation."""
+    if st.session_state.get("freeze_view"):
+        logging.info("route:blocked while frozen (wanted=%s)", view)
+        return
     st.session_state["active_view"] = view
+    st.session_state["page"] = view
     logging.info("route:set %s", view)
 
 try:
@@ -136,6 +141,16 @@ CHECKS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 # RUN_RESULTS_TBL already defined above
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
+
+# Hard override during profiling: force Profile view and stop further processing
+if st.session_state.get("freeze_view"):
+    logging.info("dispatch:hard-freeze → profile")
+    st.session_state["active_view"] = "profile"
+    st.session_state["page"] = "profile"  # keep in sync if your router uses 'page'
+    from views.profile_view import render_profile
+
+    render_profile()
+    st.stop()  # halt this rerun so no other routing can change the page
 
 st.caption(
     f"rerun #{st.session_state.get('_rerun_count')} "
@@ -234,7 +249,6 @@ def _get_page_from_query_params() -> Optional[str]:
 def navigate_to(page: str) -> None:
     """Update the current page selection in session state."""
     set_view(page)
-    st.session_state["page"] = page
     st.session_state["_last_query_page"] = page
     try:
         current = dict(st.query_params)  # type: ignore[attr-defined]
@@ -1679,7 +1693,6 @@ if query_page and query_page != last_query_page:
     st.session_state["_last_query_page"] = query_page
     if query_page != st.session_state.get("active_view"):
         set_view(query_page)
-        st.session_state["page"] = query_page
 elif query_page is None:
     if "_last_query_page" not in st.session_state:
         st.session_state["_last_query_page"] = st.session_state.get(

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+import logging
 import pandas as pd
 import streamlit as st
 
 from services import profiling_v2 as profiling_service
 from ui import strings as ui_strings
 from views.table_picker import stateless_table_picker
+
+st.session_state.setdefault("busy_profiling", False)
+st.session_state.setdefault("freeze_view", False)
 
 
 @dataclass
@@ -798,21 +802,42 @@ def render_profile(
     classify_fn = getattr(helpers, "run_classification_only", None)
     suggestions_fn = getattr(helpers, "run_suggestions_only", None)
 
-    if run_clicked and target_fqn:
-        with st.spinner(ui_strings.PROFILE_V2_RUN_SPINNER.format(table=target_fqn)):
+    fqn = (
+        st.session_state.get("editor_target_fqn")
+        or st.session_state.get("profile_target_fqn")
+        or ""
+    )
+
+    if run_clicked:
+        if not fqn:
+            st.warning("Select a table first.")
+        elif not st.session_state["busy_profiling"]:
+            st.session_state["busy_profiling"] = True
+            st.session_state["freeze_view"] = True
             try:
-                helpers.run_profiling_v2(session, target_fqn)
+                with st.spinner(
+                    ui_strings.PROFILE_V2_RUN_SPINNER.format(table=fqn)
+                ):
+                    helpers.run_profiling_v2(session, fqn)
             except Exception as exc:
+                logging.exception("profiling:unhandled")
+                st.session_state["last_profile_err"] = (
+                    f"{type(exc).__name__}: {exc}"
+                )
                 status_placeholder.error(
                     ui_strings.PROFILE_V2_RUN_ERROR.format(error=str(exc))
                 )
             else:
                 st.session_state["profile_data_nonce"] += 1
-                st.session_state["profile_last_table"] = target_fqn
+                st.session_state["profile_last_table"] = fqn
                 st.session_state["profile_last_run_id"] = None
+                st.session_state["last_profile_err"] = None
                 status_placeholder.success(
-                    ui_strings.PROFILE_V2_RUN_SUCCESS.format(table=target_fqn)
+                    ui_strings.PROFILE_V2_RUN_SUCCESS.format(table=fqn)
                 )
+            finally:
+                st.session_state["busy_profiling"] = False
+                st.session_state["freeze_view"] = False
     elif refresh_clicked and target_fqn:
         status_placeholder.info(ui_strings.PROFILE_V2_REFRESH_MESSAGE)
         st.session_state["profile_data_nonce"] += 1
@@ -860,6 +885,10 @@ def render_profile(
                             table=target_fqn
                         )
                     )
+
+    last_profile_err = st.session_state.get("last_profile_err")
+    if last_profile_err:
+        status_placeholder.error(last_profile_err)
 
     if not target_fqn:
         st.info(ui_strings.PROFILE_V2_NO_TARGET)


### PR DESCRIPTION
- Hard-override routing to keep the Profile view active during profiling runs with centralized navigation guard.
- Toggle profiling freeze/busy flags around run execution to debounce and persist inline errors while keeping layout intact.
- Mirror updated Python sources into /snapshots .p files.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69294b030a8c83249a0d4e531112bdc6)