### PR TITLE
PROFILING-A105 Fix profiling metadata NameError

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -178,6 +178,36 @@ def _latest_partition(
     return working.drop_duplicates(subset=subset, keep="first")
 
 
+def _latest_classifications(class_df: pd.DataFrame) -> Dict[str, Dict[str, Any]]:
+    if not isinstance(class_df, pd.DataFrame) or class_df.empty:
+        return {}
+
+    working = class_df.copy()
+    sort_by: List[str] = []
+    ascending: List[bool] = []
+    if "COLUMN_NAME" in working.columns:
+        sort_by.append("COLUMN_NAME")
+        ascending.append(True)
+    for column in ("SOURCE", "CLASSIFIED_AT"):
+        if column in working.columns:
+            sort_by.append(column)
+            ascending.append(False)
+
+    if sort_by:
+        working = working.sort_values(by=sort_by, ascending=ascending)
+
+    if "COLUMN_NAME" not in working.columns:
+        return {}
+
+    deduped = working.drop_duplicates(subset=["COLUMN_NAME"], keep="first")
+    result: Dict[str, Dict[str, Any]] = {}
+    for record in deduped.to_dict("records"):
+        column = record.get("COLUMN_NAME")
+        if column is not None:
+            result[str(column)] = record
+    return result
+
+
 def _format_count_ratio(count: Any, ratio: Any) -> str:
     def _format_value(value: Any) -> str:
         if pd.isna(value):

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -178,6 +178,36 @@ def _latest_partition(
     return working.drop_duplicates(subset=subset, keep="first")
 
 
+def _latest_classifications(class_df: pd.DataFrame) -> Dict[str, Dict[str, Any]]:
+    if not isinstance(class_df, pd.DataFrame) or class_df.empty:
+        return {}
+
+    working = class_df.copy()
+    sort_by: List[str] = []
+    ascending: List[bool] = []
+    if "COLUMN_NAME" in working.columns:
+        sort_by.append("COLUMN_NAME")
+        ascending.append(True)
+    for column in ("SOURCE", "CLASSIFIED_AT"):
+        if column in working.columns:
+            sort_by.append(column)
+            ascending.append(False)
+
+    if sort_by:
+        working = working.sort_values(by=sort_by, ascending=ascending)
+
+    if "COLUMN_NAME" not in working.columns:
+        return {}
+
+    deduped = working.drop_duplicates(subset=["COLUMN_NAME"], keep="first")
+    result: Dict[str, Dict[str, Any]] = {}
+    for record in deduped.to_dict("records"):
+        column = record.get("COLUMN_NAME")
+        if column is not None:
+            result[str(column)] = record
+    return result
+
+
 def _format_count_ratio(count: Any, ratio: Any) -> str:
     def _format_value(value: Any) -> str:
         if pd.isna(value):

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -746,28 +746,50 @@ def _load_metadata(
     session: Any,
     table_fqn: str,
 ) -> _ProfilingData:
+    overview_grid: pd.DataFrame = pd.DataFrame()
+    column_classification: pd.DataFrame = pd.DataFrame()
+    recent_runs: pd.DataFrame = pd.DataFrame()
+
     overview_fn = getattr(helpers, "get_overview_grid", None)
-    overview_grid = (
-        overview_fn(session, table_fqn)
-        if callable(overview_fn)
+    if callable(overview_fn):
+        try:
+            overview_grid = overview_fn(session, table_fqn)
+        except Exception:  # pragma: no cover - Snowflake/IO failures
+            logging.exception("profiling:overview_metadata_failed table=%s", table_fqn)
+            overview_grid = pd.DataFrame()
+
+    effective_class_fn = getattr(helpers, "get_effective_classification", None)
+    column_class_fn = getattr(helpers, "get_column_classification", None)
+    classification_fn = effective_class_fn if callable(effective_class_fn) else column_class_fn
+    if callable(classification_fn):
+        try:
+            column_classification = classification_fn(session, table_fqn)
+        except Exception:  # pragma: no cover - Snowflake/IO failures
+            logging.exception(
+                "profiling:classification_metadata_failed table=%s", table_fqn
+            )
+            column_classification = pd.DataFrame()
+
+    run_history_fn = getattr(helpers, "fetch_recent_runs", None)
+    if callable(run_history_fn):
+        try:
+            recent_runs = run_history_fn(session, table_fqn)
+        except Exception:  # pragma: no cover - Snowflake/IO failures
+            logging.exception("profiling:recent_runs_failed table=%s", table_fqn)
+            recent_runs = pd.DataFrame()
+
+    overview_grid = overview_grid if isinstance(overview_grid, pd.DataFrame) else pd.DataFrame()
+    column_classification = (
+        column_classification
+        if isinstance(column_classification, pd.DataFrame)
         else pd.DataFrame()
     )
-    effective_class_fn = getattr(helpers, "get_effective_classification", None)
-    if callable(effective_class_fn):
-        column_classification = effective_class_fn(session, table_fqn)
-    else:
-        column_class_fn = getattr(helpers, "get_column_classification", None)
-        column_classification = (
-            column_class_fn(session, table_fqn)
-            if callable(column_class_fn)
-            else pd.DataFrame()
-        )
-    run_history_fn = getattr(helpers, "fetch_recent_runs", None)
-    recent_runs = run_history_fn(session, table_fqn) if callable(run_history_fn) else pd.DataFrame()
+    recent_runs = recent_runs if isinstance(recent_runs, pd.DataFrame) else pd.DataFrame()
+
     return _ProfilingData(
-        overview_grid=overview_grid if isinstance(overview_grid, pd.DataFrame) else pd.DataFrame(),
-        column_classification=column_classification if isinstance(column_classification, pd.DataFrame) else pd.DataFrame(),
-        recent_runs=recent_runs if isinstance(recent_runs, pd.DataFrame) else pd.DataFrame(),
+        overview_grid=overview_grid,
+        column_classification=column_classification,
+        recent_runs=recent_runs,
         run_info=_extract_run_info(recent_runs),
     )
 
@@ -937,10 +959,18 @@ def render_profile(
         try:
             data = _load_metadata(helpers, session, target_fqn)
         except Exception as exc:
+            logging.exception(
+                "profiling:metadata_load_failed table=%s", target_fqn
+            )
             st.error(
                 ui_strings.PROFILE_V2_METADATA_ERROR.format(error=str(exc))
             )
-            return
+            data = _ProfilingData(
+                overview_grid=pd.DataFrame(),
+                column_classification=pd.DataFrame(),
+                recent_runs=pd.DataFrame(),
+                run_info={},
+            )
 
     st.session_state["profile_last_table"] = target_fqn
     st.session_state["profile_last_run_id"] = _extract_last_run_id(data.recent_runs)

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -746,28 +746,50 @@ def _load_metadata(
     session: Any,
     table_fqn: str,
 ) -> _ProfilingData:
+    overview_grid: pd.DataFrame = pd.DataFrame()
+    column_classification: pd.DataFrame = pd.DataFrame()
+    recent_runs: pd.DataFrame = pd.DataFrame()
+
     overview_fn = getattr(helpers, "get_overview_grid", None)
-    overview_grid = (
-        overview_fn(session, table_fqn)
-        if callable(overview_fn)
+    if callable(overview_fn):
+        try:
+            overview_grid = overview_fn(session, table_fqn)
+        except Exception:  # pragma: no cover - Snowflake/IO failures
+            logging.exception("profiling:overview_metadata_failed table=%s", table_fqn)
+            overview_grid = pd.DataFrame()
+
+    effective_class_fn = getattr(helpers, "get_effective_classification", None)
+    column_class_fn = getattr(helpers, "get_column_classification", None)
+    classification_fn = effective_class_fn if callable(effective_class_fn) else column_class_fn
+    if callable(classification_fn):
+        try:
+            column_classification = classification_fn(session, table_fqn)
+        except Exception:  # pragma: no cover - Snowflake/IO failures
+            logging.exception(
+                "profiling:classification_metadata_failed table=%s", table_fqn
+            )
+            column_classification = pd.DataFrame()
+
+    run_history_fn = getattr(helpers, "fetch_recent_runs", None)
+    if callable(run_history_fn):
+        try:
+            recent_runs = run_history_fn(session, table_fqn)
+        except Exception:  # pragma: no cover - Snowflake/IO failures
+            logging.exception("profiling:recent_runs_failed table=%s", table_fqn)
+            recent_runs = pd.DataFrame()
+
+    overview_grid = overview_grid if isinstance(overview_grid, pd.DataFrame) else pd.DataFrame()
+    column_classification = (
+        column_classification
+        if isinstance(column_classification, pd.DataFrame)
         else pd.DataFrame()
     )
-    effective_class_fn = getattr(helpers, "get_effective_classification", None)
-    if callable(effective_class_fn):
-        column_classification = effective_class_fn(session, table_fqn)
-    else:
-        column_class_fn = getattr(helpers, "get_column_classification", None)
-        column_classification = (
-            column_class_fn(session, table_fqn)
-            if callable(column_class_fn)
-            else pd.DataFrame()
-        )
-    run_history_fn = getattr(helpers, "fetch_recent_runs", None)
-    recent_runs = run_history_fn(session, table_fqn) if callable(run_history_fn) else pd.DataFrame()
+    recent_runs = recent_runs if isinstance(recent_runs, pd.DataFrame) else pd.DataFrame()
+
     return _ProfilingData(
-        overview_grid=overview_grid if isinstance(overview_grid, pd.DataFrame) else pd.DataFrame(),
-        column_classification=column_classification if isinstance(column_classification, pd.DataFrame) else pd.DataFrame(),
-        recent_runs=recent_runs if isinstance(recent_runs, pd.DataFrame) else pd.DataFrame(),
+        overview_grid=overview_grid,
+        column_classification=column_classification,
+        recent_runs=recent_runs,
         run_info=_extract_run_info(recent_runs),
     )
 
@@ -937,10 +959,18 @@ def render_profile(
         try:
             data = _load_metadata(helpers, session, target_fqn)
         except Exception as exc:
+            logging.exception(
+                "profiling:metadata_load_failed table=%s", target_fqn
+            )
             st.error(
                 ui_strings.PROFILE_V2_METADATA_ERROR.format(error=str(exc))
             )
-            return
+            data = _ProfilingData(
+                overview_grid=pd.DataFrame(),
+                column_classification=pd.DataFrame(),
+                recent_runs=pd.DataFrame(),
+                run_info={},
+            )
 
     st.session_state["profile_last_table"] = target_fqn
     st.session_state["profile_last_run_id"] = _extract_last_run_id(data.recent_runs)


### PR DESCRIPTION
- Define latest classification helper in profiling service to avoid NameError and handle empty results
- Harden profiling metadata loader to catch metadata fetch errors and return empty frames instead of failing
- Mirror updated snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ed705414c8324b45e33d03c489eb4)