### PR TITLE
Fix dq suggest config parameter binding

### DIFF
--- a/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
+++ b/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
@@ -52,10 +52,10 @@ def _load_table_columns(session: Session, table_name: str) -> List[str]:
         """
         SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME
         FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_NAME = UPPER(:table_name)
-          AND TABLE_SCHEMA = UPPER(:schema_name)
+        WHERE TABLE_NAME = UPPER(?)
+          AND TABLE_SCHEMA = UPPER(?)
         """,
-        params={'table_name': table_only, 'schema_name': schema_name},
+        params=[table_only, schema_name],
     ).collect()
     return [r[0] for r in cols]
 


### PR DESCRIPTION
- Adjust DQ_SUGGEST_CONFIG_FROM_PROFILE to use positional bindings when reading information_schema columns
- Prevent parameter binding errors when suggesting DQ config from profiling

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ebaabca48324a8a6899a431225d7)