### PR TITLE
Require explicit timestamp column for table checks

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1428,7 +1428,7 @@ def render_config_editor():
         (session_ts_col if isinstance(session_ts_col, str) and session_ts_col else None)
         or freshness_defaults.get("timestamp_column")
         or legacy_row_count_params.get("timestamp_column")
-        or "LOAD_TIMESTAMP"
+        or ""
     )
     max_age_source: Any = session_max_age if session_max_age is not None else freshness_defaults.get("max_age_minutes")
     if max_age_source is None:

--- a/snapshots/utils/checkdefs.p
+++ b/snapshots/utils/checkdefs.p
@@ -166,7 +166,9 @@ def build_rule_for_column_check(fqn: str, col: str, ctype: str, params: dict):
 def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
     ttype = (ttype or "").upper()
     if ttype == "FRESHNESS":
-        ts_col_raw = params.get("timestamp_column", "LOAD_TIMESTAMP")
+        ts_col_raw = (params or {}).get("timestamp_column")
+        if not ts_col_raw or not str(ts_col_raw).strip():
+            raise ValueError("timestamp_column is required for FRESHNESS checks")
         ts_col = _quote_identifier(ts_col_raw)
         max_age = int(params.get("max_age_minutes", 1920))
         table_name = _quote_table_fqn(fqn)
@@ -184,7 +186,9 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         table_name = _quote_table_fqn(fqn)
         return f"SELECT COUNT(*) >= {min_rows} AS OK FROM {table_name}", True
     if ttype == "ROW_COUNT_ANOMALY":
-        ts_col_raw = params.get("timestamp_column", "LOAD_TIMESTAMP")
+        ts_col_raw = (params or {}).get("timestamp_column")
+        if not ts_col_raw or not str(ts_col_raw).strip():
+            raise ValueError("timestamp_column is required for ROW_COUNT_ANOMALY checks")
         ts_col = _quote_identifier(ts_col_raw)
         lookback_days = int(params.get("lookback_days", 28))
         sensitivity = float(params.get("sensitivity", 3.0))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1428,7 +1428,7 @@ def render_config_editor():
         (session_ts_col if isinstance(session_ts_col, str) and session_ts_col else None)
         or freshness_defaults.get("timestamp_column")
         or legacy_row_count_params.get("timestamp_column")
-        or "LOAD_TIMESTAMP"
+        or ""
     )
     max_age_source: Any = session_max_age if session_max_age is not None else freshness_defaults.get("max_age_minutes")
     if max_age_source is None:

--- a/utils/checkdefs.py
+++ b/utils/checkdefs.py
@@ -166,7 +166,9 @@ def build_rule_for_column_check(fqn: str, col: str, ctype: str, params: dict):
 def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
     ttype = (ttype or "").upper()
     if ttype == "FRESHNESS":
-        ts_col_raw = params.get("timestamp_column", "LOAD_TIMESTAMP")
+        ts_col_raw = (params or {}).get("timestamp_column")
+        if not ts_col_raw or not str(ts_col_raw).strip():
+            raise ValueError("timestamp_column is required for FRESHNESS checks")
         ts_col = _quote_identifier(ts_col_raw)
         max_age = int(params.get("max_age_minutes", 1920))
         table_name = _quote_table_fqn(fqn)
@@ -184,7 +186,9 @@ def build_rule_for_table_check(fqn: str, ttype: str, params: dict):
         table_name = _quote_table_fqn(fqn)
         return f"SELECT COUNT(*) >= {min_rows} AS OK FROM {table_name}", True
     if ttype == "ROW_COUNT_ANOMALY":
-        ts_col_raw = params.get("timestamp_column", "LOAD_TIMESTAMP")
+        ts_col_raw = (params or {}).get("timestamp_column")
+        if not ts_col_raw or not str(ts_col_raw).strip():
+            raise ValueError("timestamp_column is required for ROW_COUNT_ANOMALY checks")
         ts_col = _quote_identifier(ts_col_raw)
         lookback_days = int(params.get("lookback_days", 28))
         sensitivity = float(params.get("sensitivity", 3.0))


### PR DESCRIPTION
- Require explicit timestamp columns for freshness and row count anomaly rule generation to avoid invalid identifiers.
- Stop auto-defaulting the timestamp column to LOAD_TIMESTAMP in the editor and rely on stored/session values instead.
- Refresh mirrored snapshot artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939284114ec8324b36de73aaee1d796)