### PR TITLE
Fix DSL identifier quoting syntax error

### DIFF
--- a/services/dq_dsl_compiler.py
+++ b/services/dq_dsl_compiler.py
@@ -22,7 +22,8 @@ def quote_identifier(name: str) -> str:
     segments = [seg.strip() for seg in name.split(".") if seg.strip()]
     if not segments:
         raise ValueError("Identifier cannot be empty")
-    return ".".join(f'"{seg.replace("\"", "\"\"")}"' for seg in segments)
+    escaped_segments = [seg.replace('"', '""') for seg in segments]
+    return ".".join(f'"{seg}"' for seg in escaped_segments)
 
 
 def quote_fqn(fqn: str) -> str:

--- a/snapshots/services/dq_dsl_compiler.p
+++ b/snapshots/services/dq_dsl_compiler.p
@@ -22,7 +22,8 @@ def quote_identifier(name: str) -> str:
     segments = [seg.strip() for seg in name.split(".") if seg.strip()]
     if not segments:
         raise ValueError("Identifier cannot be empty")
-    return ".".join(f'"{seg.replace("\"", "\"\"")}"' for seg in segments)
+    escaped_segments = [seg.replace('"', '""') for seg in segments]
+    return ".".join(f'"{seg}"' for seg in escaped_segments)
 
 
 def quote_fqn(fqn: str) -> str:


### PR DESCRIPTION
- escape identifier segments before joining to avoid f-string backslash errors
- mirror snapshot updates

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302b1e80148324a018e679286e407c)