### PR TITLE
Fix handling of empty relation names in UI

### DIFF
--- a/snapshots/utils/meta.p
+++ b/snapshots/utils/meta.p
@@ -225,6 +225,8 @@ def _parse_relation_name(name: str) -> Tuple[Optional[str], Optional[str], str]:
         return None, parts[0], parts[1]
     if len(parts) == 1:
         return None, None, parts[0]
+    if len(parts) == 0:
+        return None, None, ""
     raise ValueError("Invalid relation name")
 
 def _current_db_schema(session: Session) -> Tuple[Optional[str], Optional[str]]:

--- a/utils/meta.py
+++ b/utils/meta.py
@@ -225,6 +225,8 @@ def _parse_relation_name(name: str) -> Tuple[Optional[str], Optional[str], str]:
         return None, parts[0], parts[1]
     if len(parts) == 1:
         return None, None, parts[0]
+    if len(parts) == 0:
+        return None, None, ""
     raise ValueError("Invalid relation name")
 
 def _current_db_schema(session: Session) -> Tuple[Optional[str], Optional[str]]:


### PR DESCRIPTION
- Treat empty relation names as blank components instead of raising, preventing crashes when no table is selected.
- Update mirrored snapshot files.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693954b2a1488324a52f9cd44dbc0ab7)