### PR TITLE
Fix positional bindings for suggest config

### DIFF
--- a/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
+++ b/sql/DQ_SUGGEST_CONFIG_FROM_PROFILE
@@ -121,8 +121,8 @@ def _existing_rules(session: Session, table_fqn: str, dq_check_cols: List[str]) 
         selectors.append('COLUMN_NAME')
     base_cols = ', '.join(['TABLE_FQN'] + selectors + columns) if columns else 'TABLE_FQN, COLUMN_NAME'
     rows = session.sql(
-        f"SELECT {base_cols} FROM {DQ_CHECK_TABLE} WHERE TABLE_FQN = :table_fqn",
-        params={'table_fqn': table_fqn},
+        f"SELECT {base_cols} FROM {DQ_CHECK_TABLE} WHERE TABLE_FQN = ?",
+        params=[table_fqn],
     ).collect()
     out: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
     for r in rows:
@@ -175,11 +175,11 @@ def _load_column_features(session: Session, profile_run_id: str, column_name: st
         f"""
         SELECT *
         FROM {DQ_COLUMN_FEATURES_TABLE}
-        WHERE PROFILE_RUN_ID = :profile_run_id AND UPPER(COLUMN_NAME) = UPPER(:column_name)
+        WHERE PROFILE_RUN_ID = ? AND UPPER(COLUMN_NAME) = UPPER(?)
         ORDER BY UPDATED_AT DESC
         LIMIT 1
         """,
-        params={'profile_run_id': profile_run_id, 'column_name': column_name},
+        params=[profile_run_id, column_name],
     ).collect()
     return rows[0].as_dict() if rows else {}
 
@@ -189,11 +189,11 @@ def _load_column_classification(session: Session, table_fqn: str, column_name: s
         f"""
         SELECT CONTENT_TYPE
         FROM {DQ_COLUMN_CLASSIFICATION_TABLE}
-        WHERE TABLE_FQN = :table_fqn AND UPPER(COLUMN_NAME) = UPPER(:column_name)
+        WHERE TABLE_FQN = ? AND UPPER(COLUMN_NAME) = UPPER(?)
         ORDER BY CLASSIFIED_AT DESC
         LIMIT 1
         """,
-        params={'table_fqn': table_fqn, 'column_name': column_name},
+        params=[table_fqn, column_name],
     ).collect()
     if not rows:
         return None
@@ -324,11 +324,11 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
         f"""
         SELECT CONFIG_ID
         FROM {DQ_CONFIG_TABLE}
-        WHERE TARGET_TABLE_FQN = :target_table_fqn AND NAME = :config_name
+        WHERE TARGET_TABLE_FQN = ? AND NAME = ?
         ORDER BY UPDATED_AT DESC
         LIMIT 1
         """,
-        params={'target_table_fqn': TARGET_TABLE_FQN, 'config_name': config_name},
+        params=[TARGET_TABLE_FQN, config_name],
     ).collect()
 
     if existing_cfg:
@@ -348,9 +348,9 @@ def suggest_from_profile(session: Session, PROFILE_RUN_ID: str, TARGET_TABLE_FQN
         f"""
         SELECT COALESCE(MAX(TRY_TO_NUMBER(CHECK_ID)), 0) AS MAX_ID
         FROM {DQ_CHECK_TABLE}
-        WHERE CONFIG_ID = :config_id
+        WHERE CONFIG_ID = ?
         """,
-        params={'config_id': config_id},
+        params=[config_id],
     ).collect()
     check_counter = int(next_index_rows[0][0]) if next_index_rows else 0
 


### PR DESCRIPTION
- switch stored procedure queries to positional parameters for compatibility
- prevent suggest config execution errors caused by dict-based parameter binding

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693801f7e6088324a7209c9d9a481078)