### PR TITLE
Fix classification lookup in DQ suggestion

### DIFF
--- a/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
+++ b/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
@@ -164,16 +164,16 @@ def _load_column_features(session: Session, profile_run_id: str, column_name: st
     return rows[0].as_dict() if rows else {}
 
 
-def _load_column_classification(session: Session, profile_run_id: str, column_name: str) -> Optional[str]:
+def _load_column_classification(session: Session, table_fqn: str, column_name: str) -> Optional[str]:
     rows = session.sql(
         """
-        SELECT CLASSIFICATION
-        FROM DQ_CLASSIFICATION
-        WHERE PROFILE_RUN_ID = ? AND UPPER(COLUMN_NAME) = UPPER(?)
-        ORDER BY UPDATED_AT DESC
+        SELECT CONTENT_TYPE
+        FROM DQ_COLUMN_CLASSIFICATION
+        WHERE TABLE_FQN = ? AND UPPER(COLUMN_NAME) = UPPER(?)
+        ORDER BY CLASSIFIED_AT DESC
         LIMIT 1
         """,
-        params=[profile_run_id, column_name],
+        params=[table_fqn, column_name],
     ).collect()
     if not rows:
         return None
@@ -333,7 +333,7 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
 
     for col in included:
         features = _load_column_features(session, PROFILE_RUN_ID, col)
-        classification = _load_column_classification(session, PROFILE_RUN_ID, col)
+        classification = _load_column_classification(session, TARGET_TABLE_FQN, col)
         suggestions = _select_rules_for_column(col, features, classification)
         for suggestion in suggestions:
             rule_code = suggestion['rule_code']


### PR DESCRIPTION
- update DQ suggestion procedure to read semantic classifications from DQ_COLUMN_CLASSIFICATION
- use table FQN for latest classification lookup when building suggested rules

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69318f2b0628832481feb64da4536ea5)