### PR TITLE
Handle suggestion rerun timeout in profile view

### DIFF
--- a/snapshots/tests/test_profile_view.p
+++ b/snapshots/tests/test_profile_view.p
@@ -1,3 +1,6 @@
+import time
+from concurrent.futures import TimeoutError
+
 import pytest
 
 pd = pytest.importorskip("pandas")
@@ -43,5 +46,22 @@ def test_overview_grid_widget_key_changes_with_nonce():
 
     assert key_first != key_second
     assert "DB_SCHEMA_TABLE" in key_first
+
+
+def test_call_with_timeout_completes():
+    result, error = profile_view._call_with_timeout(lambda x: x + 1, 1, 2)
+
+    assert result == 3
+    assert error is None
+
+
+def test_call_with_timeout_handles_timeout():
+    def slow_call():
+        time.sleep(0.05)
+
+    result, error = profile_view._call_with_timeout(slow_call, 0.01)
+
+    assert result is None
+    assert isinstance(error, TimeoutError)
 
 

--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -28,6 +28,9 @@ PROFILE_V2_SUGGESTIONS_SPINNER = "Re-running suggestions for {table}..."
 PROFILE_V2_SUGGESTIONS_ERROR = "Suggestions run failed: {error}"
 PROFILE_V2_SUGGESTIONS_SUCCESS = "Suggestions refreshed for {table}."
 PROFILE_V2_SUGGESTIONS_UNAVAILABLE = "Suggestions rerun is unavailable in this environment."
+PROFILE_V2_SUGGESTIONS_TIMEOUT = (
+    "Suggestions run did not finish within {timeout} seconds for {table}."
+)
 PROFILE_V2_SUGGEST_CONFIG_BUTTON = "Suggest DQ Config"
 PROFILE_V2_SUGGEST_CONFIG_SPINNER = (
     "Suggesting DQ config from latest profiling run for {table}..."

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from dataclasses import dataclass
 from datetime import datetime
 import json
@@ -18,6 +19,28 @@ st.session_state.setdefault("freeze_view", False)
 st.session_state.setdefault("last_profile_summary", None)
 st.session_state.setdefault("last_profile_rows", [])
 st.session_state.setdefault("last_profile_err", None)
+
+SUGGESTIONS_TIMEOUT_SECONDS = 60
+
+
+def _call_with_timeout(func, timeout_seconds: float, *args, **kwargs):
+    """Execute *func* with a timeout.
+
+    Returns a tuple ``(result, error)`` where *error* is ``None`` when the call
+    finished successfully, ``TimeoutError`` when the timeout elapsed, or the
+    caught exception instance for other failures.
+    """
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(func, *args, **kwargs)
+        try:
+            return future.result(timeout=timeout_seconds), None
+        except TimeoutError as exc:
+            future.cancel()
+            return None, exc
+        except Exception as exc:  # pragma: no cover - passthrough for UI feedback
+            future.cancel()
+            return None, exc
 
 
 @dataclass
@@ -1185,21 +1208,33 @@ def render_profile(
             with st.spinner(
                 ui_strings.PROFILE_V2_SUGGESTIONS_SPINNER.format(table=target_fqn)
             ):
-                try:
-                    suggestions_fn(session, target_fqn)
-                except Exception as exc:
-                    status_placeholder.error(
-                        ui_strings.PROFILE_V2_SUGGESTIONS_ERROR.format(
-                            error=str(exc)
-                        )
+                _, error = _call_with_timeout(
+                    suggestions_fn,
+                    SUGGESTIONS_TIMEOUT_SECONDS,
+                    session,
+                    target_fqn,
+                )
+
+            if isinstance(error, TimeoutError):
+                status_placeholder.error(
+                    ui_strings.PROFILE_V2_SUGGESTIONS_TIMEOUT.format(
+                        table=target_fqn,
+                        timeout=SUGGESTIONS_TIMEOUT_SECONDS,
                     )
-                else:
-                    st.session_state["profile_data_nonce"] += 1
-                    status_placeholder.success(
-                        ui_strings.PROFILE_V2_SUGGESTIONS_SUCCESS.format(
-                            table=target_fqn
-                        )
+                )
+            elif isinstance(error, Exception):
+                status_placeholder.error(
+                    ui_strings.PROFILE_V2_SUGGESTIONS_ERROR.format(
+                        error=str(error)
                     )
+                )
+            else:
+                st.session_state["profile_data_nonce"] += 1
+                status_placeholder.success(
+                    ui_strings.PROFILE_V2_SUGGESTIONS_SUCCESS.format(
+                        table=target_fqn
+                    )
+                )
 
     last_profile_err = st.session_state.get("last_profile_err")
     if last_profile_err:

--- a/tests/test_profile_view.py
+++ b/tests/test_profile_view.py
@@ -1,3 +1,6 @@
+import time
+from concurrent.futures import TimeoutError
+
 import pytest
 
 pd = pytest.importorskip("pandas")
@@ -43,5 +46,22 @@ def test_overview_grid_widget_key_changes_with_nonce():
 
     assert key_first != key_second
     assert "DB_SCHEMA_TABLE" in key_first
+
+
+def test_call_with_timeout_completes():
+    result, error = profile_view._call_with_timeout(lambda x: x + 1, 1, 2)
+
+    assert result == 3
+    assert error is None
+
+
+def test_call_with_timeout_handles_timeout():
+    def slow_call():
+        time.sleep(0.05)
+
+    result, error = profile_view._call_with_timeout(slow_call, 0.01)
+
+    assert result is None
+    assert isinstance(error, TimeoutError)
 
 

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -28,6 +28,9 @@ PROFILE_V2_SUGGESTIONS_SPINNER = "Re-running suggestions for {table}..."
 PROFILE_V2_SUGGESTIONS_ERROR = "Suggestions run failed: {error}"
 PROFILE_V2_SUGGESTIONS_SUCCESS = "Suggestions refreshed for {table}."
 PROFILE_V2_SUGGESTIONS_UNAVAILABLE = "Suggestions rerun is unavailable in this environment."
+PROFILE_V2_SUGGESTIONS_TIMEOUT = (
+    "Suggestions run did not finish within {timeout} seconds for {table}."
+)
 PROFILE_V2_SUGGEST_CONFIG_BUTTON = "Suggest DQ Config"
 PROFILE_V2_SUGGEST_CONFIG_SPINNER = (
     "Suggesting DQ config from latest profiling run for {table}..."

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from dataclasses import dataclass
 from datetime import datetime
 import json
@@ -18,6 +19,28 @@ st.session_state.setdefault("freeze_view", False)
 st.session_state.setdefault("last_profile_summary", None)
 st.session_state.setdefault("last_profile_rows", [])
 st.session_state.setdefault("last_profile_err", None)
+
+SUGGESTIONS_TIMEOUT_SECONDS = 60
+
+
+def _call_with_timeout(func, timeout_seconds: float, *args, **kwargs):
+    """Execute *func* with a timeout.
+
+    Returns a tuple ``(result, error)`` where *error* is ``None`` when the call
+    finished successfully, ``TimeoutError`` when the timeout elapsed, or the
+    caught exception instance for other failures.
+    """
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(func, *args, **kwargs)
+        try:
+            return future.result(timeout=timeout_seconds), None
+        except TimeoutError as exc:
+            future.cancel()
+            return None, exc
+        except Exception as exc:  # pragma: no cover - passthrough for UI feedback
+            future.cancel()
+            return None, exc
 
 
 @dataclass
@@ -1185,21 +1208,33 @@ def render_profile(
             with st.spinner(
                 ui_strings.PROFILE_V2_SUGGESTIONS_SPINNER.format(table=target_fqn)
             ):
-                try:
-                    suggestions_fn(session, target_fqn)
-                except Exception as exc:
-                    status_placeholder.error(
-                        ui_strings.PROFILE_V2_SUGGESTIONS_ERROR.format(
-                            error=str(exc)
-                        )
+                _, error = _call_with_timeout(
+                    suggestions_fn,
+                    SUGGESTIONS_TIMEOUT_SECONDS,
+                    session,
+                    target_fqn,
+                )
+
+            if isinstance(error, TimeoutError):
+                status_placeholder.error(
+                    ui_strings.PROFILE_V2_SUGGESTIONS_TIMEOUT.format(
+                        table=target_fqn,
+                        timeout=SUGGESTIONS_TIMEOUT_SECONDS,
                     )
-                else:
-                    st.session_state["profile_data_nonce"] += 1
-                    status_placeholder.success(
-                        ui_strings.PROFILE_V2_SUGGESTIONS_SUCCESS.format(
-                            table=target_fqn
-                        )
+                )
+            elif isinstance(error, Exception):
+                status_placeholder.error(
+                    ui_strings.PROFILE_V2_SUGGESTIONS_ERROR.format(
+                        error=str(error)
                     )
+                )
+            else:
+                st.session_state["profile_data_nonce"] += 1
+                status_placeholder.success(
+                    ui_strings.PROFILE_V2_SUGGESTIONS_SUCCESS.format(
+                        table=target_fqn
+                    )
+                )
 
     last_profile_err = st.session_state.get("last_profile_err")
     if last_profile_err:


### PR DESCRIPTION
- add timeout wrapper to the profile view suggestion rerun button so stalled requests are surfaced as errors
- add UI copy for suggestion timeout messaging and unit tests for the timeout helper
- mirror updated python snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693190bf2e488324aced9d1289470a4e)