### PR TITLE
Fix profiling classification dedupe ordering

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -681,7 +681,7 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         QUALIFY ROW_NUMBER() OVER (
             PARTITION BY TABLE_FQN, COLUMN_NAME
-            ORDER BY UPDATED_AT DESC NULLS LAST
+            ORDER BY CLASSIFIED_AT DESC NULLS LAST
         ) = 1
     """
 

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -681,7 +681,7 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         WHERE TABLE_FQN = ?
         QUALIFY ROW_NUMBER() OVER (
             PARTITION BY TABLE_FQN, COLUMN_NAME
-            ORDER BY UPDATED_AT DESC NULLS LAST
+            ORDER BY CLASSIFIED_AT DESC NULLS LAST
         ) = 1
     """
 


### PR DESCRIPTION
- Order latest column classifications by CLASSIFIED_AT to avoid referencing missing UPDATED_AT during profiling runs.
- Refresh mirrored snapshots after profiling service change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942aca3022483248a796422ab962532)