### PR TITLE
Codex Task E2 — Normalize and seed 4 core rules in DQ_RULE_LIBRARY

### DIFF
--- a/sql/DQ_RULE_LIBRARY_SEED_V2.sql
+++ b/sql/DQ_RULE_LIBRARY_SEED_V2.sql
@@ -1,4 +1,7 @@
 -- Seeds core DSL-based rules into DQ_RULE_LIBRARY without impacting existing entries
+-- Assumptions:
+--   - DQ_RULE_LIBRARY schema matches ZEUS_ANALYTICS_SIMU.DISCOVERY with columns used below.
+--   - PARAM_SCHEMA, DEFAULT_PARAMS, ALLOWED_DATA_TYPES, and ALLOWED_CLASSIFICATIONS accept VARIANT JSON.
 MERGE INTO ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_RULE_LIBRARY AS target
 USING (
     SELECT
@@ -16,10 +19,62 @@ USING (
         VERSION
     FROM (
         SELECT * FROM VALUES
-            ('NOT_NULL', 'COLUMN', 'DSL', 'ASSERT NOT is_null(value)', '[]', '{}', '[]', '[]', 'Completeness', 'HIGH', TRUE, 1),
-            ('RANGE_CHECK', 'COLUMN', 'DSL', 'ASSERT value BETWEEN param("min_value") AND param("max_value")', '[{"name":"min_value","type":"NUMBER","required":true},{"name":"max_value","type":"NUMBER","required":true}]', '{}', '[]', '[]', 'Validity', 'MEDIUM', TRUE, 1),
-            ('REGEX_MATCH', 'COLUMN', 'DSL', 'ASSERT matches(value, param("pattern"))', '[{"name":"pattern","type":"STRING","required":true}]', '{}', '[]', '[]', 'Validity', 'MEDIUM', TRUE, 1),
-            ('IN_REFERENCE_TABLE', 'COLUMN', 'DSL', 'ASSERT (is_null(value) AND param("allow_nulls")) OR lookup_exists(param("ref_table"), param("ref_key_column"), value)', '[{"name":"allow_nulls","type":"BOOLEAN","required":false},{"name":"ref_table","type":"FQN_TABLE","required":true},{"name":"ref_key_column","type":"COLUMN_NAME","required":true}]', '{"allow_nulls": false}', '[]', '[]', 'Consistency', 'HIGH', TRUE, 1)
+            (
+                'NOT_NULL',
+                'COLUMN',
+                'DSL',
+                'ASSERT NOT is_null(value)',
+                '[]',
+                '{}',
+                '[]',
+                '[]',
+                'COMPLETENESS',
+                'HIGH',
+                TRUE,
+                1
+            ),
+            (
+                'RANGE_CHECK',
+                'COLUMN',
+                'DSL',
+                'ASSERT value BETWEEN param("min_value") AND param("max_value")',
+                '[{"name":"min_value","type":"NUMBER","required":true},{"name":"max_value","type":"NUMBER","required":true}]',
+                '{}',
+                '[]',
+                '[]',
+                'VALIDITY',
+                'MEDIUM',
+                TRUE,
+                1
+            ),
+            (
+                'REGEX_MATCH',
+                'COLUMN',
+                'DSL',
+                'ASSERT matches(value, param("pattern"))',
+                '[{"name":"pattern","type":"STRING","required":true}]',
+                '{}',
+                '[]',
+                '[]',
+                'VALIDITY',
+                'MEDIUM',
+                TRUE,
+                1
+            ),
+            (
+                'IN_REFERENCE_TABLE',
+                'COLUMN',
+                'DSL',
+                'ASSERT (is_null(value) AND param("allow_nulls")) OR lookup_exists(param("ref_table"), param("ref_key_column"), value)',
+                '[{"name":"ref_table","type":"FQN_TABLE","required":true},{"name":"ref_key_column","type":"COLUMN_NAME","required":true},{"name":"allow_nulls","type":"BOOLEAN","required":false}]',
+                '{"allow_nulls": true}',
+                '[]',
+                '[]',
+                'REFERENTIAL_INTEGRITY',
+                'HIGH',
+                TRUE,
+                1
+            )
             AS v(RULE_CODE, SCOPE, ENGINE_TYPE, EXPRESSION, PARAM_SCHEMA_JSON, DEFAULT_PARAMS_JSON, ALLOWED_DATA_TYPES_JSON, ALLOWED_CLASSIFICATIONS_JSON, CATEGORY, SEVERITY, ENABLED, VERSION)
     )
 ) AS source


### PR DESCRIPTION
- Normalize core DSL rule definitions to align with target scopes, expressions, and metadata
- Update seed script to enforce required parameter schemas and defaults for reference lookup rule
- Document assumptions for seeding into ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_RULE_LIBRARY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fdd9609608324b57de772b9776c60)