### PR TITLE
Add matplotlib runtime dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Runtime dependencies for the Streamlit application
+pandas
+streamlit
+jinja2
+altair
+matplotlib


### PR DESCRIPTION
- add a runtime requirements.txt capturing Streamlit dependencies including matplotlib
- ensure deployment environments install matplotlib alongside other app libraries

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af71478608324b49148c5d1b49f15)