### PR TITLE
Handle quoted compiled rule payloads

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -30,14 +30,26 @@ def _normalize_rule_expression(check: DQCheck) -> str:
 
     raw_expr = (check.compiled_rule or check.rule_expr or "").strip()
     rule_expr = raw_expr
-    if raw_expr.startswith("{"):
-        try:
-            parsed = json.loads(raw_expr)
-            if isinstance(parsed, dict):
-                compiled = (parsed.get("compiled_predicate") or "").strip()
-                if compiled:
-                    rule_expr = compiled
-        except Exception:
+    try:
+        parsed = json.loads(raw_expr)
+        parsed_compiled = None
+        if isinstance(parsed, dict):
+            parsed_compiled = (parsed.get("compiled_predicate") or "").strip()
+        elif isinstance(parsed, str):
+            # Handle double-encoded JSON payloads or quoted predicates.
+            parsed_compiled = parsed.strip()
+            try:
+                nested = json.loads(parsed)
+                if isinstance(nested, dict):
+                    nested_compiled = (nested.get("compiled_predicate") or "").strip()
+                    if nested_compiled:
+                        parsed_compiled = nested_compiled
+            except Exception:
+                pass
+        if parsed_compiled:
+            rule_expr = parsed_compiled
+    except Exception:
+        if raw_expr.startswith("{"):
             # Attempt a defensive extraction when the payload is not valid JSON.
             patterns = [
                 r'"compiled_predicate"\s*:\s*"(?P<predicate>.*?)"\s*,\s*"',

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -30,14 +30,26 @@ def _normalize_rule_expression(check: DQCheck) -> str:
 
     raw_expr = (check.compiled_rule or check.rule_expr or "").strip()
     rule_expr = raw_expr
-    if raw_expr.startswith("{"):
-        try:
-            parsed = json.loads(raw_expr)
-            if isinstance(parsed, dict):
-                compiled = (parsed.get("compiled_predicate") or "").strip()
-                if compiled:
-                    rule_expr = compiled
-        except Exception:
+    try:
+        parsed = json.loads(raw_expr)
+        parsed_compiled = None
+        if isinstance(parsed, dict):
+            parsed_compiled = (parsed.get("compiled_predicate") or "").strip()
+        elif isinstance(parsed, str):
+            # Handle double-encoded JSON payloads or quoted predicates.
+            parsed_compiled = parsed.strip()
+            try:
+                nested = json.loads(parsed)
+                if isinstance(nested, dict):
+                    nested_compiled = (nested.get("compiled_predicate") or "").strip()
+                    if nested_compiled:
+                        parsed_compiled = nested_compiled
+            except Exception:
+                pass
+        if parsed_compiled:
+            rule_expr = parsed_compiled
+    except Exception:
+        if raw_expr.startswith("{"):
             # Attempt a defensive extraction when the payload is not valid JSON.
             patterns = [
                 r'"compiled_predicate"\s*:\s*"(?P<predicate>.*?)"\s*,\s*"',

--- a/snapshots/tests/test_runner.p
+++ b/snapshots/tests/test_runner.p
@@ -42,3 +42,20 @@ def test_normalize_rule_expression_handles_invalid_json_payload():
     check = _make_check(rule_expr=payload)
 
     assert _normalize_rule_expression(check) == compiled
+
+
+def test_normalize_rule_expression_handles_quoted_json_string():
+    compiled = 'T."COL" > 10'
+    payload = json.dumps({"compiled_predicate": compiled})
+    quoted = json.dumps(payload)  # Stored with extra quotes
+    check = _make_check(rule_expr=quoted)
+
+    assert _normalize_rule_expression(check) == compiled
+
+
+def test_normalize_rule_expression_handles_wrapped_predicate_string():
+    compiled = "T.COL < 5"
+    wrapped = json.dumps(compiled)
+    check = _make_check(rule_expr=wrapped)
+
+    assert _normalize_rule_expression(check) == compiled

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -42,3 +42,20 @@ def test_normalize_rule_expression_handles_invalid_json_payload():
     check = _make_check(rule_expr=payload)
 
     assert _normalize_rule_expression(check) == compiled
+
+
+def test_normalize_rule_expression_handles_quoted_json_string():
+    compiled = 'T."COL" > 10'
+    payload = json.dumps({"compiled_predicate": compiled})
+    quoted = json.dumps(payload)  # Stored with extra quotes
+    check = _make_check(rule_expr=quoted)
+
+    assert _normalize_rule_expression(check) == compiled
+
+
+def test_normalize_rule_expression_handles_wrapped_predicate_string():
+    compiled = "T.COL < 5"
+    wrapped = json.dumps(compiled)
+    check = _make_check(rule_expr=wrapped)
+
+    assert _normalize_rule_expression(check) == compiled


### PR DESCRIPTION
- Normalize compiled rule expressions when stored as quoted strings or double-encoded JSON payloads
- Add runner tests covering quoted payloads and regenerate snapshots

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399a2075b883248ad7a268f8a0015e)