### PR TITLE
Codex Task TL1 — Fix table-level checks (no more duplicates, no more mixing)

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -1062,7 +1062,12 @@ def render_config_editor():
         sel_id = draft_id
     cfg = get_config(session, sel_id) if sel_id else None
     existing_checks = get_checks(session, sel_id) if sel_id else []
-    library_checks = get_library_checks(session, sel_id) if sel_id else []
+    column_library_checks = (
+        get_library_checks(session, sel_id, scope="COLUMN") if sel_id else []
+    )
+    table_library_checks = (
+        get_library_checks(session, sel_id, scope="TABLE") if sel_id else []
+    )
 
     rule_templates = load_rule_library(
         session, METADATA_DB, METADATA_SCHEMA, include_inactive=True
@@ -1096,6 +1101,12 @@ def render_config_editor():
     def _builder_key(rule_id: str, fallback: str) -> str:
         template = active_rules.get(rule_id) or all_rules_map.get(rule_id)
         return (template.check_type or template.rule_id) if template else fallback
+
+    table_templates_by_key: Dict[str, RuleTemplate] = {}
+    for tmpl in rule_templates:
+        key = _rule_key(tmpl.rule_id or tmpl.rule_code or "")
+        if (tmpl.scope or "").upper() == "TABLE" and key:
+            table_templates_by_key[key] = tmpl
 
     for chk in existing_checks:
         legacy_key = _rule_key(chk.check_type or "")
@@ -1239,7 +1250,7 @@ def render_config_editor():
         return "||".join([str(check_id or ""), column_part, (rule_code or "").upper()])
 
     excluded_table_rules = {"FRESHNESS", "ROW_COUNT"}
-    for rule in library_checks:
+    for rule in column_library_checks:
         rule_code_key = (rule.get("rule_code") or rule.get("rule_id") or "").upper()
         if rule_code_key in excluded_table_rules:
             continue
@@ -1293,21 +1304,21 @@ def render_config_editor():
         )
 
         filter_col, filter_code, filter_sev = st.columns(3)
-        rule_columns = sorted({chk.get("column_name") for chk in library_checks if chk.get("column_name")})
+        rule_columns = sorted({chk.get("column_name") for chk in column_library_checks if chk.get("column_name")})
         filter_column = filter_col.selectbox(
             "Filter by column",
             options=["All"] + rule_columns,
             index=0,
             key="rule_filter_column",
         )
-        rule_codes = sorted({(chk.get("rule_code") or "").upper() for chk in library_checks if chk.get("rule_code")})
+        rule_codes = sorted({(chk.get("rule_code") or "").upper() for chk in column_library_checks if chk.get("rule_code")})
         filter_rule_code = filter_code.selectbox(
             "Filter by rule",
             options=["All"] + rule_codes,
             index=0,
             key="rule_filter_code",
         )
-        severities = sorted({(chk.get("severity") or chk.get("rule_severity") or "ERROR") for chk in library_checks})
+        severities = sorted({(chk.get("severity") or chk.get("rule_severity") or "ERROR") for chk in column_library_checks})
         filter_severity = filter_sev.selectbox(
             "Filter by severity",
             options=["All"] + severities,
@@ -1385,7 +1396,7 @@ def render_config_editor():
                 table_suggestions=table_suggestions,
                 column_lookup=column_lookup,
                 rule_templates=rule_templates,
-                existing_library_checks=library_checks,
+                existing_library_checks=column_library_checks,
                 key_prefix=st.session_state.get("rule_add_key", "add_rule"),
                 state_keys_to_clear=["rule_add_mode", "rule_add_key"],
                 config_id=active_config_id,
@@ -1479,22 +1490,34 @@ def render_config_editor():
         # -------- Form --------
         # Pre-populate table-level defaults from existing checks / state
         existing_table_params: Dict[str, Dict[str, Any]] = {}
-        existing_table_checks: Dict[str, DQCheck] = {}
+        existing_table_checks: Dict[str, Dict[str, Any]] = {}
         legacy_row_count_params: Dict[str, object] = {}
-        for ec in existing_checks:
-            if not ec.column_name and ec.params_json:
-                key = _rule_key(ec.check_type or "")
-                try:
-                    parsed_params = json.loads(ec.params_json)
-                except Exception:
-                    parsed_params = {}
+        for rule in table_library_checks:
+            key = _rule_key(
+                rule.get("rule_code")
+                or rule.get("rule_id")
+                or rule.get("check_type")
+                or ""
+            )
+            params = _parse_params(rule.get("rule_params") or rule.get("params_json"))
+            parsed_params = params if isinstance(params, dict) else {}
 
-                if key == "ROW_COUNT":
-                    legacy_row_count_params = parsed_params or {}
-                    continue
+            if key == "ROW_COUNT":
+                legacy_row_count_params = parsed_params or {}
+                continue
 
-                existing_table_params[key] = parsed_params or {}
-                existing_table_checks.setdefault(key, ec)
+            existing_table_params[key] = parsed_params or {}
+            existing_table_checks.setdefault(
+                key,
+                {
+                    "check_id": rule.get("check_id"),
+                    "severity": rule.get("severity")
+                    or rule.get("rule_severity")
+                    or "ERROR",
+                    "rule_code": rule.get("rule_code"),
+                    "rule_version": rule.get("rule_version") or rule.get("version"),
+                },
+            )
     
         freshness_key = _rule_key("FRESHNESS")
         rowcount_anomaly_key = _rule_key("ROW_COUNT_ANOMALY")
@@ -1648,15 +1671,36 @@ def render_config_editor():
                     except ValueError as exc:
                         table_check_error = f"Invalid freshness configuration: {exc}"
                     else:
-                        existing_freshness = existing_table_checks.get(freshness_key)
-                        check_rows.append(DQCheck(
-                            config_id=(cfg.config_id if cfg else "temp"),
-                            check_id=(existing_freshness.check_id if existing_freshness else "TABLE_FRESHNESS"),
-                            table_fqn=target_table, column_name=None,
-                            rule_expr=(f"AGG: {fr_rule}" if fr_is_agg else fr_rule), severity=(existing_freshness.severity if existing_freshness else "ERROR"),
-                            sample_rows=0, check_type=freshness_key,
-                            params_json=json.dumps(fr_params)
-                        ))
+                        existing_freshness = existing_table_checks.get(freshness_key) or {}
+                        fr_template = table_templates_by_key.get(freshness_key)
+                        check_rows.append(
+                            DQCheck(
+                                config_id=(cfg.config_id if cfg else "temp"),
+                                check_id=(
+                                    existing_freshness.get("check_id")
+                                    or "TABLE_FRESHNESS"
+                                ),
+                                table_fqn=target_table,
+                                column_name=None,
+                                rule_expr=(f"AGG: {fr_rule}" if fr_is_agg else fr_rule),
+                                severity=(
+                                    existing_freshness.get("severity")
+                                    or "ERROR"
+                                ),
+                                sample_rows=0,
+                                check_type=freshness_key,
+                                params_json=json.dumps(fr_params),
+                                rule_code=(
+                                    (existing_freshness.get("rule_code") or "").upper()
+                                    or (fr_template.rule_code if fr_template else None)
+                                ),
+                                rule_params=json.dumps(fr_params),
+                                rule_version=(
+                                    fr_template.version if fr_template else existing_freshness.get("rule_version")
+                                ),
+                                compiled_rule=(f"AGG: {fr_rule}" if fr_is_agg else fr_rule),
+                            )
+                        )
 
                 row_defaults = existing_table_params.get(rowcount_anomaly_key, {}) or {}
                 try:
@@ -1684,15 +1728,42 @@ def render_config_editor():
                 except ValueError as exc:
                     table_check_error = f"Invalid row count anomaly configuration: {exc}"
                 else:
-                    existing_anomaly = existing_table_checks.get(rowcount_anomaly_key)
-                    check_rows.append(DQCheck(
-                        config_id=(cfg.config_id if cfg else "temp"),
-                        check_id=(existing_anomaly.check_id if existing_anomaly else "TABLE_ROW_COUNT_ANOMALY"),
-                        table_fqn=target_table, column_name=None,
-                        rule_expr=(f"AGG: {anomaly_rule}" if anomaly_is_agg else anomaly_rule), severity=(existing_anomaly.severity if existing_anomaly else "ERROR"),
-                        sample_rows=0, check_type=rowcount_anomaly_key,
-                        params_json=json.dumps(anomaly_params)
-                    ))
+                    existing_anomaly = existing_table_checks.get(rowcount_anomaly_key) or {}
+                    anomaly_template = table_templates_by_key.get(rowcount_anomaly_key)
+                    check_rows.append(
+                        DQCheck(
+                            config_id=(cfg.config_id if cfg else "temp"),
+                            check_id=(
+                                existing_anomaly.get("check_id")
+                                or "TABLE_ROW_COUNT_ANOMALY"
+                            ),
+                            table_fqn=target_table,
+                            column_name=None,
+                            rule_expr=(
+                                f"AGG: {anomaly_rule}" if anomaly_is_agg else anomaly_rule
+                            ),
+                            severity=(
+                                existing_anomaly.get("severity")
+                                or "ERROR"
+                            ),
+                            sample_rows=0,
+                            check_type=rowcount_anomaly_key,
+                            params_json=json.dumps(anomaly_params),
+                            rule_code=(
+                                (existing_anomaly.get("rule_code") or "").upper()
+                                or (anomaly_template.rule_code if anomaly_template else None)
+                            ),
+                            rule_params=json.dumps(anomaly_params),
+                            rule_version=(
+                                anomaly_template.version
+                                if anomaly_template
+                                else existing_anomaly.get("rule_version")
+                            ),
+                            compiled_rule=(
+                                f"AGG: {anomaly_rule}" if anomaly_is_agg else anomaly_rule
+                            ),
+                        )
+                    )
     
             st.markdown("### Schedule")
             existing_cron = getattr(cfg, "schedule_cron", None) if cfg else None
@@ -1836,7 +1907,7 @@ def render_config_editor():
                     return
             # Preserve existing column-level rules and rebind to the active config
             existing_column_checks: List[DQCheck] = []
-            for rule in library_checks:
+            for rule in column_library_checks:
                 column_name = rule.get("column_name")
                 if not column_name:
                     continue

--- a/snapshots/utils/meta.p
+++ b/snapshots/utils/meta.p
@@ -398,13 +398,26 @@ def delete_config(session: Session, config_id: str):
     session.sql(f"DELETE FROM {_q(DQ_CONFIG_TBL)} WHERE CONFIG_ID = ?", params=[config_id]).collect()
 
 
-def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]:
-    """Load DQ_CHECK rows joined to the rule library for a config."""
+def get_library_checks(
+    session: Session, config_id: str, *, scope: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Load DQ_CHECK rows joined to the rule library for a config.
+
+    Optionally filters by rule scope (TABLE/COLUMN) to keep table-level
+    checks out of the rule grid while still allowing dedicated loading for
+    the configuration header.
+    """
 
     if not session or not config_id:
         return []
 
     rule_table = _q(f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_RULE_LIBRARY")
+    scope_clause = ""
+    params = [config_id]
+    if scope:
+        scope_clause = " AND COALESCE(UPPER(r.SCOPE), '') = UPPER(?)"
+        params.append(scope)
+
     df = session.sql(
         f"""
         SELECT
@@ -431,9 +444,9 @@ def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]
         FROM {_q(DQ_CHECK_TBL)} c
         LEFT JOIN {rule_table} r
           ON c.RULE_CODE = r.RULE_CODE
-        WHERE c.CONFIG_ID = ?
+        WHERE c.CONFIG_ID = ?{scope_clause}
         """,
-        params=[config_id],
+        params=params,
     )
     out: List[Dict[str, Any]] = []
     for row in df.collect():
@@ -526,23 +539,112 @@ def delete_check_by_id(session: Session, check_id: str):
     ).collect()
 
 def upsert_checks(session: Session, checks: List[DQCheck]):
-    if not session or not checks: return
+    if not session or not checks:
+        return
+
     ensure_meta_tables(session)
     cfg_id = checks[0].config_id
-    session.sql(f"DELETE FROM {_q(DQ_CHECK_TBL)} WHERE CONFIG_ID = ?", params=[cfg_id]).collect()
+
+    existing_df = session.sql(
+        f"""
+        SELECT CHECK_ID, COLUMN_NAME, RULE_CODE, CHECK_TYPE
+        FROM {_q(DQ_CHECK_TBL)}
+        WHERE CONFIG_ID = ?
+        """,
+        params=[cfg_id],
+    )
+    existing_map: Dict[Tuple[str, str], str] = {}
+    for row in existing_df.collect():
+        norm_col = (row["COLUMN_NAME"] or "").upper()
+        norm_rule = (row["RULE_CODE"] or row["CHECK_TYPE"] or "").upper()
+        existing_map[(norm_col, norm_rule)] = row["CHECK_ID"]
+
+    seen_ids: set[str] = set()
+
     for c in checks:
-        session.sql(f"""
-            INSERT INTO {_q(DQ_CHECK_TBL)} (
-              CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY,
-              SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON, RULE_CODE, RULE_PARAMS,
-              RULE_VERSION, COMPILED_RULE
-            )
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-        """, params=[
-            c.config_id, c.check_id, c.table_fqn, c.column_name, c.rule_expr,
-            c.severity, int(c.sample_rows), c.check_type, c.params_json,
-            c.rule_code, c.rule_params, c.rule_version, c.compiled_rule
-        ]).collect()
+        norm_col = (c.column_name or "").upper()
+        norm_rule = (c.rule_code or c.check_type or "").upper()
+        serialized_params = c.rule_params
+        if isinstance(serialized_params, dict):
+            serialized_params = json.dumps(serialized_params, default=str)
+        params_json = c.params_json
+        if isinstance(params_json, dict):
+            params_json = json.dumps(params_json, default=str)
+        serialized_params = serialized_params or params_json
+
+        existing_id = existing_map.get((norm_col, norm_rule))
+        check_id = existing_id or c.check_id or str(uuid4())
+        seen_ids.add(check_id)
+
+        if existing_id:
+            session.sql(
+                f"""
+                UPDATE {_q(DQ_CHECK_TBL)}
+                SET TABLE_FQN = :1,
+                    RULE_EXPR = :2,
+                    SEVERITY = :3,
+                    SAMPLE_ROWS = :4,
+                    CHECK_TYPE = :5,
+                    PARAMS_JSON = :6,
+                    RULE_CODE = :7,
+                    RULE_PARAMS = :8,
+                    RULE_VERSION = :9,
+                    COMPILED_RULE = :10,
+                    UPDATED_AT = CURRENT_TIMESTAMP()
+                WHERE CHECK_ID = :11
+                  AND CONFIG_ID = :12
+                """,
+                params=[
+                    c.table_fqn,
+                    c.rule_expr,
+                    c.severity,
+                    int(c.sample_rows),
+                    c.check_type,
+                    params_json,
+                    c.rule_code,
+                    serialized_params,
+                    c.rule_version,
+                    c.compiled_rule,
+                    check_id,
+                    cfg_id,
+                ],
+            ).collect()
+        else:
+            session.sql(
+                f"""
+                INSERT INTO {_q(DQ_CHECK_TBL)} (
+                  CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY,
+                  SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON, RULE_CODE, RULE_PARAMS,
+                  RULE_VERSION, COMPILED_RULE, UPDATED_AT
+                )
+                SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP()
+                """,
+                params=[
+                    c.config_id,
+                    check_id,
+                    c.table_fqn,
+                    c.column_name,
+                    c.rule_expr,
+                    c.severity,
+                    int(c.sample_rows),
+                    c.check_type,
+                    params_json,
+                    c.rule_code,
+                    serialized_params,
+                    c.rule_version,
+                    c.compiled_rule,
+                ],
+            ).collect()
+
+    if seen_ids:
+        session.sql(
+            f"""
+            DELETE FROM {_q(DQ_CHECK_TBL)}
+            WHERE CONFIG_ID = :1
+              AND CHECK_ID NOT IN ({', '.join(['?' for _ in seen_ids])})
+            """,
+            params=[cfg_id, *seen_ids],
+        ).collect()
 
 def get_checks(session: Session, config_id: str) -> List[DQCheck]:
     if not session: return []

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1062,7 +1062,12 @@ def render_config_editor():
         sel_id = draft_id
     cfg = get_config(session, sel_id) if sel_id else None
     existing_checks = get_checks(session, sel_id) if sel_id else []
-    library_checks = get_library_checks(session, sel_id) if sel_id else []
+    column_library_checks = (
+        get_library_checks(session, sel_id, scope="COLUMN") if sel_id else []
+    )
+    table_library_checks = (
+        get_library_checks(session, sel_id, scope="TABLE") if sel_id else []
+    )
 
     rule_templates = load_rule_library(
         session, METADATA_DB, METADATA_SCHEMA, include_inactive=True
@@ -1096,6 +1101,12 @@ def render_config_editor():
     def _builder_key(rule_id: str, fallback: str) -> str:
         template = active_rules.get(rule_id) or all_rules_map.get(rule_id)
         return (template.check_type or template.rule_id) if template else fallback
+
+    table_templates_by_key: Dict[str, RuleTemplate] = {}
+    for tmpl in rule_templates:
+        key = _rule_key(tmpl.rule_id or tmpl.rule_code or "")
+        if (tmpl.scope or "").upper() == "TABLE" and key:
+            table_templates_by_key[key] = tmpl
 
     for chk in existing_checks:
         legacy_key = _rule_key(chk.check_type or "")
@@ -1239,7 +1250,7 @@ def render_config_editor():
         return "||".join([str(check_id or ""), column_part, (rule_code or "").upper()])
 
     excluded_table_rules = {"FRESHNESS", "ROW_COUNT"}
-    for rule in library_checks:
+    for rule in column_library_checks:
         rule_code_key = (rule.get("rule_code") or rule.get("rule_id") or "").upper()
         if rule_code_key in excluded_table_rules:
             continue
@@ -1293,21 +1304,21 @@ def render_config_editor():
         )
 
         filter_col, filter_code, filter_sev = st.columns(3)
-        rule_columns = sorted({chk.get("column_name") for chk in library_checks if chk.get("column_name")})
+        rule_columns = sorted({chk.get("column_name") for chk in column_library_checks if chk.get("column_name")})
         filter_column = filter_col.selectbox(
             "Filter by column",
             options=["All"] + rule_columns,
             index=0,
             key="rule_filter_column",
         )
-        rule_codes = sorted({(chk.get("rule_code") or "").upper() for chk in library_checks if chk.get("rule_code")})
+        rule_codes = sorted({(chk.get("rule_code") or "").upper() for chk in column_library_checks if chk.get("rule_code")})
         filter_rule_code = filter_code.selectbox(
             "Filter by rule",
             options=["All"] + rule_codes,
             index=0,
             key="rule_filter_code",
         )
-        severities = sorted({(chk.get("severity") or chk.get("rule_severity") or "ERROR") for chk in library_checks})
+        severities = sorted({(chk.get("severity") or chk.get("rule_severity") or "ERROR") for chk in column_library_checks})
         filter_severity = filter_sev.selectbox(
             "Filter by severity",
             options=["All"] + severities,
@@ -1385,7 +1396,7 @@ def render_config_editor():
                 table_suggestions=table_suggestions,
                 column_lookup=column_lookup,
                 rule_templates=rule_templates,
-                existing_library_checks=library_checks,
+                existing_library_checks=column_library_checks,
                 key_prefix=st.session_state.get("rule_add_key", "add_rule"),
                 state_keys_to_clear=["rule_add_mode", "rule_add_key"],
                 config_id=active_config_id,
@@ -1479,22 +1490,34 @@ def render_config_editor():
         # -------- Form --------
         # Pre-populate table-level defaults from existing checks / state
         existing_table_params: Dict[str, Dict[str, Any]] = {}
-        existing_table_checks: Dict[str, DQCheck] = {}
+        existing_table_checks: Dict[str, Dict[str, Any]] = {}
         legacy_row_count_params: Dict[str, object] = {}
-        for ec in existing_checks:
-            if not ec.column_name and ec.params_json:
-                key = _rule_key(ec.check_type or "")
-                try:
-                    parsed_params = json.loads(ec.params_json)
-                except Exception:
-                    parsed_params = {}
+        for rule in table_library_checks:
+            key = _rule_key(
+                rule.get("rule_code")
+                or rule.get("rule_id")
+                or rule.get("check_type")
+                or ""
+            )
+            params = _parse_params(rule.get("rule_params") or rule.get("params_json"))
+            parsed_params = params if isinstance(params, dict) else {}
 
-                if key == "ROW_COUNT":
-                    legacy_row_count_params = parsed_params or {}
-                    continue
+            if key == "ROW_COUNT":
+                legacy_row_count_params = parsed_params or {}
+                continue
 
-                existing_table_params[key] = parsed_params or {}
-                existing_table_checks.setdefault(key, ec)
+            existing_table_params[key] = parsed_params or {}
+            existing_table_checks.setdefault(
+                key,
+                {
+                    "check_id": rule.get("check_id"),
+                    "severity": rule.get("severity")
+                    or rule.get("rule_severity")
+                    or "ERROR",
+                    "rule_code": rule.get("rule_code"),
+                    "rule_version": rule.get("rule_version") or rule.get("version"),
+                },
+            )
     
         freshness_key = _rule_key("FRESHNESS")
         rowcount_anomaly_key = _rule_key("ROW_COUNT_ANOMALY")
@@ -1648,15 +1671,36 @@ def render_config_editor():
                     except ValueError as exc:
                         table_check_error = f"Invalid freshness configuration: {exc}"
                     else:
-                        existing_freshness = existing_table_checks.get(freshness_key)
-                        check_rows.append(DQCheck(
-                            config_id=(cfg.config_id if cfg else "temp"),
-                            check_id=(existing_freshness.check_id if existing_freshness else "TABLE_FRESHNESS"),
-                            table_fqn=target_table, column_name=None,
-                            rule_expr=(f"AGG: {fr_rule}" if fr_is_agg else fr_rule), severity=(existing_freshness.severity if existing_freshness else "ERROR"),
-                            sample_rows=0, check_type=freshness_key,
-                            params_json=json.dumps(fr_params)
-                        ))
+                        existing_freshness = existing_table_checks.get(freshness_key) or {}
+                        fr_template = table_templates_by_key.get(freshness_key)
+                        check_rows.append(
+                            DQCheck(
+                                config_id=(cfg.config_id if cfg else "temp"),
+                                check_id=(
+                                    existing_freshness.get("check_id")
+                                    or "TABLE_FRESHNESS"
+                                ),
+                                table_fqn=target_table,
+                                column_name=None,
+                                rule_expr=(f"AGG: {fr_rule}" if fr_is_agg else fr_rule),
+                                severity=(
+                                    existing_freshness.get("severity")
+                                    or "ERROR"
+                                ),
+                                sample_rows=0,
+                                check_type=freshness_key,
+                                params_json=json.dumps(fr_params),
+                                rule_code=(
+                                    (existing_freshness.get("rule_code") or "").upper()
+                                    or (fr_template.rule_code if fr_template else None)
+                                ),
+                                rule_params=json.dumps(fr_params),
+                                rule_version=(
+                                    fr_template.version if fr_template else existing_freshness.get("rule_version")
+                                ),
+                                compiled_rule=(f"AGG: {fr_rule}" if fr_is_agg else fr_rule),
+                            )
+                        )
 
                 row_defaults = existing_table_params.get(rowcount_anomaly_key, {}) or {}
                 try:
@@ -1684,15 +1728,42 @@ def render_config_editor():
                 except ValueError as exc:
                     table_check_error = f"Invalid row count anomaly configuration: {exc}"
                 else:
-                    existing_anomaly = existing_table_checks.get(rowcount_anomaly_key)
-                    check_rows.append(DQCheck(
-                        config_id=(cfg.config_id if cfg else "temp"),
-                        check_id=(existing_anomaly.check_id if existing_anomaly else "TABLE_ROW_COUNT_ANOMALY"),
-                        table_fqn=target_table, column_name=None,
-                        rule_expr=(f"AGG: {anomaly_rule}" if anomaly_is_agg else anomaly_rule), severity=(existing_anomaly.severity if existing_anomaly else "ERROR"),
-                        sample_rows=0, check_type=rowcount_anomaly_key,
-                        params_json=json.dumps(anomaly_params)
-                    ))
+                    existing_anomaly = existing_table_checks.get(rowcount_anomaly_key) or {}
+                    anomaly_template = table_templates_by_key.get(rowcount_anomaly_key)
+                    check_rows.append(
+                        DQCheck(
+                            config_id=(cfg.config_id if cfg else "temp"),
+                            check_id=(
+                                existing_anomaly.get("check_id")
+                                or "TABLE_ROW_COUNT_ANOMALY"
+                            ),
+                            table_fqn=target_table,
+                            column_name=None,
+                            rule_expr=(
+                                f"AGG: {anomaly_rule}" if anomaly_is_agg else anomaly_rule
+                            ),
+                            severity=(
+                                existing_anomaly.get("severity")
+                                or "ERROR"
+                            ),
+                            sample_rows=0,
+                            check_type=rowcount_anomaly_key,
+                            params_json=json.dumps(anomaly_params),
+                            rule_code=(
+                                (existing_anomaly.get("rule_code") or "").upper()
+                                or (anomaly_template.rule_code if anomaly_template else None)
+                            ),
+                            rule_params=json.dumps(anomaly_params),
+                            rule_version=(
+                                anomaly_template.version
+                                if anomaly_template
+                                else existing_anomaly.get("rule_version")
+                            ),
+                            compiled_rule=(
+                                f"AGG: {anomaly_rule}" if anomaly_is_agg else anomaly_rule
+                            ),
+                        )
+                    )
     
             st.markdown("### Schedule")
             existing_cron = getattr(cfg, "schedule_cron", None) if cfg else None
@@ -1836,7 +1907,7 @@ def render_config_editor():
                     return
             # Preserve existing column-level rules and rebind to the active config
             existing_column_checks: List[DQCheck] = []
-            for rule in library_checks:
+            for rule in column_library_checks:
                 column_name = rule.get("column_name")
                 if not column_name:
                     continue

--- a/utils/meta.py
+++ b/utils/meta.py
@@ -398,13 +398,26 @@ def delete_config(session: Session, config_id: str):
     session.sql(f"DELETE FROM {_q(DQ_CONFIG_TBL)} WHERE CONFIG_ID = ?", params=[config_id]).collect()
 
 
-def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]:
-    """Load DQ_CHECK rows joined to the rule library for a config."""
+def get_library_checks(
+    session: Session, config_id: str, *, scope: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Load DQ_CHECK rows joined to the rule library for a config.
+
+    Optionally filters by rule scope (TABLE/COLUMN) to keep table-level
+    checks out of the rule grid while still allowing dedicated loading for
+    the configuration header.
+    """
 
     if not session or not config_id:
         return []
 
     rule_table = _q(f"{METADATA_DB}.{METADATA_SCHEMA}.DQ_RULE_LIBRARY")
+    scope_clause = ""
+    params = [config_id]
+    if scope:
+        scope_clause = " AND COALESCE(UPPER(r.SCOPE), '') = UPPER(?)"
+        params.append(scope)
+
     df = session.sql(
         f"""
         SELECT
@@ -431,9 +444,9 @@ def get_library_checks(session: Session, config_id: str) -> List[Dict[str, Any]]
         FROM {_q(DQ_CHECK_TBL)} c
         LEFT JOIN {rule_table} r
           ON c.RULE_CODE = r.RULE_CODE
-        WHERE c.CONFIG_ID = ?
+        WHERE c.CONFIG_ID = ?{scope_clause}
         """,
-        params=[config_id],
+        params=params,
     )
     out: List[Dict[str, Any]] = []
     for row in df.collect():
@@ -526,23 +539,112 @@ def delete_check_by_id(session: Session, check_id: str):
     ).collect()
 
 def upsert_checks(session: Session, checks: List[DQCheck]):
-    if not session or not checks: return
+    if not session or not checks:
+        return
+
     ensure_meta_tables(session)
     cfg_id = checks[0].config_id
-    session.sql(f"DELETE FROM {_q(DQ_CHECK_TBL)} WHERE CONFIG_ID = ?", params=[cfg_id]).collect()
+
+    existing_df = session.sql(
+        f"""
+        SELECT CHECK_ID, COLUMN_NAME, RULE_CODE, CHECK_TYPE
+        FROM {_q(DQ_CHECK_TBL)}
+        WHERE CONFIG_ID = ?
+        """,
+        params=[cfg_id],
+    )
+    existing_map: Dict[Tuple[str, str], str] = {}
+    for row in existing_df.collect():
+        norm_col = (row["COLUMN_NAME"] or "").upper()
+        norm_rule = (row["RULE_CODE"] or row["CHECK_TYPE"] or "").upper()
+        existing_map[(norm_col, norm_rule)] = row["CHECK_ID"]
+
+    seen_ids: set[str] = set()
+
     for c in checks:
-        session.sql(f"""
-            INSERT INTO {_q(DQ_CHECK_TBL)} (
-              CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY,
-              SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON, RULE_CODE, RULE_PARAMS,
-              RULE_VERSION, COMPILED_RULE
-            )
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-        """, params=[
-            c.config_id, c.check_id, c.table_fqn, c.column_name, c.rule_expr,
-            c.severity, int(c.sample_rows), c.check_type, c.params_json,
-            c.rule_code, c.rule_params, c.rule_version, c.compiled_rule
-        ]).collect()
+        norm_col = (c.column_name or "").upper()
+        norm_rule = (c.rule_code or c.check_type or "").upper()
+        serialized_params = c.rule_params
+        if isinstance(serialized_params, dict):
+            serialized_params = json.dumps(serialized_params, default=str)
+        params_json = c.params_json
+        if isinstance(params_json, dict):
+            params_json = json.dumps(params_json, default=str)
+        serialized_params = serialized_params or params_json
+
+        existing_id = existing_map.get((norm_col, norm_rule))
+        check_id = existing_id or c.check_id or str(uuid4())
+        seen_ids.add(check_id)
+
+        if existing_id:
+            session.sql(
+                f"""
+                UPDATE {_q(DQ_CHECK_TBL)}
+                SET TABLE_FQN = :1,
+                    RULE_EXPR = :2,
+                    SEVERITY = :3,
+                    SAMPLE_ROWS = :4,
+                    CHECK_TYPE = :5,
+                    PARAMS_JSON = :6,
+                    RULE_CODE = :7,
+                    RULE_PARAMS = :8,
+                    RULE_VERSION = :9,
+                    COMPILED_RULE = :10,
+                    UPDATED_AT = CURRENT_TIMESTAMP()
+                WHERE CHECK_ID = :11
+                  AND CONFIG_ID = :12
+                """,
+                params=[
+                    c.table_fqn,
+                    c.rule_expr,
+                    c.severity,
+                    int(c.sample_rows),
+                    c.check_type,
+                    params_json,
+                    c.rule_code,
+                    serialized_params,
+                    c.rule_version,
+                    c.compiled_rule,
+                    check_id,
+                    cfg_id,
+                ],
+            ).collect()
+        else:
+            session.sql(
+                f"""
+                INSERT INTO {_q(DQ_CHECK_TBL)} (
+                  CONFIG_ID, CHECK_ID, TABLE_FQN, COLUMN_NAME, RULE_EXPR, SEVERITY,
+                  SAMPLE_ROWS, CHECK_TYPE, PARAMS_JSON, RULE_CODE, RULE_PARAMS,
+                  RULE_VERSION, COMPILED_RULE, UPDATED_AT
+                )
+                SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP()
+                """,
+                params=[
+                    c.config_id,
+                    check_id,
+                    c.table_fqn,
+                    c.column_name,
+                    c.rule_expr,
+                    c.severity,
+                    int(c.sample_rows),
+                    c.check_type,
+                    params_json,
+                    c.rule_code,
+                    serialized_params,
+                    c.rule_version,
+                    c.compiled_rule,
+                ],
+            ).collect()
+
+    if seen_ids:
+        session.sql(
+            f"""
+            DELETE FROM {_q(DQ_CHECK_TBL)}
+            WHERE CONFIG_ID = :1
+              AND CHECK_ID NOT IN ({', '.join(['?' for _ in seen_ids])})
+            """,
+            params=[cfg_id, *seen_ids],
+        ).collect()
 
 def get_checks(session: Session, config_id: str) -> List[DQCheck]:
     if not session: return []


### PR DESCRIPTION
- Filter rule grid data to column-scoped checks while loading table-scope rules separately for header defaults.
- Populate freshness and row count header controls from table-scoped DQ_CHECK entries using rule parameters.
- Upsert DQ_CHECK rows by rule scope/column to avoid duplicating table-level checks when saving configurations.
- Refresh snapshot mirrors after code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7c3ece5c832480dc0b61cc5f7687)