### PR TITLE
Hide table-level checks from field rule list

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1211,10 +1211,13 @@ def render_config_editor():
     detail_mode = add_mode or bool(st.session_state.get("active_rule_edit_id"))
 
     grid_entries: List[Dict[str, Any]] = []
+    excluded_table_rules = {"FRESHNESS", "ROW_COUNT"}
     for rule in library_checks:
+        rule_code_key = (rule.get("rule_code") or rule.get("rule_id") or "").upper()
+        if rule_code_key in excluded_table_rules:
+            continue
         if not rule.get("column_name"):
             continue
-        rule_code_key = (rule.get("rule_code") or "").upper()
         template = (
             active_rules_by_code.get(rule_code_key)
             or all_rules_map.get(rule_code_key)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1211,10 +1211,13 @@ def render_config_editor():
     detail_mode = add_mode or bool(st.session_state.get("active_rule_edit_id"))
 
     grid_entries: List[Dict[str, Any]] = []
+    excluded_table_rules = {"FRESHNESS", "ROW_COUNT"}
     for rule in library_checks:
+        rule_code_key = (rule.get("rule_code") or rule.get("rule_id") or "").upper()
+        if rule_code_key in excluded_table_rules:
+            continue
         if not rule.get("column_name"):
             continue
-        rule_code_key = (rule.get("rule_code") or "").upper()
         template = (
             active_rules_by_code.get(rule_code_key)
             or all_rules_map.get(rule_code_key)


### PR DESCRIPTION
- exclude freshness and row count rules from the column-level rule grid in the config editor
- refresh mirrored snapshot files

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69395b8a620c8324bc86fca9b10df61c)