### PR TITLE
Codex Task UI-PROF-REWIRE-1 — Make profiling screen read DQ_COLUMN_FEATURES as the primary dataset

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -454,7 +454,7 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         SELECT *
         FROM {COLUMN_FEATURES_TABLE}
         WHERE TABLE_FQN = ?
-        ORDER BY COLUMN_NAME
+        ORDER BY ORDINAL_POSITION
     """
     try:
         df = _fetch_dataframe(session, sql, params=[normalized])
@@ -677,16 +677,48 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         except Exception:
             return str(value)
 
-    features = _latest_column_features(
-        _normalize_dataframe_columns(get_column_features(session, normalized))
+    classification_cte = f"""
+        SELECT *
+        FROM {COLUMN_CLASSIFICATION_TABLE}
+        WHERE TABLE_FQN = ?
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY TABLE_FQN, COLUMN_NAME
+            ORDER BY UPDATED_AT DESC NULLS LAST
+        ) = 1
+    """
+
+    features_sql = f"""
+        WITH class_dedup AS (
+            {classification_cte}
+        )
+        SELECT f.*, c.CONTENT_TYPE, c.SEMANTIC_ROLE, c.SOURCE, c.CONFIDENCE, c.CLASSIFIED_AT
+        FROM {COLUMN_FEATURES_TABLE} f
+        LEFT JOIN class_dedup c
+          ON f.TABLE_FQN = c.TABLE_FQN
+         AND f.COLUMN_NAME = c.COLUMN_NAME
+        WHERE f.TABLE_FQN = ?
+        ORDER BY f.ORDINAL_POSITION
+    """
+
+    features = _normalize_dataframe_columns(
+        _fetch_dataframe(session, features_sql, params=[normalized, normalized])
     )
+    classification = _normalize_dataframe_columns(
+        _fetch_dataframe(session, classification_cte, params=[normalized])
+    )
+    feature_row_count = len(features)
+    classification_row_count = len(classification)
+
     if features.empty:
-        return pd.DataFrame(columns=overview_columns)
+        empty_df = pd.DataFrame(columns=overview_columns)
+        empty_df.attrs["dq_debug_counts"] = {
+            "feature_row_count": feature_row_count,
+            "classification_row_count": classification_row_count,
+            "columns_rendered": 0,
+        }
+        return empty_df
 
     suggestions = _normalize_dataframe_columns(get_suggested_checks(session, normalized))
-    classification = _normalize_dataframe_columns(
-        get_column_classification(session, normalized)
-    )
 
     suggestion_lookup: Dict[str, Dict[str, Any]] = {}
     if not suggestions.empty and "COLUMN_NAME" in suggestions.columns:
@@ -753,6 +785,11 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         )
 
     overview = pd.DataFrame.from_records(overview_rows, columns=overview_columns)
+    overview.attrs["dq_debug_counts"] = {
+        "feature_row_count": feature_row_count,
+        "classification_row_count": classification_row_count,
+        "columns_rendered": len(overview_rows),
+    }
     return overview
 
 

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -454,7 +454,7 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         SELECT *
         FROM {COLUMN_FEATURES_TABLE}
         WHERE TABLE_FQN = ?
-        ORDER BY COLUMN_NAME
+        ORDER BY ORDINAL_POSITION
     """
     try:
         df = _fetch_dataframe(session, sql, params=[normalized])
@@ -677,16 +677,48 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         except Exception:
             return str(value)
 
-    features = _latest_column_features(
-        _normalize_dataframe_columns(get_column_features(session, normalized))
+    classification_cte = f"""
+        SELECT *
+        FROM {COLUMN_CLASSIFICATION_TABLE}
+        WHERE TABLE_FQN = ?
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY TABLE_FQN, COLUMN_NAME
+            ORDER BY UPDATED_AT DESC NULLS LAST
+        ) = 1
+    """
+
+    features_sql = f"""
+        WITH class_dedup AS (
+            {classification_cte}
+        )
+        SELECT f.*, c.CONTENT_TYPE, c.SEMANTIC_ROLE, c.SOURCE, c.CONFIDENCE, c.CLASSIFIED_AT
+        FROM {COLUMN_FEATURES_TABLE} f
+        LEFT JOIN class_dedup c
+          ON f.TABLE_FQN = c.TABLE_FQN
+         AND f.COLUMN_NAME = c.COLUMN_NAME
+        WHERE f.TABLE_FQN = ?
+        ORDER BY f.ORDINAL_POSITION
+    """
+
+    features = _normalize_dataframe_columns(
+        _fetch_dataframe(session, features_sql, params=[normalized, normalized])
     )
+    classification = _normalize_dataframe_columns(
+        _fetch_dataframe(session, classification_cte, params=[normalized])
+    )
+    feature_row_count = len(features)
+    classification_row_count = len(classification)
+
     if features.empty:
-        return pd.DataFrame(columns=overview_columns)
+        empty_df = pd.DataFrame(columns=overview_columns)
+        empty_df.attrs["dq_debug_counts"] = {
+            "feature_row_count": feature_row_count,
+            "classification_row_count": classification_row_count,
+            "columns_rendered": 0,
+        }
+        return empty_df
 
     suggestions = _normalize_dataframe_columns(get_suggested_checks(session, normalized))
-    classification = _normalize_dataframe_columns(
-        get_column_classification(session, normalized)
-    )
 
     suggestion_lookup: Dict[str, Dict[str, Any]] = {}
     if not suggestions.empty and "COLUMN_NAME" in suggestions.columns:
@@ -753,6 +785,11 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         )
 
     overview = pd.DataFrame.from_records(overview_rows, columns=overview_columns)
+    overview.attrs["dq_debug_counts"] = {
+        "feature_row_count": feature_row_count,
+        "classification_row_count": classification_row_count,
+        "columns_rendered": len(overview_rows),
+    }
     return overview
 
 

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -637,6 +637,28 @@ def _render_suggest_config_action(
     _render_suggest_config_summary(summary or {}, table_fqn, config_name)
 
 
+def _render_overview_debug(overview: pd.DataFrame) -> None:
+    debug_counts = {}
+    if isinstance(overview, pd.DataFrame):
+        debug_counts = overview.attrs.get("dq_debug_counts", {}) or {}
+
+    feature_count = debug_counts.get("feature_row_count")
+    classification_count = debug_counts.get("classification_row_count")
+    rendered_count = debug_counts.get("columns_rendered")
+
+    with st.expander("Profiling debug", expanded=False):
+        st.caption("Profiling grid source counts")
+        st.text(f"feature_row_count: {feature_count if feature_count is not None else 0}")
+        st.text(
+            "classification_row_count: "
+            f"{classification_count if classification_count is not None else 0}"
+        )
+        fallback_rendered = len(overview) if isinstance(overview, pd.DataFrame) else 0
+        st.text(
+            f"columns_rendered: {rendered_count if rendered_count is not None else fallback_rendered}"
+        )
+
+
 def _suggestion_selection_key(
     table_fqn: str, column_name: str, rule_id: Any, check_type: Any
 ) -> str:
@@ -1341,6 +1363,7 @@ def render_profile(
     )
 
     with tab_overview:
+        _render_overview_debug(overview_grid)
         _render_suggest_config_action(
             overview_grid,
             target_fqn,

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -637,6 +637,28 @@ def _render_suggest_config_action(
     _render_suggest_config_summary(summary or {}, table_fqn, config_name)
 
 
+def _render_overview_debug(overview: pd.DataFrame) -> None:
+    debug_counts = {}
+    if isinstance(overview, pd.DataFrame):
+        debug_counts = overview.attrs.get("dq_debug_counts", {}) or {}
+
+    feature_count = debug_counts.get("feature_row_count")
+    classification_count = debug_counts.get("classification_row_count")
+    rendered_count = debug_counts.get("columns_rendered")
+
+    with st.expander("Profiling debug", expanded=False):
+        st.caption("Profiling grid source counts")
+        st.text(f"feature_row_count: {feature_count if feature_count is not None else 0}")
+        st.text(
+            "classification_row_count: "
+            f"{classification_count if classification_count is not None else 0}"
+        )
+        fallback_rendered = len(overview) if isinstance(overview, pd.DataFrame) else 0
+        st.text(
+            f"columns_rendered: {rendered_count if rendered_count is not None else fallback_rendered}"
+        )
+
+
 def _suggestion_selection_key(
     table_fqn: str, column_name: str, rule_id: Any, check_type: Any
 ) -> str:
@@ -1341,6 +1363,7 @@ def render_profile(
     )
 
     with tab_overview:
+        _render_overview_debug(overview_grid)
         _render_suggest_config_action(
             overview_grid,
             target_fqn,


### PR DESCRIPTION
- Build the profiling overview grid directly from DQ_COLUMN_FEATURES with optional deduped classification enrichment and preserve all columns.
- Add debug metadata for profiling counts and expose a compact debug expander in the UI.
- Mirror updated Python sources into the snapshots directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408a41600c8324b4d1c0b3f04cb87e)