### PR TITLE
Fix rationale truncation helper import

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -60,6 +60,15 @@ def _execute_sql(session: Any, sql: str, params: Optional[Iterable[Any]] = None)
     return stmt
 
 
+def _truncate_details(value: Any, max_length: int = 500) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1].rstrip() + "\u2026"
+
+
 def _friendly_error_message(exc: Exception) -> str:
     message = str(exc).strip()
     if not message:

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -60,6 +60,15 @@ def _execute_sql(session: Any, sql: str, params: Optional[Iterable[Any]] = None)
     return stmt
 
 
+def _truncate_details(value: Any, max_length: int = 500) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1].rstrip() + "\u2026"
+
+
 def _friendly_error_message(exc: Exception) -> str:
     message = str(exc).strip()
     if not message:


### PR DESCRIPTION
- add missing _truncate_details helper to profiling_v2 to avoid NameError during rationale formatting
- refresh mirrored snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692edbb94f388324beb2169c154be8a8)