### PR TITLE
Fix modal container fallback

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -69,13 +69,20 @@ def _modal_container(title: str, key: Optional[str] = None):
     """
 
     if hasattr(st, "modal"):
-        return st.modal(title, key=key)
+        modal = st.modal(title, key=key)
+        if hasattr(modal, "__enter__"):
+            return modal
+
     if hasattr(st, "dialog"):
         dialog_fn = st.dialog
         dialog_signature = inspect.signature(dialog_fn)
         if "key" in dialog_signature.parameters and key is not None:
-            return dialog_fn(title, key=key)
-        return dialog_fn(title)
+            dialog = dialog_fn(title, key=key)
+        else:
+            dialog = dialog_fn(title)
+        if hasattr(dialog, "__enter__"):
+            return dialog
+
     st.warning("Streamlit modal not available; showing content inline instead.")
     return st.container()
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -69,13 +69,20 @@ def _modal_container(title: str, key: Optional[str] = None):
     """
 
     if hasattr(st, "modal"):
-        return st.modal(title, key=key)
+        modal = st.modal(title, key=key)
+        if hasattr(modal, "__enter__"):
+            return modal
+
     if hasattr(st, "dialog"):
         dialog_fn = st.dialog
         dialog_signature = inspect.signature(dialog_fn)
         if "key" in dialog_signature.parameters and key is not None:
-            return dialog_fn(title, key=key)
-        return dialog_fn(title)
+            dialog = dialog_fn(title, key=key)
+        else:
+            dialog = dialog_fn(title)
+        if hasattr(dialog, "__enter__"):
+            return dialog
+
     st.warning("Streamlit modal not available; showing content inline instead.")
     return st.container()
 


### PR DESCRIPTION
- ensure the modal helper only returns context managers and falls back to inline containers when unavailable
- mirror updated Python files into /snapshots .p artifacts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939114c38948324a45f3a82285bc663)