### PR TITLE
Codex Task DC1 — DQ Config: Show Library-Based Rules per Column

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -816,6 +816,7 @@ def render_config_editor():
 
         # Restore per-column settings from existing checks
         existing_by_coltype = {}
+        library_checks_by_column: Dict[str, List[DQCheck]] = {}
         for ec in existing_checks:
             key = (ec.column_name or "", _rule_key(ec.check_type or ""))
             try:
@@ -824,6 +825,9 @@ def render_config_editor():
                 params = {}
             existing_by_coltype[key] = {"severity": ec.severity, "params": params}
 
+            if ec.rule_code and ec.column_name:
+                library_checks_by_column.setdefault(ec.column_name, []).append(ec)
+
         existing_rule_keys = {
             (ec.column_name or "", _rule_key(ec.check_type or "")) for ec in existing_checks
         }
@@ -831,6 +835,41 @@ def render_config_editor():
         for col in selected_cols:
             sk = _keyify(col)
             with st.expander(f"Column: {col}", expanded=False):
+                existing_library = library_checks_by_column.get(col, [])
+                if existing_library:
+                    st.caption("Applied rules from library")
+                    for rule in existing_library:
+                        template = active_rules.get((rule.rule_code or "").upper()) or all_rules_map.get((rule.rule_code or "").upper())
+                        label = (template.rule_id if template else (rule.rule_code or "")).upper()
+                        severity_label = rule.severity or (template.default_severity if template else "")
+                        summary_parts = [label]
+                        if severity_label:
+                            summary_parts.append(f"({severity_label})")
+                        params_text = None
+                        if isinstance(rule.rule_params, (dict, list)):
+                            parsed_params = rule.rule_params
+                        else:
+                            try:
+                                parsed_params = json.loads(rule.rule_params) if rule.rule_params else {}
+                            except Exception:
+                                parsed_params = {}
+                        if isinstance(parsed_params, dict) and parsed_params:
+                            if "min_value" in parsed_params or "max_value" in parsed_params:
+                                summary_parts.append(
+                                    f"[{parsed_params.get('min_value', '—')}–{parsed_params.get('max_value', '—')}]"
+                                )
+                            elif "allowed_values" in parsed_params:
+                                allowed_values = parsed_params.get("allowed_values") or []
+                                if isinstance(allowed_values, list):
+                                    preview = ", ".join(map(str, allowed_values[:5]))
+                                    if len(allowed_values) > 5:
+                                        preview += ", …"
+                                    params_text = f"[{preview}]"
+                            elif "ref_table" in parsed_params and "key_column" in parsed_params:
+                                params_text = f"→ {parsed_params.get('ref_table')}.{parsed_params.get('key_column')}"
+                        if params_text:
+                            summary_parts.append(params_text)
+                        st.markdown(" ".join(summary_parts))
                 sample_n = st.number_input(
                     f"Sample failing rows for {col}",
                     min_value=0, max_value=1000, value=10, key=f"samp_{sk}"
@@ -1082,6 +1121,15 @@ def render_config_editor():
                             check_type=value_dist_key,
                             params_json=json.dumps(params)
                         ))
+
+        # Preserve existing library-based checks that are not covered by the legacy widgets
+        legacy_ids = {cr.check_id for cr in check_rows}
+        for ec in existing_checks:
+            if not ec.rule_code:
+                continue
+            if ec.check_id in legacy_ids:
+                continue
+            check_rows.append(ec)
 
         # Table-level (always)
         st.markdown("### Table-level checks (always included)")

--- a/snapshots/utils/meta.p
+++ b/snapshots/utils/meta.p
@@ -113,6 +113,10 @@ class DQCheck:
     sample_rows: int = 0
     check_type: Optional[str] = None
     params_json: Optional[str] = None
+    rule_code: Optional[str] = None
+    rule_params: Optional[str] = None
+    rule_version: Optional[str] = None
+    compiled_rule: Optional[str] = None
 
 # ---------- Helpers ----------
 def _q(ident: str) -> str:
@@ -277,9 +281,17 @@ def ensure_meta_tables(session: Session):
           SAMPLE_ROWS NUMBER DEFAULT 0,
           CHECK_TYPE STRING,
           PARAMS_JSON STRING,
+          RULE_CODE STRING,
+          RULE_PARAMS STRING,
+          RULE_VERSION STRING,
+          COMPILED_RULE STRING,
           PRIMARY KEY (CONFIG_ID, CHECK_ID)
         )
     """).collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS RULE_CODE STRING").collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS RULE_PARAMS STRING").collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS RULE_VERSION STRING").collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS COMPILED_RULE STRING").collect()
 
 # ---------- CRUD ----------
 def upsert_config(session: Session, cfg: DQConfig):
@@ -381,20 +393,51 @@ def upsert_checks(session: Session, checks: List[DQCheck]):
     session.sql(f"DELETE FROM {_q(DQ_CHECK_TBL)} WHERE CONFIG_ID = ?", params=[cfg_id]).collect()
     for c in checks:
         session.sql(f"""
-            INSERT INTO {_q(DQ_CHECK_TBL)} (CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY, SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON)
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
-        """, params=[c.config_id, c.check_id, c.table_fqn, c.column_name, c.rule_expr, c.severity, int(c.sample_rows), c.check_type, c.params_json]).collect()
+            INSERT INTO {_q(DQ_CHECK_TBL)} (
+              CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY,
+              SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON, RULE_CODE, RULE_PARAMS,
+              RULE_VERSION, COMPILED_RULE
+            )
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        """, params=[
+            c.config_id, c.check_id, c.table_fqn, c.column_name, c.rule_expr,
+            c.severity, int(c.sample_rows), c.check_type, c.params_json,
+            c.rule_code, c.rule_params, c.rule_version, c.compiled_rule
+        ]).collect()
 
 def get_checks(session: Session, config_id: str) -> List[DQCheck]:
     if not session: return []
-    df = session.sql(f"SELECT CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY, SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON FROM {_q(DQ_CHECK_TBL)} WHERE CONFIG_ID = ? ORDER BY CHECK_ID", params=[config_id])
+    df = session.sql(
+        f"""
+        SELECT
+          CONFIG_ID,
+          CHECK_ID,
+          TABLE_FQN,
+          COLUMN_NAME,
+          RULE_EXPR,
+          SEVERITY,
+          SAMPLE_ROWS,
+          CHECK_TYPE,
+          PARAMS_JSON,
+          RULE_CODE,
+          RULE_PARAMS,
+          RULE_VERSION,
+          COMPILED_RULE
+        FROM {_q(DQ_CHECK_TBL)}
+        WHERE CONFIG_ID = ?
+        ORDER BY CHECK_ID
+        """,
+        params=[config_id],
+    )
     out: List[DQCheck] = []
     for r in df.collect():
         d = _normalize_row(r)
         out.append(DQCheck(
             config_id=d["config_id"], check_id=d["check_id"], table_fqn=d["table_fqn"],
             column_name=d.get("column_name"), rule_expr=d["rule_expr"], severity=d.get("severity") or "ERROR",
-            sample_rows=int(d.get("sample_rows") or 0), check_type=d.get("check_type"), params_json=d.get("params_json")
+            sample_rows=int(d.get("sample_rows") or 0), check_type=d.get("check_type"), params_json=d.get("params_json"),
+            rule_code=d.get("rule_code"), rule_params=d.get("rule_params"),
+            rule_version=d.get("rule_version"), compiled_rule=d.get("compiled_rule")
         ))
     return out
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -816,6 +816,7 @@ def render_config_editor():
 
         # Restore per-column settings from existing checks
         existing_by_coltype = {}
+        library_checks_by_column: Dict[str, List[DQCheck]] = {}
         for ec in existing_checks:
             key = (ec.column_name or "", _rule_key(ec.check_type or ""))
             try:
@@ -824,6 +825,9 @@ def render_config_editor():
                 params = {}
             existing_by_coltype[key] = {"severity": ec.severity, "params": params}
 
+            if ec.rule_code and ec.column_name:
+                library_checks_by_column.setdefault(ec.column_name, []).append(ec)
+
         existing_rule_keys = {
             (ec.column_name or "", _rule_key(ec.check_type or "")) for ec in existing_checks
         }
@@ -831,6 +835,41 @@ def render_config_editor():
         for col in selected_cols:
             sk = _keyify(col)
             with st.expander(f"Column: {col}", expanded=False):
+                existing_library = library_checks_by_column.get(col, [])
+                if existing_library:
+                    st.caption("Applied rules from library")
+                    for rule in existing_library:
+                        template = active_rules.get((rule.rule_code or "").upper()) or all_rules_map.get((rule.rule_code or "").upper())
+                        label = (template.rule_id if template else (rule.rule_code or "")).upper()
+                        severity_label = rule.severity or (template.default_severity if template else "")
+                        summary_parts = [label]
+                        if severity_label:
+                            summary_parts.append(f"({severity_label})")
+                        params_text = None
+                        if isinstance(rule.rule_params, (dict, list)):
+                            parsed_params = rule.rule_params
+                        else:
+                            try:
+                                parsed_params = json.loads(rule.rule_params) if rule.rule_params else {}
+                            except Exception:
+                                parsed_params = {}
+                        if isinstance(parsed_params, dict) and parsed_params:
+                            if "min_value" in parsed_params or "max_value" in parsed_params:
+                                summary_parts.append(
+                                    f"[{parsed_params.get('min_value', '—')}–{parsed_params.get('max_value', '—')}]"
+                                )
+                            elif "allowed_values" in parsed_params:
+                                allowed_values = parsed_params.get("allowed_values") or []
+                                if isinstance(allowed_values, list):
+                                    preview = ", ".join(map(str, allowed_values[:5]))
+                                    if len(allowed_values) > 5:
+                                        preview += ", …"
+                                    params_text = f"[{preview}]"
+                            elif "ref_table" in parsed_params and "key_column" in parsed_params:
+                                params_text = f"→ {parsed_params.get('ref_table')}.{parsed_params.get('key_column')}"
+                        if params_text:
+                            summary_parts.append(params_text)
+                        st.markdown(" ".join(summary_parts))
                 sample_n = st.number_input(
                     f"Sample failing rows for {col}",
                     min_value=0, max_value=1000, value=10, key=f"samp_{sk}"
@@ -1082,6 +1121,15 @@ def render_config_editor():
                             check_type=value_dist_key,
                             params_json=json.dumps(params)
                         ))
+
+        # Preserve existing library-based checks that are not covered by the legacy widgets
+        legacy_ids = {cr.check_id for cr in check_rows}
+        for ec in existing_checks:
+            if not ec.rule_code:
+                continue
+            if ec.check_id in legacy_ids:
+                continue
+            check_rows.append(ec)
 
         # Table-level (always)
         st.markdown("### Table-level checks (always included)")

--- a/utils/meta.py
+++ b/utils/meta.py
@@ -113,6 +113,10 @@ class DQCheck:
     sample_rows: int = 0
     check_type: Optional[str] = None
     params_json: Optional[str] = None
+    rule_code: Optional[str] = None
+    rule_params: Optional[str] = None
+    rule_version: Optional[str] = None
+    compiled_rule: Optional[str] = None
 
 # ---------- Helpers ----------
 def _q(ident: str) -> str:
@@ -277,9 +281,17 @@ def ensure_meta_tables(session: Session):
           SAMPLE_ROWS NUMBER DEFAULT 0,
           CHECK_TYPE STRING,
           PARAMS_JSON STRING,
+          RULE_CODE STRING,
+          RULE_PARAMS STRING,
+          RULE_VERSION STRING,
+          COMPILED_RULE STRING,
           PRIMARY KEY (CONFIG_ID, CHECK_ID)
         )
     """).collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS RULE_CODE STRING").collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS RULE_PARAMS STRING").collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS RULE_VERSION STRING").collect()
+    session.sql(f"ALTER TABLE {_q(DQ_CHECK_TBL)} ADD COLUMN IF NOT EXISTS COMPILED_RULE STRING").collect()
 
 # ---------- CRUD ----------
 def upsert_config(session: Session, cfg: DQConfig):
@@ -381,20 +393,51 @@ def upsert_checks(session: Session, checks: List[DQCheck]):
     session.sql(f"DELETE FROM {_q(DQ_CHECK_TBL)} WHERE CONFIG_ID = ?", params=[cfg_id]).collect()
     for c in checks:
         session.sql(f"""
-            INSERT INTO {_q(DQ_CHECK_TBL)} (CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY, SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON)
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
-        """, params=[c.config_id, c.check_id, c.table_fqn, c.column_name, c.rule_expr, c.severity, int(c.sample_rows), c.check_type, c.params_json]).collect()
+            INSERT INTO {_q(DQ_CHECK_TBL)} (
+              CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY,
+              SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON, RULE_CODE, RULE_PARAMS,
+              RULE_VERSION, COMPILED_RULE
+            )
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        """, params=[
+            c.config_id, c.check_id, c.table_fqn, c.column_name, c.rule_expr,
+            c.severity, int(c.sample_rows), c.check_type, c.params_json,
+            c.rule_code, c.rule_params, c.rule_version, c.compiled_rule
+        ]).collect()
 
 def get_checks(session: Session, config_id: str) -> List[DQCheck]:
     if not session: return []
-    df = session.sql(f"SELECT CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY, SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON FROM {_q(DQ_CHECK_TBL)} WHERE CONFIG_ID = ? ORDER BY CHECK_ID", params=[config_id])
+    df = session.sql(
+        f"""
+        SELECT
+          CONFIG_ID,
+          CHECK_ID,
+          TABLE_FQN,
+          COLUMN_NAME,
+          RULE_EXPR,
+          SEVERITY,
+          SAMPLE_ROWS,
+          CHECK_TYPE,
+          PARAMS_JSON,
+          RULE_CODE,
+          RULE_PARAMS,
+          RULE_VERSION,
+          COMPILED_RULE
+        FROM {_q(DQ_CHECK_TBL)}
+        WHERE CONFIG_ID = ?
+        ORDER BY CHECK_ID
+        """,
+        params=[config_id],
+    )
     out: List[DQCheck] = []
     for r in df.collect():
         d = _normalize_row(r)
         out.append(DQCheck(
             config_id=d["config_id"], check_id=d["check_id"], table_fqn=d["table_fqn"],
             column_name=d.get("column_name"), rule_expr=d["rule_expr"], severity=d.get("severity") or "ERROR",
-            sample_rows=int(d.get("sample_rows") or 0), check_type=d.get("check_type"), params_json=d.get("params_json")
+            sample_rows=int(d.get("sample_rows") or 0), check_type=d.get("check_type"), params_json=d.get("params_json"),
+            rule_code=d.get("rule_code"), rule_params=d.get("rule_params"),
+            rule_version=d.get("rule_version"), compiled_rule=d.get("compiled_rule")
         ))
     return out
 


### PR DESCRIPTION
- Extend DQ_CHECK metadata support to include rule-library fields when creating and reading checks.
- Show applied library rules per column in the configuration editor and retain them when saving.
- Update mirrored snapshot artifacts for modified Python sources.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69380552e1bc8324acb8ede18c221d70)