### PR TITLE
Fix library check query identifier error

### DIFF
--- a/snapshots/utils/meta.p
+++ b/snapshots/utils/meta.p
@@ -417,7 +417,6 @@ def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]
           c.RULE_VERSION,
           c.COMPILED_RULE,
           r.RULE_ID,
-          r.NAME,
           r.CATEGORY,
           r.SEVERITY AS RULE_SEVERITY,
           r.PARAM_SCHEMA,

--- a/utils/meta.py
+++ b/utils/meta.py
@@ -417,7 +417,6 @@ def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]
           c.RULE_VERSION,
           c.COMPILED_RULE,
           r.RULE_ID,
-          r.NAME,
           r.CATEGORY,
           r.SEVERITY AS RULE_SEVERITY,
           r.PARAM_SCHEMA,


### PR DESCRIPTION
- remove reference to nonexistent rule library name column when loading config checks
- mirror snapshot for updated metadata query

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69380dc22db083249c2c88ec524c6417)