### PR TITLE
Codex Task P2 — UI: Wire Profiling “Suggest DQ Config” to Backend

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -17,6 +17,7 @@ DISCOVERY_NAMESPACE = f"{DISCOVERY_DB}.{DISCOVERY_SCHEMA}"
 PROFILE_PROC = f"{DISCOVERY_NAMESPACE}.DQ_PROFILE_FULL"
 CLASSIFY_PROC = f"{DISCOVERY_NAMESPACE}.DQ_CLASSIFY_COLUMNS_HEURISTIC"
 SUGGESTIONS_PROC = f"{DISCOVERY_NAMESPACE}.DQ_APPLY_RULES"
+SUGGEST_CONFIG_PROC = f"{DISCOVERY_NAMESPACE}.DQ_SUGGEST_CONFIG_FROM_PROFILE"
 TABLE_SUMMARY_VIEW = f"{DISCOVERY_NAMESPACE}.DQ_TABLE_PROFILE_SUMMARY"
 COLUMN_FEATURES_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_FEATURES"
 COLUMN_CLASSIFICATION_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_CLASSIFICATION"
@@ -150,6 +151,68 @@ def run_suggestions_only(session: Any, table_fqn: str) -> None:
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:apply_rules_failed target=%s", normalized)
         raise ProfilingError(f"Suggestions run failed: {message}") from exc
+
+
+def suggest_config_from_profile(
+    session: Any,
+    table_fqn: str,
+    profile_run_id: Any,
+    included_columns: Iterable[str],
+    config_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Call ``DQ_SUGGEST_CONFIG_FROM_PROFILE`` using current profiling context."""
+
+    normalized = _normalize_table_fqn(table_fqn)
+    if not normalized:
+        raise ProfilingError("Fully-qualified table name is required")
+
+    if profile_run_id is None:
+        raise ProfilingError("Profile run ID is required")
+
+    columns = [str(col).strip() for col in (included_columns or []) if str(col).strip()]
+    if not columns:
+        raise ProfilingError("At least one included column is required")
+
+    params = [normalized, profile_run_id, columns, config_name]
+    LOGGER.info(
+        "profiling_v2:suggest_config target=%s profile_run_id=%s columns=%s",
+        normalized,
+        profile_run_id,
+        ",".join(columns),
+    )
+    try:
+        rows = _execute_sql(
+            session,
+            f"CALL {SUGGEST_CONFIG_PROC}(?, ?, ?, ?)",
+            params=params,
+        ).collect()
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        message = _friendly_error_message(exc)
+        LOGGER.exception(
+            "profiling_v2:suggest_config_failed target=%s profile_run_id=%s",
+            normalized,
+            profile_run_id,
+        )
+        raise ProfilingError(f"Suggest DQ config failed: {message}") from exc
+
+    if not rows:
+        return {}
+
+    first_row = rows[0]
+    if hasattr(first_row, "as_dict"):
+        payload = list(first_row.as_dict().values())[0]
+    elif hasattr(first_row, "__iter__"):
+        payload = list(first_row)[0]
+    else:
+        payload = getattr(first_row, "_x", first_row)
+
+    if isinstance(payload, dict):
+        return payload
+
+    try:
+        return json.loads(payload)
+    except Exception:
+        return {"result": payload}
 
 
 def _fetch_dataframe(session: Any, sql: str, params: Optional[Iterable[Any]] = None) -> pd.DataFrame:

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -17,6 +17,7 @@ DISCOVERY_NAMESPACE = f"{DISCOVERY_DB}.{DISCOVERY_SCHEMA}"
 PROFILE_PROC = f"{DISCOVERY_NAMESPACE}.DQ_PROFILE_FULL"
 CLASSIFY_PROC = f"{DISCOVERY_NAMESPACE}.DQ_CLASSIFY_COLUMNS_HEURISTIC"
 SUGGESTIONS_PROC = f"{DISCOVERY_NAMESPACE}.DQ_APPLY_RULES"
+SUGGEST_CONFIG_PROC = f"{DISCOVERY_NAMESPACE}.DQ_SUGGEST_CONFIG_FROM_PROFILE"
 TABLE_SUMMARY_VIEW = f"{DISCOVERY_NAMESPACE}.DQ_TABLE_PROFILE_SUMMARY"
 COLUMN_FEATURES_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_FEATURES"
 COLUMN_CLASSIFICATION_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_CLASSIFICATION"
@@ -150,6 +151,68 @@ def run_suggestions_only(session: Any, table_fqn: str) -> None:
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:apply_rules_failed target=%s", normalized)
         raise ProfilingError(f"Suggestions run failed: {message}") from exc
+
+
+def suggest_config_from_profile(
+    session: Any,
+    table_fqn: str,
+    profile_run_id: Any,
+    included_columns: Iterable[str],
+    config_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Call ``DQ_SUGGEST_CONFIG_FROM_PROFILE`` using current profiling context."""
+
+    normalized = _normalize_table_fqn(table_fqn)
+    if not normalized:
+        raise ProfilingError("Fully-qualified table name is required")
+
+    if profile_run_id is None:
+        raise ProfilingError("Profile run ID is required")
+
+    columns = [str(col).strip() for col in (included_columns or []) if str(col).strip()]
+    if not columns:
+        raise ProfilingError("At least one included column is required")
+
+    params = [normalized, profile_run_id, columns, config_name]
+    LOGGER.info(
+        "profiling_v2:suggest_config target=%s profile_run_id=%s columns=%s",
+        normalized,
+        profile_run_id,
+        ",".join(columns),
+    )
+    try:
+        rows = _execute_sql(
+            session,
+            f"CALL {SUGGEST_CONFIG_PROC}(?, ?, ?, ?)",
+            params=params,
+        ).collect()
+    except Exception as exc:  # pragma: no cover - Snowflake specific failures
+        message = _friendly_error_message(exc)
+        LOGGER.exception(
+            "profiling_v2:suggest_config_failed target=%s profile_run_id=%s",
+            normalized,
+            profile_run_id,
+        )
+        raise ProfilingError(f"Suggest DQ config failed: {message}") from exc
+
+    if not rows:
+        return {}
+
+    first_row = rows[0]
+    if hasattr(first_row, "as_dict"):
+        payload = list(first_row.as_dict().values())[0]
+    elif hasattr(first_row, "__iter__"):
+        payload = list(first_row)[0]
+    else:
+        payload = getattr(first_row, "_x", first_row)
+
+    if isinstance(payload, dict):
+        return payload
+
+    try:
+        return json.loads(payload)
+    except Exception:
+        return {"result": payload}
 
 
 def _fetch_dataframe(session: Any, sql: str, params: Optional[Iterable[Any]] = None) -> pd.DataFrame:

--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -28,6 +28,25 @@ PROFILE_V2_SUGGESTIONS_SPINNER = "Re-running suggestions for {table}..."
 PROFILE_V2_SUGGESTIONS_ERROR = "Suggestions run failed: {error}"
 PROFILE_V2_SUGGESTIONS_SUCCESS = "Suggestions refreshed for {table}."
 PROFILE_V2_SUGGESTIONS_UNAVAILABLE = "Suggestions rerun is unavailable in this environment."
+PROFILE_V2_SUGGEST_CONFIG_BUTTON = "Suggest DQ Config"
+PROFILE_V2_SUGGEST_CONFIG_SPINNER = (
+    "Suggesting DQ config from latest profiling run for {table}..."
+)
+PROFILE_V2_SUGGEST_CONFIG_NO_COLUMNS = (
+    "Please select at least one column with Include = True."
+)
+PROFILE_V2_SUGGEST_CONFIG_NO_RUN_ID = (
+    "Run profiling first to record a profiling run ID before suggesting a config."
+)
+PROFILE_V2_SUGGEST_CONFIG_ERROR = "Failed to suggest DQ config: {error}"
+PROFILE_V2_SUGGEST_CONFIG_SUCCESS = (
+    "✅ DQ Config suggested successfully for {table}. Created/updated config: {config}. "
+    "Rules created: {created}, skipped: {skipped}."
+)
+PROFILE_V2_SUGGEST_CONFIG_SUMMARY_TITLE = "Config suggestion details"
+PROFILE_V2_SUGGEST_CONFIG_UNAVAILABLE = (
+    "Suggest DQ Config is unavailable in this environment."
+)
 PROFILE_V2_METADATA_ERROR = "Failed to load profiling metadata: {error}"
 PROFILE_V2_STATUS_SUBHEADER = "Last profiling run"
 PROFILE_V2_STATUS_EMPTY = "No profiling runs recorded for {table}. Run profiling to populate results."

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 import json
 from typing import Any, Dict, List, Optional
 import pandas as pd
@@ -420,6 +421,171 @@ def _classification_confidence_lookup(
         column: _format_confidence(record.get("CONFIDENCE"))
         for column, record in latest.items()
     }
+
+
+def _included_overview_columns(overview: pd.DataFrame) -> List[str]:
+    if not isinstance(overview, pd.DataFrame) or overview.empty:
+        return []
+
+    lower_lookup = {col.lower(): col for col in overview.columns}
+    include_column = lower_lookup.get("include_in_dq_config")
+    name_column = lower_lookup.get("column_name")
+    if not include_column or not name_column:
+        return []
+
+    included: List[str] = []
+    for _, row in overview.iterrows():
+        try:
+            include_value = bool(row.get(include_column))
+        except Exception:
+            include_value = False
+        if not include_value:
+            continue
+        name_value = row.get(name_column)
+        if name_value is None:
+            continue
+        included.append(str(name_value))
+
+    seen = set()
+    unique_columns: List[str] = []
+    for column in included:
+        normalized = column.strip()
+        if not normalized:
+            continue
+        folded = normalized.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        unique_columns.append(normalized)
+    return unique_columns
+
+
+def _selected_suggestion_columns(table_fqn: str) -> List[str]:
+    selection = st.session_state.get("dq_config_selection", {}).get(table_fqn, {})
+    included: List[str] = []
+    for key, value in selection.items():
+        if not value:
+            continue
+        parts = key.split("|")
+        if len(parts) < 2:
+            continue
+        included.append(parts[1])
+    seen = set()
+    result: List[str] = []
+    for column in included:
+        folded = column.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        result.append(column)
+    return result
+
+
+def _resolve_included_columns(table_fqn: str, overview: pd.DataFrame) -> List[str]:
+    included = _included_overview_columns(overview)
+    if included:
+        return included
+    return _selected_suggestion_columns(table_fqn)
+
+
+def _default_config_name(table_fqn: str) -> str:
+    parts = (table_fqn or "").split(".")
+    table_name = parts[-1] if parts else "TABLE"
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    return f"PROFILE_{table_name}_{timestamp}"
+
+
+def _render_suggest_config_summary(
+    summary: Dict[str, Any], table_fqn: str, config_name: str
+) -> None:
+    rules_created = summary.get("rules_created") or []
+    rules_skipped = summary.get("rules_skipped") or []
+    created_count = len(rules_created)
+    skipped_count = len(rules_skipped)
+
+    st.success(
+        ui_strings.PROFILE_V2_SUGGEST_CONFIG_SUCCESS.format(
+            table=table_fqn,
+            config=config_name,
+            created=created_count,
+            skipped=skipped_count,
+        )
+    )
+
+    combined_rows: List[Dict[str, Any]] = []
+    for entry in rules_created:
+        combined_rows.append(
+            {
+                "Column": entry.get("column"),
+                "Rule": entry.get("rule_code"),
+                "Status": "Created",
+            }
+        )
+    for entry in rules_skipped:
+        combined_rows.append(
+            {
+                "Column": entry.get("column"),
+                "Rule": entry.get("rule_code"),
+                "Status": "Skipped",
+            }
+        )
+
+    if not combined_rows:
+        return
+
+    with st.expander(ui_strings.PROFILE_V2_SUGGEST_CONFIG_SUMMARY_TITLE):
+        st.dataframe(pd.DataFrame(combined_rows))
+
+
+def _render_suggest_config_action(
+    overview: pd.DataFrame,
+    table_fqn: str,
+    helpers: Any,
+    session: Any,
+    profile_run_id: Optional[str],
+):
+    suggest_fn = getattr(helpers, "suggest_config_from_profile", None)
+    if not callable(suggest_fn):
+        st.info(ui_strings.PROFILE_V2_SUGGEST_CONFIG_UNAVAILABLE)
+        return
+
+    suggest_button = st.button(
+        ui_strings.PROFILE_V2_SUGGEST_CONFIG_BUTTON,
+        use_container_width=False,
+    )
+    if not suggest_button:
+        return
+
+    included_columns = _resolve_included_columns(table_fqn, overview)
+    if not included_columns:
+        st.warning(ui_strings.PROFILE_V2_SUGGEST_CONFIG_NO_COLUMNS)
+        return
+
+    if not profile_run_id:
+        st.warning(ui_strings.PROFILE_V2_SUGGEST_CONFIG_NO_RUN_ID)
+        return
+
+    config_name = _default_config_name(table_fqn)
+    with st.spinner(
+        ui_strings.PROFILE_V2_SUGGEST_CONFIG_SPINNER.format(table=table_fqn)
+    ):
+        try:
+            summary = suggest_fn(
+                session,
+                table_fqn,
+                profile_run_id,
+                included_columns,
+                config_name,
+            )
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            st.error(
+                ui_strings.PROFILE_V2_SUGGEST_CONFIG_ERROR.format(error=str(exc))
+            )
+            return
+
+    if isinstance(summary, dict):
+        st.session_state["last_suggest_config_summary"] = summary
+    _render_suggest_config_summary(summary or {}, table_fqn, config_name)
 
 
 def _suggestion_selection_key(
@@ -1095,6 +1261,13 @@ def render_profile(
     )
 
     with tab_overview:
+        _render_suggest_config_action(
+            overview_grid,
+            target_fqn,
+            helpers,
+            session,
+            st.session_state.get("profile_last_run_id"),
+        )
         _render_suggestion_sections(
             overview_grid,
             data.suggested_checks,

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -28,6 +28,25 @@ PROFILE_V2_SUGGESTIONS_SPINNER = "Re-running suggestions for {table}..."
 PROFILE_V2_SUGGESTIONS_ERROR = "Suggestions run failed: {error}"
 PROFILE_V2_SUGGESTIONS_SUCCESS = "Suggestions refreshed for {table}."
 PROFILE_V2_SUGGESTIONS_UNAVAILABLE = "Suggestions rerun is unavailable in this environment."
+PROFILE_V2_SUGGEST_CONFIG_BUTTON = "Suggest DQ Config"
+PROFILE_V2_SUGGEST_CONFIG_SPINNER = (
+    "Suggesting DQ config from latest profiling run for {table}..."
+)
+PROFILE_V2_SUGGEST_CONFIG_NO_COLUMNS = (
+    "Please select at least one column with Include = True."
+)
+PROFILE_V2_SUGGEST_CONFIG_NO_RUN_ID = (
+    "Run profiling first to record a profiling run ID before suggesting a config."
+)
+PROFILE_V2_SUGGEST_CONFIG_ERROR = "Failed to suggest DQ config: {error}"
+PROFILE_V2_SUGGEST_CONFIG_SUCCESS = (
+    "✅ DQ Config suggested successfully for {table}. Created/updated config: {config}. "
+    "Rules created: {created}, skipped: {skipped}."
+)
+PROFILE_V2_SUGGEST_CONFIG_SUMMARY_TITLE = "Config suggestion details"
+PROFILE_V2_SUGGEST_CONFIG_UNAVAILABLE = (
+    "Suggest DQ Config is unavailable in this environment."
+)
 PROFILE_V2_METADATA_ERROR = "Failed to load profiling metadata: {error}"
 PROFILE_V2_STATUS_SUBHEADER = "Last profiling run"
 PROFILE_V2_STATUS_EMPTY = "No profiling runs recorded for {table}. Run profiling to populate results."

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 import json
 from typing import Any, Dict, List, Optional
 import pandas as pd
@@ -420,6 +421,171 @@ def _classification_confidence_lookup(
         column: _format_confidence(record.get("CONFIDENCE"))
         for column, record in latest.items()
     }
+
+
+def _included_overview_columns(overview: pd.DataFrame) -> List[str]:
+    if not isinstance(overview, pd.DataFrame) or overview.empty:
+        return []
+
+    lower_lookup = {col.lower(): col for col in overview.columns}
+    include_column = lower_lookup.get("include_in_dq_config")
+    name_column = lower_lookup.get("column_name")
+    if not include_column or not name_column:
+        return []
+
+    included: List[str] = []
+    for _, row in overview.iterrows():
+        try:
+            include_value = bool(row.get(include_column))
+        except Exception:
+            include_value = False
+        if not include_value:
+            continue
+        name_value = row.get(name_column)
+        if name_value is None:
+            continue
+        included.append(str(name_value))
+
+    seen = set()
+    unique_columns: List[str] = []
+    for column in included:
+        normalized = column.strip()
+        if not normalized:
+            continue
+        folded = normalized.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        unique_columns.append(normalized)
+    return unique_columns
+
+
+def _selected_suggestion_columns(table_fqn: str) -> List[str]:
+    selection = st.session_state.get("dq_config_selection", {}).get(table_fqn, {})
+    included: List[str] = []
+    for key, value in selection.items():
+        if not value:
+            continue
+        parts = key.split("|")
+        if len(parts) < 2:
+            continue
+        included.append(parts[1])
+    seen = set()
+    result: List[str] = []
+    for column in included:
+        folded = column.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        result.append(column)
+    return result
+
+
+def _resolve_included_columns(table_fqn: str, overview: pd.DataFrame) -> List[str]:
+    included = _included_overview_columns(overview)
+    if included:
+        return included
+    return _selected_suggestion_columns(table_fqn)
+
+
+def _default_config_name(table_fqn: str) -> str:
+    parts = (table_fqn or "").split(".")
+    table_name = parts[-1] if parts else "TABLE"
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    return f"PROFILE_{table_name}_{timestamp}"
+
+
+def _render_suggest_config_summary(
+    summary: Dict[str, Any], table_fqn: str, config_name: str
+) -> None:
+    rules_created = summary.get("rules_created") or []
+    rules_skipped = summary.get("rules_skipped") or []
+    created_count = len(rules_created)
+    skipped_count = len(rules_skipped)
+
+    st.success(
+        ui_strings.PROFILE_V2_SUGGEST_CONFIG_SUCCESS.format(
+            table=table_fqn,
+            config=config_name,
+            created=created_count,
+            skipped=skipped_count,
+        )
+    )
+
+    combined_rows: List[Dict[str, Any]] = []
+    for entry in rules_created:
+        combined_rows.append(
+            {
+                "Column": entry.get("column"),
+                "Rule": entry.get("rule_code"),
+                "Status": "Created",
+            }
+        )
+    for entry in rules_skipped:
+        combined_rows.append(
+            {
+                "Column": entry.get("column"),
+                "Rule": entry.get("rule_code"),
+                "Status": "Skipped",
+            }
+        )
+
+    if not combined_rows:
+        return
+
+    with st.expander(ui_strings.PROFILE_V2_SUGGEST_CONFIG_SUMMARY_TITLE):
+        st.dataframe(pd.DataFrame(combined_rows))
+
+
+def _render_suggest_config_action(
+    overview: pd.DataFrame,
+    table_fqn: str,
+    helpers: Any,
+    session: Any,
+    profile_run_id: Optional[str],
+):
+    suggest_fn = getattr(helpers, "suggest_config_from_profile", None)
+    if not callable(suggest_fn):
+        st.info(ui_strings.PROFILE_V2_SUGGEST_CONFIG_UNAVAILABLE)
+        return
+
+    suggest_button = st.button(
+        ui_strings.PROFILE_V2_SUGGEST_CONFIG_BUTTON,
+        use_container_width=False,
+    )
+    if not suggest_button:
+        return
+
+    included_columns = _resolve_included_columns(table_fqn, overview)
+    if not included_columns:
+        st.warning(ui_strings.PROFILE_V2_SUGGEST_CONFIG_NO_COLUMNS)
+        return
+
+    if not profile_run_id:
+        st.warning(ui_strings.PROFILE_V2_SUGGEST_CONFIG_NO_RUN_ID)
+        return
+
+    config_name = _default_config_name(table_fqn)
+    with st.spinner(
+        ui_strings.PROFILE_V2_SUGGEST_CONFIG_SPINNER.format(table=table_fqn)
+    ):
+        try:
+            summary = suggest_fn(
+                session,
+                table_fqn,
+                profile_run_id,
+                included_columns,
+                config_name,
+            )
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            st.error(
+                ui_strings.PROFILE_V2_SUGGEST_CONFIG_ERROR.format(error=str(exc))
+            )
+            return
+
+    if isinstance(summary, dict):
+        st.session_state["last_suggest_config_summary"] = summary
+    _render_suggest_config_summary(summary or {}, table_fqn, config_name)
 
 
 def _suggestion_selection_key(
@@ -1095,6 +1261,13 @@ def render_profile(
     )
 
     with tab_overview:
+        _render_suggest_config_action(
+            overview_grid,
+            target_fqn,
+            helpers,
+            session,
+            st.session_state.get("profile_last_run_id"),
+        )
         _render_suggestion_sections(
             overview_grid,
             data.suggested_checks,


### PR DESCRIPTION
- Added UI wiring for Suggest DQ Config to gather selected columns and call the new profiling suggestion stored procedure.
- Added supporting strings, summary rendering, and service helper for DQ_SUGGEST_CONFIG_FROM_PROFILE along with mirrored snapshot updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69317d47cdc88324a5a964e1f9ebe5b0)