### PR TITLE
Fix parameter binding in suggest config procedure

### DIFF
--- a/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
+++ b/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
@@ -122,7 +122,7 @@ def _existing_rules(session: Session, table_fqn: str, dq_check_cols: List[str]) 
     base_cols = ', '.join(['TABLE_FQN'] + selectors + columns) if columns else 'TABLE_FQN, COLUMN_NAME'
     rows = session.sql(
         f"SELECT {base_cols} FROM {DQ_CHECK_TABLE} WHERE TABLE_FQN = :table_fqn",
-        params={'table_fqn': table_fqn},
+        params=[table_fqn],
     ).collect()
     out: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
     for r in rows:
@@ -179,7 +179,7 @@ def _load_column_features(session: Session, profile_run_id: str, column_name: st
         ORDER BY UPDATED_AT DESC
         LIMIT 1
         """,
-        params={'profile_run_id': profile_run_id, 'column_name': column_name},
+        params=[profile_run_id, column_name],
     ).collect()
     return rows[0].as_dict() if rows else {}
 
@@ -193,7 +193,7 @@ def _load_column_classification(session: Session, table_fqn: str, column_name: s
         ORDER BY CLASSIFIED_AT DESC
         LIMIT 1
         """,
-        params={'table_fqn': table_fqn, 'column_name': column_name},
+        params=[table_fqn, column_name],
     ).collect()
     if not rows:
         return None
@@ -302,15 +302,14 @@ def _insert_config(session: Session, config_id: str, config_name: str, target_ta
     }
     cols = [c for c in values.keys() if c in dq_config_cols]
     placeholders = []
-    params = {}
-    for idx, col in enumerate(cols):
-        param_name = f"p{idx}"
-        placeholders.append(f":{param_name}")
-        params[param_name] = values[col]
+    param_values = []
+    for col in cols:
+        placeholders.append("?")
+        param_values.append(values[col])
     columns_sql = ', '.join(cols)
     session.sql(
         f"INSERT INTO {DQ_CONFIG_TABLE} ({columns_sql}) VALUES ({', '.join(placeholders)})",
-        params=params,
+        params=param_values,
     ).collect()
 
 
@@ -329,7 +328,7 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
         ORDER BY UPDATED_AT DESC
         LIMIT 1
         """,
-        params={'target_table_fqn': TARGET_TABLE_FQN, 'config_name': config_name},
+        params=[TARGET_TABLE_FQN, config_name],
     ).collect()
 
     if existing_cfg:
@@ -351,7 +350,7 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
         FROM {DQ_CHECK_TABLE}
         WHERE CONFIG_ID = :config_id
         """,
-        params={'config_id': config_id},
+        params=[config_id],
     ).collect()
     check_counter = int(next_index_rows[0][0]) if next_index_rows else 0
 
@@ -410,15 +409,14 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
             }
             cols = [c for c in insert_values.keys() if c in dq_check_cols]
             placeholder_tokens = []
-            params_map = {}
-            for idx, col_name in enumerate(cols):
-                param_name = f"p{idx}"
-                placeholder_tokens.append(f":{param_name}")
-                params_map[param_name] = insert_values[col_name]
+            param_values = []
+            for col_name in cols:
+                placeholder_tokens.append("?")
+                param_values.append(insert_values[col_name])
             column_sql = ', '.join(cols)
             session.sql(
                 f"INSERT INTO {DQ_CHECK_TABLE} ({column_sql}) VALUES ({', '.join(placeholder_tokens)})",
-                params=params_map,
+                params=param_values,
             ).collect()
             rules_created.append({'column': col, 'rule_code': rule_code})
 


### PR DESCRIPTION
- Update Snowpark SQL calls in the suggest-from-profile procedure to use positional parameter lists
- Adjust insert helpers to build positional placeholder lists for config and check inserts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ecb6c7ec8324887048a80cd5d982)