### PR TITLE
Fix Streamlit form buttons for library rules

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -990,11 +990,15 @@ def render_config_editor():
                         with summary_col:
                             st.markdown(" ".join(summary_parts))
                         with action_col:
-                            if st.button("Edit", key=f"edit_lib_{rule.get('check_id')}"):
+                            if st.form_submit_button(
+                                "Edit", key=f"edit_lib_{rule.get('check_id')}"
+                            ):
                                 st.session_state["dq_edit_target"] = rule.get("check_id")
                                 st.session_state.pop("dq_add_target", None)
                                 st.rerun()
-                            if st.button("Delete", key=f"del_lib_{rule.get('check_id')}"):
+                            if st.form_submit_button(
+                                "Delete", key=f"del_lib_{rule.get('check_id')}"
+                            ):
                                 delete_check_by_id(session, str(rule.get("check_id")))
                                 st.success("Rule removed.")
                                 st.rerun()
@@ -1049,7 +1053,7 @@ def render_config_editor():
                                             st.session_state.pop("dq_edit_target", None)
                                             st.rerun()
 
-                add_clicked = st.button("➕ Add rule", key=f"add_rule_btn_{sk}")
+                add_clicked = st.form_submit_button("➕ Add rule", key=f"add_rule_btn_{sk}")
                 if add_clicked:
                     st.session_state["dq_add_target"] = col
                     st.session_state.pop("dq_edit_target", None)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -990,11 +990,15 @@ def render_config_editor():
                         with summary_col:
                             st.markdown(" ".join(summary_parts))
                         with action_col:
-                            if st.button("Edit", key=f"edit_lib_{rule.get('check_id')}"):
+                            if st.form_submit_button(
+                                "Edit", key=f"edit_lib_{rule.get('check_id')}"
+                            ):
                                 st.session_state["dq_edit_target"] = rule.get("check_id")
                                 st.session_state.pop("dq_add_target", None)
                                 st.rerun()
-                            if st.button("Delete", key=f"del_lib_{rule.get('check_id')}"):
+                            if st.form_submit_button(
+                                "Delete", key=f"del_lib_{rule.get('check_id')}"
+                            ):
                                 delete_check_by_id(session, str(rule.get("check_id")))
                                 st.success("Rule removed.")
                                 st.rerun()
@@ -1049,7 +1053,7 @@ def render_config_editor():
                                             st.session_state.pop("dq_edit_target", None)
                                             st.rerun()
 
-                add_clicked = st.button("➕ Add rule", key=f"add_rule_btn_{sk}")
+                add_clicked = st.form_submit_button("➕ Add rule", key=f"add_rule_btn_{sk}")
                 if add_clicked:
                     st.session_state["dq_add_target"] = col
                     st.session_state.pop("dq_edit_target", None)


### PR DESCRIPTION
- Replace inline buttons in the configuration form with submit buttons to comply with Streamlit form requirements
- Mirror updated Python snapshot artifacts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69380f4e70088324ba9ace7347e0f6b4)