### PR TITLE
Fix rule admin JSON parameter binding

### DIFF
--- a/snapshots/views/rule_admin_view.p
+++ b/snapshots/views/rule_admin_view.p
@@ -478,8 +478,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
         st.error("\n".join(errors))
         return
 
-    param_schema_json = json.dumps(parsed_param_schema, default=str)
-    default_params_json = json.dumps(parsed_default_params, default=str)
+    param_schema_value = parsed_param_schema
+    default_params_value = parsed_default_params
 
     if action == "test":
         _run_test_compile(
@@ -522,8 +522,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     SCOPE = :4,
                     ENGINE_TYPE = :5,
                     EXPRESSION = :6,
-                    PARAM_SCHEMA = PARSE_JSON(:7),
-                    DEFAULT_PARAMS = PARSE_JSON(:8),
+                    PARAM_SCHEMA = :7,
+                    DEFAULT_PARAMS = :8,
                     ENABLED = :9,
                     VERSION = :10,
                     UPDATED_AT = CURRENT_TIMESTAMP()
@@ -536,8 +536,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     scope_val,
                     engine_val,
                     expression_val,
-                    param_schema_json,
-                    default_params_json,
+                    param_schema_value,
+                    default_params_value,
                     enabled,
                     version_val,
                     selected_uid,
@@ -561,7 +561,7 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     CREATED_AT,
                     UPDATED_AT
                 ) VALUES (
-                    :1, :2, :3, :4, :5, :6, :7, PARSE_JSON(:8), PARSE_JSON(:9), :10, :11, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()
+                    :1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()
                 )
                 """,
                 params=[
@@ -572,8 +572,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     scope_val,
                     engine_val,
                     expression_val,
-                    param_schema_json,
-                    default_params_json,
+                    param_schema_value,
+                    default_params_value,
                     enabled,
                     version_val,
                 ],

--- a/views/rule_admin_view.py
+++ b/views/rule_admin_view.py
@@ -478,8 +478,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
         st.error("\n".join(errors))
         return
 
-    param_schema_json = json.dumps(parsed_param_schema, default=str)
-    default_params_json = json.dumps(parsed_default_params, default=str)
+    param_schema_value = parsed_param_schema
+    default_params_value = parsed_default_params
 
     if action == "test":
         _run_test_compile(
@@ -522,8 +522,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     SCOPE = :4,
                     ENGINE_TYPE = :5,
                     EXPRESSION = :6,
-                    PARAM_SCHEMA = PARSE_JSON(:7),
-                    DEFAULT_PARAMS = PARSE_JSON(:8),
+                    PARAM_SCHEMA = :7,
+                    DEFAULT_PARAMS = :8,
                     ENABLED = :9,
                     VERSION = :10,
                     UPDATED_AT = CURRENT_TIMESTAMP()
@@ -536,8 +536,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     scope_val,
                     engine_val,
                     expression_val,
-                    param_schema_json,
-                    default_params_json,
+                    param_schema_value,
+                    default_params_value,
                     enabled,
                     version_val,
                     selected_uid,
@@ -561,7 +561,7 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     CREATED_AT,
                     UPDATED_AT
                 ) VALUES (
-                    :1, :2, :3, :4, :5, :6, :7, PARSE_JSON(:8), PARSE_JSON(:9), :10, :11, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()
+                    :1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()
                 )
                 """,
                 params=[
@@ -572,8 +572,8 @@ def _render_rule_edit_page(session: Session, metadata_db: str, metadata_schema: 
                     scope_val,
                     engine_val,
                     expression_val,
-                    param_schema_json,
-                    default_params_json,
+                    param_schema_value,
+                    default_params_value,
                     enabled,
                     version_val,
                 ],


### PR DESCRIPTION
- Bind parameter schema and default parameters directly as VARIANT values instead of parsing JSON strings in SQL
- Keep snapshot mirror updated for rule admin view

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302fa35d508324b52c15a39996bf6d)