### PR TITLE
Fix dialog key handling for modal fallback

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -31,6 +31,7 @@ Forbidden patterns:
 • Do not allow manual editing of the configuration name or target caption formatting.
 """
 
+import inspect
 import streamlit as st, logging
 from typing import Optional
 
@@ -70,7 +71,11 @@ def _modal_container(title: str, key: Optional[str] = None):
     if hasattr(st, "modal"):
         return st.modal(title, key=key)
     if hasattr(st, "dialog"):
-        return st.dialog(title, key=key)
+        dialog_fn = st.dialog
+        dialog_signature = inspect.signature(dialog_fn)
+        if "key" in dialog_signature.parameters and key is not None:
+            return dialog_fn(title, key=key)
+        return dialog_fn(title)
     st.warning("Streamlit modal not available; showing content inline instead.")
     return st.container()
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -31,6 +31,7 @@ Forbidden patterns:
 • Do not allow manual editing of the configuration name or target caption formatting.
 """
 
+import inspect
 import streamlit as st, logging
 from typing import Optional
 
@@ -70,7 +71,11 @@ def _modal_container(title: str, key: Optional[str] = None):
     if hasattr(st, "modal"):
         return st.modal(title, key=key)
     if hasattr(st, "dialog"):
-        return st.dialog(title, key=key)
+        dialog_fn = st.dialog
+        dialog_signature = inspect.signature(dialog_fn)
+        if "key" in dialog_signature.parameters and key is not None:
+            return dialog_fn(title, key=key)
+        return dialog_fn(title)
     st.warning("Streamlit modal not available; showing content inline instead.")
     return st.container()
 


### PR DESCRIPTION
- guard dialog fallback against Streamlit versions that do not support the `key` argument
- refresh mirrored snapshot for streamlit_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390fcdda248324a6c55d0e88fa281b)