### PR TITLE
DQ-MONITOR-V3-SKELETON

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -29,7 +29,7 @@ logging.getLogger("snowflake").setLevel(logging.WARNING)
 
 from typing import Dict, List, Optional
 
-ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs", "rules"}
+ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "monitor_v3", "docs", "rules"}
 
 if st.session_state["_rerun_count"] == 1:
     logging.info("route:init %s", current_view)
@@ -76,6 +76,7 @@ from utils.flags import DEBUG_PROFILING
 from utils.meta import _q, list_configs
 from utils.version import build_sha, build_time
 from views.docs_view import render_docs as render_docs_view
+from views.monitor_v3_view import render_monitor_v3
 from views.profile_view import render_profile as render_profiling_view
 from views.rule_admin_view import render_rule_admin
 
@@ -525,6 +526,14 @@ with st.sidebar:
         args=("monitor",),
     )
     st.button(
+        "📈 DQ Monitor v3",
+        use_container_width=True,
+        type="primary" if view == "monitor_v3" else "secondary",
+        key="nav_monitor_v3",
+        on_click=navigate_to,
+        args=("monitor_v3",),
+    )
+    st.button(
         "DQ Rule Library",
         use_container_width=True,
         type="primary" if view == "rules" else "secondary",
@@ -570,6 +579,8 @@ elif view == "profile":
     render_profiling_view(session, METADATA_DB, METADATA_SCHEMA, profiling_v2)
 elif view == "monitor":
     render_monitor()
+elif view == "monitor_v3":
+    render_monitor_v3(session)
 elif view == "rules":
     render_rule_admin(session, METADATA_DB, METADATA_SCHEMA)
 elif view == "docs":

--- a/snapshots/views/monitor_v3_view.p
+++ b/snapshots/views/monitor_v3_view.p
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import streamlit as st
+
+from views.table_picker import stateless_table_picker
+
+
+def render_monitor_v3(session):
+    """Render the scaffolding for the Monitor v3 dashboard."""
+
+    st.header("📈 DQ Monitor v3")
+    st.caption("Early preview of the upcoming monitoring dashboard.")
+
+    today = date.today()
+    default_start = today - timedelta(days=7)
+
+    filters = st.columns([2, 1.2, 1.2, 1])
+    with filters[0]:
+        st.date_input("Date range", value=(default_start, today))
+    with filters[1]:
+        st.selectbox(
+            "Schema",
+            ["All schemas", "PUBLIC", "ANALYTICS", "RAW"],
+            key="monitor_v3_schema_filter",
+        )
+    with filters[2]:
+        st.selectbox(
+            "Table",
+            ["All tables", "ORDERS", "CUSTOMERS", "INVOICES"],
+            key="monitor_v3_table_filter",
+        )
+    with filters[3]:
+        st.selectbox(
+            "Rule category",
+            [
+                "All categories",
+                "Freshness",
+                "Completeness",
+                "Validity",
+                "Anomaly detection",
+            ],
+            key="monitor_v3_rule_category",
+        )
+
+    st.text_input("Search", placeholder="Search tables, columns, or rules", key="monitor_v3_search")
+
+    st.divider()
+
+    metrics = st.columns(4)
+    metrics[0].metric("Pass Rate", "—")
+    metrics[1].metric("Failed Checks", "—")
+    metrics[2].metric("Critical Issues", "—")
+    metrics[3].metric("Average DQ Score", "—")
+
+    st.divider()
+
+    st.subheader("Heatmap")
+    st.empty().write("Heatmap placeholder")
+
+    st.subheader("Trend")
+    trend_data = pd.DataFrame(
+        {
+            "Date": pd.date_range(end=today, periods=7),
+            "Failures": [5, 3, 6, 2, 4, 1, 3],
+        }
+    )
+    st.line_chart(trend_data.set_index("Date"))
+
+    st.subheader("Top failing checks")
+    top_failing = pd.DataFrame(
+        {
+            "Rule": ["Null count", "Freshness", "Row count", "Format distribution"],
+            "Failures": [23, 17, 12, 9],
+        }
+    )
+    st.bar_chart(top_failing.set_index("Rule"))
+
+    st.subheader("Rule outcomes")
+    outcome_placeholder = st.empty()
+    outcome_placeholder.write("Pie chart placeholder")
+
+    st.divider()
+    st.subheader("Drill-down")
+
+    st.caption("Table and column filters use the stateless picker pattern from Profiling v2.")
+    stateless_table_picker(session, None, disabled=not session)
+
+    drilldown_df = pd.DataFrame(
+        {
+            "Table": ["ORDERS", "CUSTOMERS", "PAYMENTS"],
+            "Column": ["ORDER_ID", "EMAIL", "AMOUNT"],
+            "Rule": ["Uniqueness", "Format", "Min/Max"],
+            "Status": ["Failed", "Failed", "Passed"],
+            "Failures": [5, 12, 0],
+            "Timestamp": pd.date_range(end=today, periods=3, freq="12H"),
+        }
+    )
+    st.dataframe(
+        drilldown_df,
+        use_container_width=True,
+        hide_index=True,
+    )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -29,7 +29,7 @@ logging.getLogger("snowflake").setLevel(logging.WARNING)
 
 from typing import Dict, List, Optional
 
-ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "docs", "rules"}
+ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "monitor_v3", "docs", "rules"}
 
 if st.session_state["_rerun_count"] == 1:
     logging.info("route:init %s", current_view)
@@ -76,6 +76,7 @@ from utils.flags import DEBUG_PROFILING
 from utils.meta import _q, list_configs
 from utils.version import build_sha, build_time
 from views.docs_view import render_docs as render_docs_view
+from views.monitor_v3_view import render_monitor_v3
 from views.profile_view import render_profile as render_profiling_view
 from views.rule_admin_view import render_rule_admin
 
@@ -525,6 +526,14 @@ with st.sidebar:
         args=("monitor",),
     )
     st.button(
+        "📈 DQ Monitor v3",
+        use_container_width=True,
+        type="primary" if view == "monitor_v3" else "secondary",
+        key="nav_monitor_v3",
+        on_click=navigate_to,
+        args=("monitor_v3",),
+    )
+    st.button(
         "DQ Rule Library",
         use_container_width=True,
         type="primary" if view == "rules" else "secondary",
@@ -570,6 +579,8 @@ elif view == "profile":
     render_profiling_view(session, METADATA_DB, METADATA_SCHEMA, profiling_v2)
 elif view == "monitor":
     render_monitor()
+elif view == "monitor_v3":
+    render_monitor_v3(session)
 elif view == "rules":
     render_rule_admin(session, METADATA_DB, METADATA_SCHEMA)
 elif view == "docs":

--- a/views/monitor_v3_view.py
+++ b/views/monitor_v3_view.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import streamlit as st
+
+from views.table_picker import stateless_table_picker
+
+
+def render_monitor_v3(session):
+    """Render the scaffolding for the Monitor v3 dashboard."""
+
+    st.header("📈 DQ Monitor v3")
+    st.caption("Early preview of the upcoming monitoring dashboard.")
+
+    today = date.today()
+    default_start = today - timedelta(days=7)
+
+    filters = st.columns([2, 1.2, 1.2, 1])
+    with filters[0]:
+        st.date_input("Date range", value=(default_start, today))
+    with filters[1]:
+        st.selectbox(
+            "Schema",
+            ["All schemas", "PUBLIC", "ANALYTICS", "RAW"],
+            key="monitor_v3_schema_filter",
+        )
+    with filters[2]:
+        st.selectbox(
+            "Table",
+            ["All tables", "ORDERS", "CUSTOMERS", "INVOICES"],
+            key="monitor_v3_table_filter",
+        )
+    with filters[3]:
+        st.selectbox(
+            "Rule category",
+            [
+                "All categories",
+                "Freshness",
+                "Completeness",
+                "Validity",
+                "Anomaly detection",
+            ],
+            key="monitor_v3_rule_category",
+        )
+
+    st.text_input("Search", placeholder="Search tables, columns, or rules", key="monitor_v3_search")
+
+    st.divider()
+
+    metrics = st.columns(4)
+    metrics[0].metric("Pass Rate", "—")
+    metrics[1].metric("Failed Checks", "—")
+    metrics[2].metric("Critical Issues", "—")
+    metrics[3].metric("Average DQ Score", "—")
+
+    st.divider()
+
+    st.subheader("Heatmap")
+    st.empty().write("Heatmap placeholder")
+
+    st.subheader("Trend")
+    trend_data = pd.DataFrame(
+        {
+            "Date": pd.date_range(end=today, periods=7),
+            "Failures": [5, 3, 6, 2, 4, 1, 3],
+        }
+    )
+    st.line_chart(trend_data.set_index("Date"))
+
+    st.subheader("Top failing checks")
+    top_failing = pd.DataFrame(
+        {
+            "Rule": ["Null count", "Freshness", "Row count", "Format distribution"],
+            "Failures": [23, 17, 12, 9],
+        }
+    )
+    st.bar_chart(top_failing.set_index("Rule"))
+
+    st.subheader("Rule outcomes")
+    outcome_placeholder = st.empty()
+    outcome_placeholder.write("Pie chart placeholder")
+
+    st.divider()
+    st.subheader("Drill-down")
+
+    st.caption("Table and column filters use the stateless picker pattern from Profiling v2.")
+    stateless_table_picker(session, None, disabled=not session)
+
+    drilldown_df = pd.DataFrame(
+        {
+            "Table": ["ORDERS", "CUSTOMERS", "PAYMENTS"],
+            "Column": ["ORDER_ID", "EMAIL", "AMOUNT"],
+            "Rule": ["Uniqueness", "Format", "Min/Max"],
+            "Status": ["Failed", "Failed", "Passed"],
+            "Failures": [5, 12, 0],
+            "Timestamp": pd.date_range(end=today, periods=3, freq="12H"),
+        }
+    )
+    st.dataframe(
+        drilldown_df,
+        use_container_width=True,
+        hide_index=True,
+    )


### PR DESCRIPTION
- Added Monitor v3 Streamlit page with placeholder filters, metrics, and drill-down content.
- Added sidebar navigation entry and routing for the new Monitor v3 view.
- Mirrored updated Python snapshots for the new dashboard scaffold.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af2e452588324a0d16b43f6c8f189)