### PR TITLE
Fix runner aliasing for compiled DQ rules

### DIFF
--- a/services/runner.py
+++ b/services/runner.py
@@ -135,7 +135,9 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
                 "sample": []
             })
         else:
-            failure_sql = f"SELECT COUNT(*) AS FAILURES FROM {chk.table_fqn} WHERE NOT ({rule})"
+            failure_sql = (
+                f"SELECT COUNT(*) AS FAILURES FROM {chk.table_fqn} AS T WHERE NOT ({rule})"
+            )
             try:
                 df = _sql_with_params(session, failure_sql, rule_params)
             except Exception as exc:
@@ -144,7 +146,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
             sample = []
             if chk.sample_rows and failures:
                 sample_sql = (
-                    f"SELECT * FROM {chk.table_fqn} WHERE NOT ({rule}) LIMIT {int(chk.sample_rows)}"
+                    f"SELECT * FROM {chk.table_fqn} AS T WHERE NOT ({rule}) LIMIT {int(chk.sample_rows)}"
                 )
                 try:
                     s_df = _sql_with_params(session, sample_sql, rule_params)

--- a/snapshots/services/runner.p
+++ b/snapshots/services/runner.p
@@ -135,7 +135,9 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
                 "sample": []
             })
         else:
-            failure_sql = f"SELECT COUNT(*) AS FAILURES FROM {chk.table_fqn} WHERE NOT ({rule})"
+            failure_sql = (
+                f"SELECT COUNT(*) AS FAILURES FROM {chk.table_fqn} AS T WHERE NOT ({rule})"
+            )
             try:
                 df = _sql_with_params(session, failure_sql, rule_params)
             except Exception as exc:
@@ -144,7 +146,7 @@ def run_now(session, cfg: DQConfig, checks: List[DQCheck]) -> Dict[str, Any]:
             sample = []
             if chk.sample_rows and failures:
                 sample_sql = (
-                    f"SELECT * FROM {chk.table_fqn} WHERE NOT ({rule}) LIMIT {int(chk.sample_rows)}"
+                    f"SELECT * FROM {chk.table_fqn} AS T WHERE NOT ({rule}) LIMIT {int(chk.sample_rows)}"
                 )
                 try:
                     s_df = _sql_with_params(session, sample_sql, rule_params)

--- a/snapshots/tests/test_runner.p
+++ b/snapshots/tests/test_runner.p
@@ -1,7 +1,8 @@
 import json
 
 from services.runner import _normalize_rule_expression
-from utils.meta import DQCheck
+from services import runner
+from utils.meta import DQCheck, DQConfig
 
 
 def _make_check(**overrides):
@@ -59,3 +60,28 @@ def test_normalize_rule_expression_handles_wrapped_predicate_string():
     check = _make_check(rule_expr=wrapped)
 
     assert _normalize_rule_expression(check) == compiled
+
+
+def test_run_now_aliases_table_for_compiled_rules():
+    sql_calls = []
+
+    class DummyDF:
+        def collect(self):
+            return [(0,)]
+
+    class DummySession:
+        def sql(self, sql, params=None):
+            sql_calls.append((sql, params))
+            return DummyDF()
+
+    check = _make_check(
+        rule_expr=json.dumps({"compiled_predicate": 'not isnull(T."COL")'}),
+        sample_rows=0,
+    )
+    cfg = DQConfig("cfg", "Cfg", None, "DB.SCHEMA.TABLE", None, None, "ACTIVE", None)
+
+    runner.run_now(DummySession(), cfg, [check])
+
+    assert sql_calls[0][0] == (
+        'SELECT COUNT(*) AS FAILURES FROM DB.SCHEMA.TABLE AS T WHERE NOT (not isnull(T."COL"))'
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,7 +1,8 @@
 import json
 
 from services.runner import _normalize_rule_expression
-from utils.meta import DQCheck
+from services import runner
+from utils.meta import DQCheck, DQConfig
 
 
 def _make_check(**overrides):
@@ -59,3 +60,28 @@ def test_normalize_rule_expression_handles_wrapped_predicate_string():
     check = _make_check(rule_expr=wrapped)
 
     assert _normalize_rule_expression(check) == compiled
+
+
+def test_run_now_aliases_table_for_compiled_rules():
+    sql_calls = []
+
+    class DummyDF:
+        def collect(self):
+            return [(0,)]
+
+    class DummySession:
+        def sql(self, sql, params=None):
+            sql_calls.append((sql, params))
+            return DummyDF()
+
+    check = _make_check(
+        rule_expr=json.dumps({"compiled_predicate": 'not isnull(T."COL")'}),
+        sample_rows=0,
+    )
+    cfg = DQConfig("cfg", "Cfg", None, "DB.SCHEMA.TABLE", None, None, "ACTIVE", None)
+
+    runner.run_now(DummySession(), cfg, [check])
+
+    assert sql_calls[0][0] == (
+        'SELECT COUNT(*) AS FAILURES FROM DB.SCHEMA.TABLE AS T WHERE NOT (not isnull(T."COL"))'
+    )


### PR DESCRIPTION
- Alias target tables when executing compiled row checks so predicates referencing table aliases run successfully
- Add regression coverage to ensure runner SQL includes the table alias for compiled predicates
- Refresh snapshot mirrors

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a45dea288324bc201c43f8304d1c)