### PR TITLE
Fix monitor error messaging and restore missing rules

### DIFF
--- a/snapshots/utils/meta.p
+++ b/snapshots/utils/meta.p
@@ -427,7 +427,7 @@ def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]
           r.VERSION,
           r.SCOPE
         FROM {_q(DQ_CHECK_TBL)} c
-        JOIN {rule_table} r
+        LEFT JOIN {rule_table} r
           ON c.RULE_CODE = r.RULE_CODE
         WHERE c.CONFIG_ID = ?
         """,

--- a/sql/CREATE_RESULTS_AND_SP.SQL
+++ b/sql/CREATE_RESULTS_AND_SP.SQL
@@ -102,6 +102,14 @@ def run_dq_config(session: Session, CONFIG_ID: str) -> str:
             else:
                 error_msg = str(exc)
 
+        if not ok and not error_msg:
+            context_sql = agg_sql or failure_sql or rule_expr_raw
+            detail = context_sql[:200] if context_sql else ""
+            error_msg = (
+                f"{check_type or 'Check'} evaluated to FALSE"
+                + (f" | SQL[:200]={detail}" if detail else "")
+            )
+
         session.sql(
             """
             INSERT INTO DQ_RUN_RESULTS (RUN_ID, CONFIG_ID, CHECK_ID, CHECK_TYPE, RUN_TS, FAILURES, OK, ERROR_MSG)

--- a/utils/meta.py
+++ b/utils/meta.py
@@ -427,7 +427,7 @@ def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]
           r.VERSION,
           r.SCOPE
         FROM {_q(DQ_CHECK_TBL)} c
-        JOIN {rule_table} r
+        LEFT JOIN {rule_table} r
           ON c.RULE_CODE = r.RULE_CODE
         WHERE c.CONFIG_ID = ?
         """,


### PR DESCRIPTION
- Add fallback error text for aggregate check failures so row count anomalies show details in Monitor
- Load configuration rules with a left join to keep displaying entries without library matches
- Refresh snapshot mirror

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393b5fb8e483249eb48b6d2e7d6dea)