### PR TITLE
Codex Task P1 — Backend: Suggest Rules from Profiling

### DIFF
--- a/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
+++ b/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
@@ -1,13 +1,13 @@
 -- Stored procedure: DQ_SUGGEST_CONFIG_FROM_PROFILE
 -- Suggests rule instances based on profiling metadata and writes them to DQ_CONFIG / DQ_CHECK.
-create or replace procedure DQ_SUGGEST_CONFIG_FROM_PROFILE(
+CREATE OR REPLACE PROCEDURE ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_SUGGEST_CONFIG_FROM_PROFILE(
     PROFILE_RUN_ID STRING,
     TARGET_TABLE_FQN STRING,
     INCLUDED_COLUMNS ARRAY,
     CONFIG_NAME STRING
 )
-returns VARIANT
-language PYTHON
+RETURNS VARIANT
+LANGUAGE PYTHON
 RUNTIME_VERSION = '3.10'
 PACKAGES = ('snowflake-snowpark-python')
 HANDLER = 'suggest_from_profile'
@@ -21,6 +21,14 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from snowflake.snowpark import Session
 
+DQ_SCHEMA = 'ZEUS_ANALYTICS_SIMU.DISCOVERY'
+DQ_CONFIG_TABLE = f"{DQ_SCHEMA}.DQ_CONFIG"
+DQ_CHECK_TABLE = f"{DQ_SCHEMA}.DQ_CHECK"
+DQ_RULE_LIBRARY_TABLE = f"{DQ_SCHEMA}.DQ_RULE_LIBRARY"
+DQ_COLUMN_FEATURES_TABLE = f"{DQ_SCHEMA}.DQ_COLUMN_FEATURES"
+DQ_COLUMN_CLASSIFICATION_TABLE = f"{DQ_SCHEMA}.DQ_COLUMN_CLASSIFICATION"
+DQ_COMPILE_RULE_PROC = f"{DQ_SCHEMA}.DQ_COMPILE_RULE_SQL"
+
 
 def _normalize_name(value: Any) -> str:
     if value is None:
@@ -28,14 +36,26 @@ def _normalize_name(value: Any) -> str:
     return str(value).strip()
 
 
+def _split_table_name(table_name: str) -> Tuple[str, Optional[str]]:
+    if not table_name:
+        return '', None
+    parts = [p.replace('"', '').strip() for p in table_name.split('.') if p.strip()]
+    if len(parts) >= 2:
+        return parts[-1], parts[-2]
+    return parts[0], None
+
+
 def _load_table_columns(session: Session, table_name: str) -> List[str]:
+    table_only, schema_override = _split_table_name(table_name)
+    schema_name = schema_override or DQ_SCHEMA.split('.')[-1]
     cols = session.sql(
         """
         SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME
         FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_NAME = UPPER(?) AND TABLE_SCHEMA = CURRENT_SCHEMA()
+        WHERE TABLE_NAME = UPPER(:table_name)
+          AND TABLE_SCHEMA = UPPER(:schema_name)
         """,
-        params=[table_name],
+        params={'table_name': table_only, 'schema_name': schema_name},
     ).collect()
     return [r[0] for r in cols]
 
@@ -101,8 +121,8 @@ def _existing_rules(session: Session, table_fqn: str, dq_check_cols: List[str]) 
         selectors.append('COLUMN_NAME')
     base_cols = ', '.join(['TABLE_FQN'] + selectors + columns) if columns else 'TABLE_FQN, COLUMN_NAME'
     rows = session.sql(
-        f"SELECT {base_cols} FROM DQ_CHECK WHERE TABLE_FQN = ?",
-        params=[table_fqn],
+        f"SELECT {base_cols} FROM {DQ_CHECK_TABLE} WHERE TABLE_FQN = :table_fqn",
+        params={'table_fqn': table_fqn},
     ).collect()
     out: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
     for r in rows:
@@ -136,7 +156,7 @@ def _rule_library(session: Session) -> Dict[str, Dict[str, Any]]:
     elif 'RULE_VERSION' in dq_rl_cols:
         select_exprs.append('RULE_VERSION AS RULE_VERSION')
 
-    sql = f"SELECT {', '.join(select_exprs)} FROM DQ_RULE_LIBRARY"
+    sql = f"SELECT {', '.join(select_exprs)} FROM {DQ_RULE_LIBRARY_TABLE}"
     rows = session.sql(sql).collect()
 
     out: Dict[str, Dict[str, Any]] = {}
@@ -152,28 +172,28 @@ def _rule_library(session: Session) -> Dict[str, Dict[str, Any]]:
 
 def _load_column_features(session: Session, profile_run_id: str, column_name: str) -> Dict[str, Any]:
     rows = session.sql(
-        """
+        f"""
         SELECT *
-        FROM DQ_COLUMN_FEATURES
-        WHERE PROFILE_RUN_ID = ? AND UPPER(COLUMN_NAME) = UPPER(?)
+        FROM {DQ_COLUMN_FEATURES_TABLE}
+        WHERE PROFILE_RUN_ID = :profile_run_id AND UPPER(COLUMN_NAME) = UPPER(:column_name)
         ORDER BY UPDATED_AT DESC
         LIMIT 1
         """,
-        params=[profile_run_id, column_name],
+        params={'profile_run_id': profile_run_id, 'column_name': column_name},
     ).collect()
     return rows[0].as_dict() if rows else {}
 
 
 def _load_column_classification(session: Session, table_fqn: str, column_name: str) -> Optional[str]:
     rows = session.sql(
-        """
+        f"""
         SELECT CONTENT_TYPE
-        FROM DQ_COLUMN_CLASSIFICATION
-        WHERE TABLE_FQN = ? AND UPPER(COLUMN_NAME) = UPPER(?)
+        FROM {DQ_COLUMN_CLASSIFICATION_TABLE}
+        WHERE TABLE_FQN = :table_fqn AND UPPER(COLUMN_NAME) = UPPER(:column_name)
         ORDER BY CLASSIFIED_AT DESC
         LIMIT 1
         """,
-        params=[table_fqn, column_name],
+        params={'table_fqn': table_fqn, 'column_name': column_name},
     ).collect()
     if not rows:
         return None
@@ -265,7 +285,7 @@ def _as_param_json(params: Dict[str, Any]) -> str:
 
 def _compile_rule(session: Session, rule_code: str, target_table_fqn: str, column_name: str, params: Dict[str, Any]) -> Optional[str]:
     try:
-        compiled = session.call('DQ_COMPILE_RULE_SQL', rule_code, target_table_fqn, [column_name], params)
+        compiled = session.call(DQ_COMPILE_RULE_PROC, rule_code, target_table_fqn, [column_name], params)
         return compiled
     except Exception:
         return None
@@ -281,11 +301,15 @@ def _insert_config(session: Session, config_id: str, config_name: str, target_ta
         'UPDATED_AT': datetime.utcnow(),
     }
     cols = [c for c in values.keys() if c in dq_config_cols]
-    placeholders = ', '.join(['?'] * len(cols))
+    placeholders = []
+    params = {}
+    for idx, col in enumerate(cols):
+        param_name = f"p{idx}"
+        placeholders.append(f":{param_name}")
+        params[param_name] = values[col]
     columns_sql = ', '.join(cols)
-    params = [values[c] for c in cols]
     session.sql(
-        f"INSERT INTO DQ_CONFIG ({columns_sql}) VALUES ({placeholders})",
+        f"INSERT INTO {DQ_CONFIG_TABLE} ({columns_sql}) VALUES ({', '.join(placeholders)})",
         params=params,
     ).collect()
 
@@ -298,14 +322,14 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
 
     config_name = _normalize_name(CONFIG_NAME) or f"AUTO_FROM_PROFILE_{datetime.utcnow().date()}"
     existing_cfg = session.sql(
-        """
+        f"""
         SELECT CONFIG_ID
-        FROM DQ_CONFIG
-        WHERE TARGET_TABLE_FQN = ? AND NAME = ?
+        FROM {DQ_CONFIG_TABLE}
+        WHERE TARGET_TABLE_FQN = :target_table_fqn AND NAME = :config_name
         ORDER BY UPDATED_AT DESC
         LIMIT 1
         """,
-        params=[TARGET_TABLE_FQN, config_name],
+        params={'target_table_fqn': TARGET_TABLE_FQN, 'config_name': config_name},
     ).collect()
 
     if existing_cfg:
@@ -322,12 +346,12 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
     rules_skipped: List[Dict[str, Any]] = []
 
     next_index_rows = session.sql(
-        """
+        f"""
         SELECT COALESCE(MAX(TRY_TO_NUMBER(CHECK_ID)), 0) AS MAX_ID
-        FROM DQ_CHECK
-        WHERE CONFIG_ID = ?
+        FROM {DQ_CHECK_TABLE}
+        WHERE CONFIG_ID = :config_id
         """,
-        params=[config_id],
+        params={'config_id': config_id},
     ).collect()
     check_counter = int(next_index_rows[0][0]) if next_index_rows else 0
 
@@ -385,12 +409,16 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
                 'CREATED_AT': datetime.utcnow(),
             }
             cols = [c for c in insert_values.keys() if c in dq_check_cols]
-            placeholders = ', '.join(['?'] * len(cols))
+            placeholder_tokens = []
+            params_map = {}
+            for idx, col_name in enumerate(cols):
+                param_name = f"p{idx}"
+                placeholder_tokens.append(f":{param_name}")
+                params_map[param_name] = insert_values[col_name]
             column_sql = ', '.join(cols)
-            params_list = [insert_values[c] for c in cols]
             session.sql(
-                f"INSERT INTO DQ_CHECK ({column_sql}) VALUES ({placeholders})",
-                params=params_list,
+                f"INSERT INTO {DQ_CHECK_TABLE} ({column_sql}) VALUES ({', '.join(placeholder_tokens)})",
+                params=params_map,
             ).collect()
             rules_created.append({'column': col, 'rule_code': rule_code})
 


### PR DESCRIPTION
- Define the DQ_SUGGEST_CONFIG_FROM_PROFILE stored procedure in the metadata schema using named parameter bindings and table constants.
- Load profiling features and classifications to suggest rules, compile them, and create DQ_CONFIG/DQ_CHECK entries while skipping duplicates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e7b7d4c08324ad21284c6c831ffe)