### PR TITLE
Clean profiling debug captions

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -141,11 +141,12 @@ CHECKS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
 
-st.caption(
-    f"rerun #{st.session_state.get('_rerun_count')} "
-    f"view={st.session_state.get('active_view')} "
-    f"fqn={st.session_state.get('editor_target_fqn')}"
-)
+if DEBUG_PROFILING:
+    st.caption(
+        f"rerun #{st.session_state.get('_rerun_count')} "
+        f"view={st.session_state.get('active_view')} "
+        f"fqn={st.session_state.get('editor_target_fqn')}"
+    )
 
 # Hard override: if profiling is running, force Profile render and stop further dispatch
 if st.session_state.get("freeze_view"):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -141,11 +141,12 @@ CHECKS_TBL = f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_CHECK"
 
 st.set_page_config(page_title="Zeus Data Quality", layout="wide")
 
-st.caption(
-    f"rerun #{st.session_state.get('_rerun_count')} "
-    f"view={st.session_state.get('active_view')} "
-    f"fqn={st.session_state.get('editor_target_fqn')}"
-)
+if DEBUG_PROFILING:
+    st.caption(
+        f"rerun #{st.session_state.get('_rerun_count')} "
+        f"view={st.session_state.get('active_view')} "
+        f"fqn={st.session_state.get('editor_target_fqn')}"
+    )
 
 # Hard override: if profiling is running, force Profile render and stop further dispatch
 if st.session_state.get("freeze_view"):


### PR DESCRIPTION
- Gate the rerun/session caption behind the profiling debug flag to keep the UI clean.
- Refresh snapshot mirrors after code updates.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f30a61eb4832484e65af49ea70e28)