### PR TITLE
Fix DQ_PROFILE_FULL min/max type casting

### DIFF
--- a/sql/DQ_PROFILE_FULL.sql
+++ b/sql/DQ_PROFILE_FULL.sql
@@ -191,8 +191,8 @@ BEGIN
             '  FROM (SELECT' || CHR(10) ||
             '                SUM(IFF(' || v_col_ident || ' IS NULL, 1, 0)) AS NULL_COUNT,' || CHR(10) ||
             '                COUNT(DISTINCT ' || v_col_ident || ') AS DISTINCT_COUNT,' || CHR(10) ||
-            '                MIN(' || v_col_ident || ') AS MIN_VALUE,' || CHR(10) ||
-            '                MAX(' || v_col_ident || ') AS MAX_VALUE,' || CHR(10) ||
+            '                TO_VARIANT(MIN(' || v_col_ident || ')) AS MIN_VALUE,' || CHR(10) ||
+            '                TO_VARIANT(MAX(' || v_col_ident || ')) AS MAX_VALUE,' || CHR(10) ||
             '                MIN(LENGTH(TO_VARCHAR(' || v_col_ident || '))) AS MIN_LENGTH_RAW,' || CHR(10) ||
             '                MAX(LENGTH(TO_VARCHAR(' || v_col_ident || '))) AS MAX_LENGTH_RAW,' || CHR(10) ||
             '                AVG(LENGTH(TO_VARCHAR(' || v_col_ident || '))) AS AVG_LENGTH_RAW' || CHR(10) ||


### PR DESCRIPTION
- Cast MIN_VALUE and MAX_VALUE to VARIANT within DQ_PROFILE_FULL to avoid set operator type mismatches

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929adbf820c8324947f1dce71b6568b)