### PR TITLE
Handle JSON rule expressions in runner

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -24,6 +24,24 @@ def _extract_rule_params(check: DQCheck) -> Sequence[Any]:
     return (params,)
 
 
+def _normalize_rule_expression(check: DQCheck) -> str:
+    """Return a SQL predicate for a rule, handling JSON-encoded payloads."""
+
+    raw_expr = (check.compiled_rule or check.rule_expr or "").strip()
+    rule_expr = raw_expr
+    if raw_expr.startswith("{"):
+        try:
+            parsed = json.loads(raw_expr)
+            if isinstance(parsed, dict):
+                compiled = (parsed.get("compiled_predicate") or "").strip()
+                if compiled:
+                    rule_expr = compiled
+        except Exception:
+            # Fall back to the raw expression when parsing fails.
+            pass
+    return rule_expr
+
+
 def _sql_with_params(session, sql: str, params: Sequence[Any]):
     if params:
         return session.sql(sql, params=tuple(params))
@@ -33,7 +51,7 @@ def _sql_with_params(session, sql: str, params: Sequence[Any]):
 def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
     results: Dict[str, Any] = {"config_id": cfg.config_id, "checks": []}
     for chk in checks:
-        rule = (chk.rule_expr or '').strip()
+        rule = _normalize_rule_expression(chk)
         rule_params = _extract_rule_params(chk)
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -24,6 +24,24 @@ def _extract_rule_params(check: DQCheck) -> Sequence[Any]:
     return (params,)
 
 
+def _normalize_rule_expression(check: DQCheck) -> str:
+    """Return a SQL predicate for a rule, handling JSON-encoded payloads."""
+
+    raw_expr = (check.compiled_rule or check.rule_expr or "").strip()
+    rule_expr = raw_expr
+    if raw_expr.startswith("{"):
+        try:
+            parsed = json.loads(raw_expr)
+            if isinstance(parsed, dict):
+                compiled = (parsed.get("compiled_predicate") or "").strip()
+                if compiled:
+                    rule_expr = compiled
+        except Exception:
+            # Fall back to the raw expression when parsing fails.
+            pass
+    return rule_expr
+
+
 def _sql_with_params(session, sql: str, params: Sequence[Any]):
     if params:
         return session.sql(sql, params=tuple(params))
@@ -33,7 +51,7 @@ def _sql_with_params(session, sql: str, params: Sequence[Any]):
 def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
     results: Dict[str, Any] = {"config_id": cfg.config_id, "checks": []}
     for chk in checks:
-        rule = (chk.rule_expr or '').strip()
+        rule = _normalize_rule_expression(chk)
         rule_params = _extract_rule_params(chk)
         if rule.upper().startswith(AGG_PREFIX):
             sql = rule[len(AGG_PREFIX):].strip()

--- a/snapshots/tests/test_runner.p
+++ b/snapshots/tests/test_runner.p
@@ -1,0 +1,36 @@
+import json
+
+from services.runner import _normalize_rule_expression
+from utils.meta import DQCheck
+
+
+def _make_check(**overrides):
+    defaults = dict(
+        config_id="cfg",
+        check_id="chk",
+        table_fqn="DB.SCHEMA.TABLE",
+        column_name=None,
+        rule_expr="",
+        severity="ERROR",
+    )
+    defaults.update(overrides)
+    return DQCheck(**defaults)
+
+
+def test_normalize_rule_expression_from_json_payload():
+    compiled = 'NOT (T."COL" IS NULL)'
+    payload = json.dumps({
+        "compiled_predicate": compiled,
+        "rule_code": "NOT_NULL",
+    })
+    check = _make_check(rule_expr=payload)
+
+    assert _normalize_rule_expression(check) == compiled
+
+
+def test_normalize_rule_expression_prefers_compiled_rule():
+    compiled_rule = "T.COL > 0"
+    payload = json.dumps({"compiled_predicate": "SHOULD_NOT_USE"})
+    check = _make_check(rule_expr=payload, compiled_rule=compiled_rule)
+
+    assert _normalize_rule_expression(check) == compiled_rule

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,36 @@
+import json
+
+from services.runner import _normalize_rule_expression
+from utils.meta import DQCheck
+
+
+def _make_check(**overrides):
+    defaults = dict(
+        config_id="cfg",
+        check_id="chk",
+        table_fqn="DB.SCHEMA.TABLE",
+        column_name=None,
+        rule_expr="",
+        severity="ERROR",
+    )
+    defaults.update(overrides)
+    return DQCheck(**defaults)
+
+
+def test_normalize_rule_expression_from_json_payload():
+    compiled = 'NOT (T."COL" IS NULL)'
+    payload = json.dumps({
+        "compiled_predicate": compiled,
+        "rule_code": "NOT_NULL",
+    })
+    check = _make_check(rule_expr=payload)
+
+    assert _normalize_rule_expression(check) == compiled
+
+
+def test_normalize_rule_expression_prefers_compiled_rule():
+    compiled_rule = "T.COL > 0"
+    payload = json.dumps({"compiled_predicate": "SHOULD_NOT_USE"})
+    check = _make_check(rule_expr=payload, compiled_rule=compiled_rule)
+
+    assert _normalize_rule_expression(check) == compiled_rule


### PR DESCRIPTION
- Normalize rule expressions from JSON payloads before executing DQ checks
- Add unit coverage for rule expression normalization
- Mirror updated Python snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939734ebb188324a5c56f08b20ebd5a)