### PR TITLE
Codex Task PROF-FEAT-1 — Restore profiling feature persistence to DQ_COLUMN_FEATURES

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -78,6 +78,28 @@ def _friendly_error_message(exc: Exception) -> str:
     return message
 
 
+def _require_feature_rows(session: Any, table_fqn: str) -> None:
+    """Ensure column features were written for *table_fqn*.
+
+    Raises :class:`ProfilingError` when no feature rows exist so the UI can
+    surface actionable feedback instead of silently succeeding.
+    """
+
+    sql = f"SELECT COUNT(*) AS ROW_COUNT FROM {COLUMN_FEATURES_TABLE} WHERE TABLE_FQN = ?"
+    counts = _fetch_dataframe(session, sql, params=[table_fqn])
+    feature_count = int(counts.iloc[0]["ROW_COUNT"]) if not counts.empty else 0
+    if feature_count <= 0:
+        message = (
+            "Profiling completed but no feature rows were persisted. "
+            "Ensure the table exists, contains readable columns, and that "
+            "your role has SELECT privileges."
+        )
+        LOGGER.warning(
+            "profiling_v2:no_features_persisted target=%s", table_fqn
+        )
+        raise ProfilingError(message)
+
+
 def run_profiling_v2(session: Any, table_fqn: str) -> None:
     """Execute the Profiling v2 stored procedure for *table_fqn*."""
 
@@ -88,6 +110,7 @@ def run_profiling_v2(session: Any, table_fqn: str) -> None:
     LOGGER.info("profiling_v2:call proc target=%s", normalized)
     try:
         _execute_sql(session, f"CALL {PROFILE_PROC}(?)", params=[normalized]).collect()
+        _require_feature_rows(session, normalized)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:proc_failed target=%s", normalized)

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -78,6 +78,28 @@ def _friendly_error_message(exc: Exception) -> str:
     return message
 
 
+def _require_feature_rows(session: Any, table_fqn: str) -> None:
+    """Ensure column features were written for *table_fqn*.
+
+    Raises :class:`ProfilingError` when no feature rows exist so the UI can
+    surface actionable feedback instead of silently succeeding.
+    """
+
+    sql = f"SELECT COUNT(*) AS ROW_COUNT FROM {COLUMN_FEATURES_TABLE} WHERE TABLE_FQN = ?"
+    counts = _fetch_dataframe(session, sql, params=[table_fqn])
+    feature_count = int(counts.iloc[0]["ROW_COUNT"]) if not counts.empty else 0
+    if feature_count <= 0:
+        message = (
+            "Profiling completed but no feature rows were persisted. "
+            "Ensure the table exists, contains readable columns, and that "
+            "your role has SELECT privileges."
+        )
+        LOGGER.warning(
+            "profiling_v2:no_features_persisted target=%s", table_fqn
+        )
+        raise ProfilingError(message)
+
+
 def run_profiling_v2(session: Any, table_fqn: str) -> None:
     """Execute the Profiling v2 stored procedure for *table_fqn*."""
 
@@ -88,6 +110,7 @@ def run_profiling_v2(session: Any, table_fqn: str) -> None:
     LOGGER.info("profiling_v2:call proc target=%s", normalized)
     try:
         _execute_sql(session, f"CALL {PROFILE_PROC}(?)", params=[normalized]).collect()
+        _require_feature_rows(session, normalized)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:proc_failed target=%s", normalized)

--- a/snapshots/ui/strings.p
+++ b/snapshots/ui/strings.p
@@ -20,6 +20,10 @@ PROFILE_V2_LOAD_SPINNER = "Loading profiling metadata..."
 PROFILE_V2_RUN_SPINNER = "Running DQ_PROFILE_FULL for {table}..."
 PROFILE_V2_RUN_ERROR = "Failed to profile table: {error}"
 PROFILE_V2_RUN_SUCCESS = "Profiling completed for {table}."
+PROFILE_V2_NO_FEATURES = (
+    "Profiling completed but no column metrics were saved for {table}. "
+    "Ensure the table exists, has columns, and that your role can SELECT it."
+)
 PROFILE_V2_CLASSIFY_SPINNER = "Re-running classification for {table}..."
 PROFILE_V2_CLASSIFY_ERROR = "Classification run failed: {error}"
 PROFILE_V2_CLASSIFY_SUCCESS = "Classification completed for {table}."

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -1011,13 +1011,32 @@ def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, 
         }
 
     with st.spinner(ui_strings.PROFILE_V2_RUN_SPINNER.format(table=table_fqn)):
-        run_fn(session, table_fqn)
+        try:
+            run_fn(session, table_fqn)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            logging.exception("profiling:run_failed")
+            return {
+                "ok": False,
+                "summary": None,
+                "column_rows": [],
+                "err": ui_strings.PROFILE_V2_RUN_ERROR.format(error=str(exc)),
+            }
 
     summary = summary_fn(session, table_fqn) if callable(summary_fn) else None
     overview = overview_fn(session, table_fqn) if callable(overview_fn) else pd.DataFrame()
     column_rows = (
         overview.to_dict("records") if isinstance(overview, pd.DataFrame) else []
     )
+
+    if isinstance(overview, pd.DataFrame) and overview.empty:
+        warning = ui_strings.PROFILE_V2_NO_FEATURES.format(table=table_fqn)
+        logging.warning("profiling:no_features target=%s", table_fqn)
+        return {
+            "ok": False,
+            "summary": summary,
+            "column_rows": [],
+            "err": warning,
+        }
     return {
         "ok": True,
         "summary": summary,

--- a/sql/DQ_PROFILE_FULL.sql
+++ b/sql/DQ_PROFILE_FULL.sql
@@ -30,6 +30,7 @@ DECLARE
     v_details STRING := NULL;
     v_profile_run_id NUMBER := NULL;
     v_feature_sql STRING := '';
+    v_feature_count NUMBER := 0;
     v_is_string BOOLEAN;
     v_col_ident STRING;
     v_union_prefix STRING := '';
@@ -200,6 +201,16 @@ BEGIN
         v_union_prefix := CHR(10) || 'UNION ALL';
     END FOR;
   
+    IF (:v_feature_sql = '') THEN
+        v_details := 'No columns found to profile for ' || :v_table_fqn;
+        RAISE STATEMENT_ERROR WITH MESSAGE = v_details;
+    END IF;
+
+    EXECUTE IMMEDIATE
+        'DELETE FROM ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_COLUMN_FEATURES
+         WHERE TABLE_FQN = ?'
+        USING (:v_table_fqn);
+
     EXECUTE IMMEDIATE 'INSERT INTO ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_COLUMN_FEATURES (
             PROFILE_RUN_ID,
             DATABASE_NAME,
@@ -221,6 +232,19 @@ BEGIN
             CREATED_AT,
             UPDATED_AT
         ) ' || v_feature_sql;
+
+    EXECUTE IMMEDIATE
+        'SELECT COUNT(*)
+           FROM ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_COLUMN_FEATURES
+          WHERE TABLE_FQN = ?'
+        INTO :v_feature_count
+        USING (:v_table_fqn);
+
+    IF (:v_feature_count = 0) THEN
+        v_details := 'Profiling completed but no feature rows were persisted for '
+                     || :v_table_fqn;
+        RAISE STATEMENT_ERROR WITH MESSAGE = v_details;
+    END IF;
 
     v_finished_at := CURRENT_TIMESTAMP();
     v_status := 'SUCCESS';

--- a/ui/strings.py
+++ b/ui/strings.py
@@ -20,6 +20,10 @@ PROFILE_V2_LOAD_SPINNER = "Loading profiling metadata..."
 PROFILE_V2_RUN_SPINNER = "Running DQ_PROFILE_FULL for {table}..."
 PROFILE_V2_RUN_ERROR = "Failed to profile table: {error}"
 PROFILE_V2_RUN_SUCCESS = "Profiling completed for {table}."
+PROFILE_V2_NO_FEATURES = (
+    "Profiling completed but no column metrics were saved for {table}. "
+    "Ensure the table exists, has columns, and that your role can SELECT it."
+)
 PROFILE_V2_CLASSIFY_SPINNER = "Re-running classification for {table}..."
 PROFILE_V2_CLASSIFY_ERROR = "Classification run failed: {error}"
 PROFILE_V2_CLASSIFY_SUCCESS = "Classification completed for {table}."

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1011,13 +1011,32 @@ def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, 
         }
 
     with st.spinner(ui_strings.PROFILE_V2_RUN_SPINNER.format(table=table_fqn)):
-        run_fn(session, table_fqn)
+        try:
+            run_fn(session, table_fqn)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            logging.exception("profiling:run_failed")
+            return {
+                "ok": False,
+                "summary": None,
+                "column_rows": [],
+                "err": ui_strings.PROFILE_V2_RUN_ERROR.format(error=str(exc)),
+            }
 
     summary = summary_fn(session, table_fqn) if callable(summary_fn) else None
     overview = overview_fn(session, table_fqn) if callable(overview_fn) else pd.DataFrame()
     column_rows = (
         overview.to_dict("records") if isinstance(overview, pd.DataFrame) else []
     )
+
+    if isinstance(overview, pd.DataFrame) and overview.empty:
+        warning = ui_strings.PROFILE_V2_NO_FEATURES.format(table=table_fqn)
+        logging.warning("profiling:no_features target=%s", table_fqn)
+        return {
+            "ok": False,
+            "summary": summary,
+            "column_rows": [],
+            "err": warning,
+        }
     return {
         "ok": True,
         "summary": summary,


### PR DESCRIPTION
- Ensure DQ_PROFILE_FULL clears prior column features, validates insert counts, and raises when nothing persists
- Verify profiling writes feature rows from the Python helper and log failures
- Surface clear Streamlit messaging when profiling yields no column metrics

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c0f8de5e0832484b7c6c0397ef091)