### PR TITLE
Fix column metadata literals in profiling

### DIFF
--- a/sql/DQ_PROFILE_FULL.sql
+++ b/sql/DQ_PROFILE_FULL.sql
@@ -165,8 +165,8 @@ BEGIN
     FOR rec in v_rs DO
         v_col_ident := '"' || REPLACE(rec.COLUMN_NAME, '"', '""') || '"';
         v_is_string := REGEXP_LIKE(UPPER(rec.DATA_TYPE), 'CHAR|TEXT|STRING');
-        v_col_literal := IFF(rec:"COLUMN_NAME" IS NULL, 'NULL', '\'' || REPLACE(rec:"COLUMN_NAME", '\'', '\'\'\'') || '\'');
-        v_data_type_literal := IFF(rec:"DATA_TYPE" IS NULL, 'NULL', '\'' || REPLACE(rec:"DATA_TYPE", '\'', '\'\'\'') || '\'');
+        v_col_literal := IFF(rec.COLUMN_NAME IS NULL, 'NULL', '\'' || REPLACE(rec.COLUMN_NAME, '\'', '\'\'\'') || '\'');
+        v_data_type_literal := IFF(rec.DATA_TYPE IS NULL, 'NULL', '\'' || REPLACE(rec.DATA_TYPE, '\'', '\'\'\'') || '\'');
 
         v_feature_sql := v_feature_sql || v_union_prefix || CHR(10) ||
             'SELECT ' || :v_profile_run_id || ' AS PROFILE_RUN_ID,' || CHR(10) ||


### PR DESCRIPTION
- Correctly reference column name and data type values when generating DQ_COLUMN_FEATURES inserts
- Ensure profiling results store populated column metadata for profile grid consumption

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b2fc8a208324af5960da275f56ef)