### PR TITLE
Fix DQ compile rule identifier quoting

### DIFF
--- a/sql/DQ_COMPILE_RULE_SQL.sql
+++ b/sql/DQ_COMPILE_RULE_SQL.sql
@@ -25,7 +25,7 @@ def quote_identifier(name: str) -> str:
     segments = [seg.strip() for seg in name.split(".") if seg.strip()]
     if not segments:
         raise ValueError("Identifier cannot be empty")
-    return ".".join(f'"{seg.replace("\"", "\"\"")}"' for seg in segments)
+    return ".".join('"' + seg.replace('"', '""') + '"' for seg in segments)
 
 
 def quote_fqn(fqn: str) -> str:


### PR DESCRIPTION
- adjust quote_identifier to avoid invalid f-string syntax when escaping double quotes
- keep identifier quoting behavior while removing Python syntax error

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fdcf2d490832482847787c127df44)