### PR TITLE
Handle invalid JSON rule payloads

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -1,5 +1,6 @@
 # services/runner.py
 import json
+import re
 from typing import Any, Dict, List, Sequence
 from utils.checkdefs import _RULE_PARAMS_KEY
 from utils.meta import DQCheck, DQConfig
@@ -37,8 +38,45 @@ def _normalize_rule_expression(check: DQCheck) -> str:
                 if compiled:
                     rule_expr = compiled
         except Exception:
-            # Fall back to the raw expression when parsing fails.
-            pass
+            # Attempt a defensive extraction when the payload is not valid JSON.
+            patterns = [
+                r'"compiled_predicate"\s*:\s*"(?P<predicate>.*?)"\s*,\s*"',
+                r'"compiled_predicate"\s*:\s*"(?P<predicate>(?:[^"\\]|\\.)*)"',
+            ]
+            for pattern in patterns:
+                match = re.search(pattern, raw_expr, flags=re.DOTALL)
+                if match:
+                    compiled = match.group("predicate")
+                    compiled = (
+                        compiled.replace("\\\"", '"')
+                        .replace("\\n", "\n")
+                        .strip()
+                    )
+                    if compiled:
+                        rule_expr = compiled
+                        break
+
+            if rule_expr == raw_expr:
+                start = raw_expr.find('"compiled_predicate"')
+                if start != -1:
+                    remainder = raw_expr[start:]
+                    colon_idx = remainder.find(":")
+                    if colon_idx != -1:
+                        value_part = remainder[colon_idx + 1 :].lstrip()
+                        if value_part.startswith('"'):
+                            value_part = value_part[1:]
+                            end_idx = value_part.find('",')
+                            if end_idx == -1:
+                                end_idx = value_part.find('"\n')
+                            if end_idx != -1:
+                                compiled = (
+                                    value_part[:end_idx]
+                                    .replace("\\\"", '"')
+                                    .replace("\\n", "\n")
+                                    .strip()
+                                )
+                                if compiled:
+                                    rule_expr = compiled
     return rule_expr
 
 

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -1,5 +1,6 @@
 # services/runner.py
 import json
+import re
 from typing import Any, Dict, List, Sequence
 from utils.checkdefs import _RULE_PARAMS_KEY
 from utils.meta import DQCheck, DQConfig
@@ -37,8 +38,45 @@ def _normalize_rule_expression(check: DQCheck) -> str:
                 if compiled:
                     rule_expr = compiled
         except Exception:
-            # Fall back to the raw expression when parsing fails.
-            pass
+            # Attempt a defensive extraction when the payload is not valid JSON.
+            patterns = [
+                r'"compiled_predicate"\s*:\s*"(?P<predicate>.*?)"\s*,\s*"',
+                r'"compiled_predicate"\s*:\s*"(?P<predicate>(?:[^"\\]|\\.)*)"',
+            ]
+            for pattern in patterns:
+                match = re.search(pattern, raw_expr, flags=re.DOTALL)
+                if match:
+                    compiled = match.group("predicate")
+                    compiled = (
+                        compiled.replace("\\\"", '"')
+                        .replace("\\n", "\n")
+                        .strip()
+                    )
+                    if compiled:
+                        rule_expr = compiled
+                        break
+
+            if rule_expr == raw_expr:
+                start = raw_expr.find('"compiled_predicate"')
+                if start != -1:
+                    remainder = raw_expr[start:]
+                    colon_idx = remainder.find(":")
+                    if colon_idx != -1:
+                        value_part = remainder[colon_idx + 1 :].lstrip()
+                        if value_part.startswith('"'):
+                            value_part = value_part[1:]
+                            end_idx = value_part.find('",')
+                            if end_idx == -1:
+                                end_idx = value_part.find('"\n')
+                            if end_idx != -1:
+                                compiled = (
+                                    value_part[:end_idx]
+                                    .replace("\\\"", '"')
+                                    .replace("\\n", "\n")
+                                    .strip()
+                                )
+                                if compiled:
+                                    rule_expr = compiled
     return rule_expr
 
 

--- a/snapshots/tests/test_runner.p
+++ b/snapshots/tests/test_runner.p
@@ -34,3 +34,11 @@ def test_normalize_rule_expression_prefers_compiled_rule():
     check = _make_check(rule_expr=payload, compiled_rule=compiled_rule)
 
     assert _normalize_rule_expression(check) == compiled_rule
+
+
+def test_normalize_rule_expression_handles_invalid_json_payload():
+    compiled = 'T."COL" > 0'
+    payload = '{\n  "compiled_predicate": "' + compiled + '",\n  "rule_code": "GT_ZERO"\n'
+    check = _make_check(rule_expr=payload)
+
+    assert _normalize_rule_expression(check) == compiled

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -34,3 +34,11 @@ def test_normalize_rule_expression_prefers_compiled_rule():
     check = _make_check(rule_expr=payload, compiled_rule=compiled_rule)
 
     assert _normalize_rule_expression(check) == compiled_rule
+
+
+def test_normalize_rule_expression_handles_invalid_json_payload():
+    compiled = 'T."COL" > 0'
+    payload = '{\n  "compiled_predicate": "' + compiled + '",\n  "rule_code": "GT_ZERO"\n'
+    check = _make_check(rule_expr=payload)
+
+    assert _normalize_rule_expression(check) == compiled


### PR DESCRIPTION
- Add defensive parsing to normalize rule expressions when rule payload JSON is malformed
- Cover invalid JSON scenario in runner normalization tests
- Refresh snapshot mirrors

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939987f24a483248afe3d3d7d807d96)