### PR TITLE
Fix table-level check reset parameter binding

### DIFF
--- a/dq_config_view.py
+++ b/dq_config_view.py
@@ -132,7 +132,7 @@ def _reset_table_level_checks(
             WHERE CONFIG_ID = :config_id
               AND COLUMN_NAME IS NULL
             """,
-            params={"config_id": config_id},
+            params=[{"config_id": config_id}],
         ).collect()
     except Exception as exc:
         logging.exception(
@@ -181,7 +181,7 @@ def _reset_table_level_checks(
                 WHERE r.RULE_CODE = :rule_code
                   AND COALESCE(UPPER(r.SCOPE), 'TABLE') = 'TABLE'
                 """,
-                params=payload,
+                params=[payload],
             ).collect()
         except Exception as exc:
             logging.exception(

--- a/snapshots/dq_config_view.p
+++ b/snapshots/dq_config_view.p
@@ -132,7 +132,7 @@ def _reset_table_level_checks(
             WHERE CONFIG_ID = :config_id
               AND COLUMN_NAME IS NULL
             """,
-            params={"config_id": config_id},
+            params=[{"config_id": config_id}],
         ).collect()
     except Exception as exc:
         logging.exception(
@@ -181,7 +181,7 @@ def _reset_table_level_checks(
                 WHERE r.RULE_CODE = :rule_code
                   AND COALESCE(UPPER(r.SCOPE), 'TABLE') = 'TABLE'
                 """,
-                params=payload,
+                params=[payload],
             ).collect()
         except Exception as exc:
             logging.exception(


### PR DESCRIPTION
- Pass Snowpark parameters as lists when resetting table-level checks to satisfy binding requirements.
- Mirror updated dq_config_view snapshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ada2ed4288324bd81e86507668207)