### PR TITLE
Show skipped suggestion reasons in profile summary

### DIFF
--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -542,6 +542,7 @@ def _render_suggest_config_summary(
                 "Column": entry.get("column"),
                 "Rule": entry.get("rule_code"),
                 "Status": "Created",
+                "Reason": "",
             }
         )
     for entry in rules_skipped:
@@ -550,6 +551,7 @@ def _render_suggest_config_summary(
                 "Column": entry.get("column"),
                 "Rule": entry.get("rule_code"),
                 "Status": "Skipped",
+                "Reason": entry.get("reason", ""),
             }
         )
 

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -542,6 +542,7 @@ def _render_suggest_config_summary(
                 "Column": entry.get("column"),
                 "Rule": entry.get("rule_code"),
                 "Status": "Created",
+                "Reason": "",
             }
         )
     for entry in rules_skipped:
@@ -550,6 +551,7 @@ def _render_suggest_config_summary(
                 "Column": entry.get("column"),
                 "Rule": entry.get("rule_code"),
                 "Status": "Skipped",
+                "Reason": entry.get("reason", ""),
             }
         )
 


### PR DESCRIPTION
- Display the skip reason alongside each suggested rule in the profiling summary table
- Mirror updated Python snapshot artifacts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69319406ebfc832483fb76455bdd0762)