### PR TITLE
PROF-QUALIFY-TABLES-1: qualify profiling metadata queries

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import pandas as pd
 from snowflake.snowpark import Session
@@ -15,15 +15,40 @@ DISCOVERY_DB = "ZEUS_ANALYTICS_SIMU"
 DISCOVERY_SCHEMA = "DISCOVERY"
 DISCOVERY_NAMESPACE = f"{DISCOVERY_DB}.{DISCOVERY_SCHEMA}"
 
-PROFILE_PROC = f"{DISCOVERY_NAMESPACE}.DQ_PROFILE_FULL"
-CLASSIFY_PROC = f"{DISCOVERY_NAMESPACE}.DQ_CLASSIFY_COLUMNS_HEURISTIC"
-SUGGESTIONS_PROC = f"{DISCOVERY_NAMESPACE}.DQ_APPLY_RULES"
-SUGGEST_CONFIG_PROC = f"{DISCOVERY_NAMESPACE}.DQ_SUGGEST_CONFIG_FROM_PROFILE"
-TABLE_SUMMARY_VIEW = f"{DISCOVERY_NAMESPACE}.DQ_TABLE_PROFILE_SUMMARY"
-COLUMN_FEATURES_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_FEATURES"
-COLUMN_CLASSIFICATION_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_CLASSIFICATION"
-SUGGESTED_CHECKS_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_SUGGESTED_CHECKS"
-PROFILE_RUN_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_PROFILE_RUN"
+
+def _clean_identifier(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _resolved_metadata(metadata_db: Optional[str], metadata_schema: Optional[str]) -> Tuple[str, str]:
+    db = _clean_identifier(metadata_db)
+    schema = _clean_identifier(metadata_schema)
+    if db and schema:
+        return db, schema
+    return DISCOVERY_DB, DISCOVERY_SCHEMA
+
+
+def _profiling_objects(
+    metadata_db: Optional[str] = None, metadata_schema: Optional[str] = None
+) -> Dict[str, str]:
+    db, schema = _resolved_metadata(metadata_db, metadata_schema)
+    namespace = f"{db}.{schema}"
+    return {
+        "metadata_db": db,
+        "metadata_schema": schema,
+        "namespace": namespace,
+        "profile_proc": f"{namespace}.DQ_PROFILE_FULL",
+        "classify_proc": f"{namespace}.DQ_CLASSIFY_COLUMNS_HEURISTIC",
+        "suggestions_proc": f"{namespace}.DQ_APPLY_RULES",
+        "suggest_config_proc": f"{namespace}.DQ_SUGGEST_CONFIG_FROM_PROFILE",
+        "table_summary_view": f"{namespace}.DQ_TABLE_PROFILE_SUMMARY",
+        "column_features_table": f"{namespace}.DQ_COLUMN_FEATURES",
+        "column_classification_table": f"{namespace}.DQ_COLUMN_CLASSIFICATION",
+        "suggested_checks_table": f"{namespace}.DQ_SUGGESTED_CHECKS",
+        "profile_run_table": f"{namespace}.DQ_PROFILE_RUN",
+    }
 
 
 class ProfilingError(RuntimeError):
@@ -78,14 +103,23 @@ def _friendly_error_message(exc: Exception) -> str:
     return message
 
 
-def _require_feature_rows(session: Any, table_fqn: str) -> None:
+def _require_feature_rows(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Ensure column features were written for *table_fqn*.
 
     Raises :class:`ProfilingError` when no feature rows exist so the UI can
     surface actionable feedback instead of silently succeeding.
     """
 
-    sql = f"SELECT COUNT(*) AS ROW_COUNT FROM {COLUMN_FEATURES_TABLE} WHERE TABLE_FQN = ?"
+    tables = _profiling_objects(metadata_db, metadata_schema)
+    sql = (
+        f"SELECT COUNT(*) AS ROW_COUNT FROM {tables['column_features_table']} "
+        "WHERE TABLE_FQN = ?"
+    )
     counts = _fetch_dataframe(session, sql, params=[table_fqn])
     feature_count = int(counts.iloc[0]["ROW_COUNT"]) if not counts.empty else 0
     if feature_count <= 0:
@@ -100,22 +134,34 @@ def _require_feature_rows(session: Any, table_fqn: str) -> None:
         raise ProfilingError(message)
 
 
-def _delete_existing_classifications(session: Any, table_fqn: str) -> None:
+def _delete_existing_classifications(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Remove prior classifications for *table_fqn* before rewrite."""
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
-        DELETE FROM {COLUMN_CLASSIFICATION_TABLE}
+        DELETE FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
     """
     _execute_sql(session, sql, params=[table_fqn]).collect()
 
 
-def _guard_duplicate_classifications(session: Any, table_fqn: str) -> None:
+def _guard_duplicate_classifications(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Raise if more than one classification exists per column."""
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT COLUMN_NAME, COUNT(*) AS ROW_COUNT
-        FROM {COLUMN_CLASSIFICATION_TABLE}
+        FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
         GROUP BY 1
         HAVING COUNT(*) > 1
@@ -135,19 +181,29 @@ def _guard_duplicate_classifications(session: Any, table_fqn: str) -> None:
     )
 
 
-def run_profiling_v2(session: Any, table_fqn: str) -> None:
+def run_profiling_v2(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Execute the Profiling v2 stored procedure for *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         raise ProfilingError("Fully-qualified table name is required")
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     LOGGER.info("profiling_v2:call proc target=%s", normalized)
     try:
-        _delete_existing_classifications(session, normalized)
-        _execute_sql(session, f"CALL {PROFILE_PROC}(?)", params=[normalized]).collect()
-        _require_feature_rows(session, normalized)
-        _guard_duplicate_classifications(session, normalized)
+        _delete_existing_classifications(session, normalized, metadata_db, metadata_schema)
+        _execute_sql(
+            session,
+            f"CALL {tables['profile_proc']}(?)",
+            params=[normalized],
+        ).collect()
+        _require_feature_rows(session, normalized, metadata_db, metadata_schema)
+        _guard_duplicate_classifications(session, normalized, metadata_db, metadata_schema)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:proc_failed target=%s", normalized)
@@ -156,7 +212,12 @@ def run_profiling_v2(session: Any, table_fqn: str) -> None:
     # Ensure suggested checks are refreshed immediately after profiling so the
     # overview grid can surface rule metadata without requiring a separate
     # button click.
-    run_suggestions_only(session, normalized)
+    run_suggestions_only(
+        session,
+        normalized,
+        metadata_db=metadata_db,
+        metadata_schema=metadata_schema,
+    )
 
 
 # Backwards compatibility for earlier callers/tests.
@@ -168,6 +229,8 @@ def _run_single_stage(
     table_fqn: str,
     proc_name: str,
     failure_message: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
 ) -> None:
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
@@ -185,33 +248,48 @@ def _run_single_stage(
         raise ProfilingError(f"{failure_message}: {message}") from exc
 
 
-def run_classification_only(session: Any, table_fqn: str) -> None:
+def run_classification_only(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Re-run only the column classification stage for *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         raise ProfilingError("Fully-qualified table name is required")
 
-    _delete_existing_classifications(session, normalized)
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
+    _delete_existing_classifications(session, normalized, metadata_db, metadata_schema)
     _run_single_stage(
         session,
         normalized,
-        CLASSIFY_PROC,
+        tables["classify_proc"],
         "Classification run failed",
+        metadata_db=metadata_db,
+        metadata_schema=metadata_schema,
     )
-    _guard_duplicate_classifications(session, normalized)
+    _guard_duplicate_classifications(session, normalized, metadata_db, metadata_schema)
 
 
-def run_suggestions_only(session: Any, table_fqn: str) -> None:
+def run_suggestions_only(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Execute only the DQ_APPLY_RULES stage for *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         raise ProfilingError("Fully-qualified table name is required")
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     LOGGER.info("profiling_v2:call apply_rules target=%s", normalized)
     try:
-        sql = f"CALL {SUGGESTIONS_PROC}(?)"
+        sql = f"CALL {tables['suggestions_proc']}(?)"
         _execute_sql(session, sql, params=[normalized]).collect()
         LOGGER.info("profiling_v2:apply_rules_complete target=%s", normalized)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
@@ -226,6 +304,8 @@ def suggest_config_from_profile(
     profile_run_id: Any,
     included_columns: Iterable[str],
     config_name: Optional[str] = None,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Call ``DQ_SUGGEST_CONFIG_FROM_PROFILE`` using current profiling context."""
 
@@ -241,6 +321,8 @@ def suggest_config_from_profile(
         raise ProfilingError("At least one included column is required")
 
     params = [profile_run_id, normalized, json.dumps(columns), config_name]
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
     LOGGER.info(
         "profiling_v2:suggest_config target=%s profile_run_id=%s columns=%s",
         normalized,
@@ -250,7 +332,7 @@ def suggest_config_from_profile(
     try:
         rows = _execute_sql(
             session,
-            f"CALL {SUGGEST_CONFIG_PROC}(?, ?, PARSE_JSON(?), ?)",
+            f"CALL {tables['suggest_config_proc']}(?, ?, PARSE_JSON(?), ?)",
             params=params,
         ).collect()
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
@@ -412,14 +494,20 @@ def _sort_summary_frame(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def get_table_profile_summary(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_table_profile_summary(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return all profiling summary rows for the table."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
-    sql = f"SELECT * FROM {TABLE_SUMMARY_VIEW} WHERE TABLE_FQN = ?"
+    tables = _profiling_objects(metadata_db, metadata_schema)
+    sql = f"SELECT * FROM {tables['table_summary_view']} WHERE TABLE_FQN = ?"
     try:
         return _fetch_dataframe(session, sql, params=[normalized])
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
@@ -427,30 +515,41 @@ def get_table_profile_summary(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def fetch_table_summary(session: Any, table_fqn: str) -> Dict[str, Any]:
+def fetch_table_summary(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> Dict[str, Any]:
     """Return the most recent table-level profiling summary."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return {}
 
-    df = get_table_profile_summary(session, normalized)
+    df = get_table_profile_summary(session, normalized, metadata_db, metadata_schema)
     if df.empty:
         return {}
     latest = _sort_summary_frame(df).iloc[0]
     return latest.to_dict()
 
 
-def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_column_features(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return profiling features for each column on *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT *
-        FROM {COLUMN_FEATURES_TABLE}
+        FROM {tables['column_features_table']}
         WHERE TABLE_FQN = ?
         ORDER BY ORDINAL_POSITION
     """
@@ -468,22 +567,33 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def fetch_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
+def fetch_column_features(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Backwards-compatible wrapper for :func:`get_column_features`."""
 
-    return get_column_features(session, table_fqn)
+    return get_column_features(session, table_fqn, metadata_db, metadata_schema)
 
 
-def get_column_classification(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_column_classification(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return semantic classification rows ordered for UI rendering."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT *
-        FROM {COLUMN_CLASSIFICATION_TABLE}
+        FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, SOURCE DESC, CLASSIFIED_AT DESC
     """
@@ -496,13 +606,23 @@ def get_column_classification(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def fetch_column_classifications(session: Any, table_fqn: str) -> pd.DataFrame:
+def fetch_column_classifications(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Backwards-compatible wrapper for :func:`get_column_classification`."""
 
-    return get_column_classification(session, table_fqn)
+    return get_column_classification(session, table_fqn, metadata_db, metadata_schema)
 
 
-def get_effective_classification(session: Session, table_fqn: str) -> pd.DataFrame:
+def get_effective_classification(
+    session: Session,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """
     Return one row per column for the latest classification (manual or heuristic).
     Used by the column editors in the Profiling v2 UI.
@@ -512,6 +632,7 @@ def get_effective_classification(session: Session, table_fqn: str) -> pd.DataFra
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         WITH ranked AS (
             SELECT
@@ -526,7 +647,7 @@ def get_effective_classification(session: Session, table_fqn: str) -> pd.DataFra
                     PARTITION BY TABLE_FQN, COLUMN_NAME
                     ORDER BY CLASSIFIED_AT DESC
                 ) AS RN
-            FROM {COLUMN_CLASSIFICATION_TABLE}
+            FROM {tables['column_classification_table']}
             WHERE TABLE_FQN = :1
         )
         SELECT
@@ -557,6 +678,8 @@ def save_manual_classification(
     content_type: Optional[str],
     semantic_role: Optional[str],
     actor: Optional[str] = None,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
 ) -> None:
     """Persist a manual classification override for *column_name*."""
 
@@ -576,8 +699,10 @@ def save_manual_classification(
             column,
         )
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
     sql = f"""
-        INSERT INTO {COLUMN_CLASSIFICATION_TABLE} (
+        INSERT INTO {tables['column_classification_table']} (
             TABLE_FQN,
             COLUMN_NAME,
             CONTENT_TYPE,
@@ -612,16 +737,22 @@ def save_manual_classification(
         raise ProfilingError("Failed to save manual classification") from exc
 
 
-def get_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_suggested_checks(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return suggested DQ checks for each column."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT *
-        FROM {SUGGESTED_CHECKS_TABLE}
+        FROM {tables['suggested_checks_table']}
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, RULE_ID
     """
@@ -632,7 +763,12 @@ def get_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
+def get_overview_grid(
+    session: Session,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """
     Unified overview grid for Profiling v2:
     - One row per column
@@ -675,9 +811,11 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         except Exception:
             return str(value)
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
     classification_cte = f"""
         SELECT *
-        FROM {COLUMN_CLASSIFICATION_TABLE}
+        FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
         QUALIFY ROW_NUMBER() OVER (
             PARTITION BY TABLE_FQN, COLUMN_NAME
@@ -690,7 +828,7 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
             {classification_cte}
         )
         SELECT f.*, c.CONTENT_TYPE, c.SEMANTIC_ROLE, c.SOURCE, c.CONFIDENCE, c.CLASSIFIED_AT
-        FROM {COLUMN_FEATURES_TABLE} f
+        FROM {tables['column_features_table']} f
         LEFT JOIN class_dedup c
           ON f.TABLE_FQN = c.TABLE_FQN
          AND f.COLUMN_NAME = c.COLUMN_NAME
@@ -706,17 +844,32 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
     )
     feature_row_count = len(features)
     classification_row_count = len(classification)
+    feature_sample = (
+        features["COLUMN_NAME"].dropna().astype(str).head(3).tolist()
+        if "COLUMN_NAME" in features.columns
+        else []
+    )
+
+    debug_counts = {
+        "feature_row_count": feature_row_count,
+        "classification_row_count": classification_row_count,
+        "columns_rendered": 0,
+        "metadata_db": tables["metadata_db"],
+        "metadata_schema": tables["metadata_schema"],
+        "features_table_fqn": tables["column_features_table"],
+        "class_table_fqn": tables["column_classification_table"],
+        "table_fqn_filter": normalized,
+        "feature_sample_columns": feature_sample,
+    }
 
     if features.empty:
         empty_df = pd.DataFrame(columns=overview_columns)
-        empty_df.attrs["dq_debug_counts"] = {
-            "feature_row_count": feature_row_count,
-            "classification_row_count": classification_row_count,
-            "columns_rendered": 0,
-        }
+        empty_df.attrs["dq_debug_counts"] = debug_counts
         return empty_df
 
-    suggestions = _normalize_dataframe_columns(get_suggested_checks(session, normalized))
+    suggestions = _normalize_dataframe_columns(
+        get_suggested_checks(session, normalized, metadata_db, metadata_schema)
+    )
 
     suggestion_lookup: Dict[str, Dict[str, Any]] = {}
     if not suggestions.empty and "COLUMN_NAME" in suggestions.columns:
@@ -783,18 +936,20 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         )
 
     overview = pd.DataFrame.from_records(overview_rows, columns=overview_columns)
-    overview.attrs["dq_debug_counts"] = {
-        "feature_row_count": feature_row_count,
-        "classification_row_count": classification_row_count,
-        "columns_rendered": len(overview_rows),
-    }
+    debug_counts["columns_rendered"] = len(overview_rows)
+    overview.attrs["dq_debug_counts"] = debug_counts
     return overview
 
 
-def fetch_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
+def fetch_suggested_checks(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Backwards-compatible wrapper for :func:`get_suggested_checks`."""
 
-    return get_suggested_checks(session, table_fqn)
+    return get_suggested_checks(session, table_fqn, metadata_db, metadata_schema)
 
 
 def _filter_column_records(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
@@ -837,7 +992,13 @@ def _pluck_fields(record: Dict[str, Any], fields: Iterable[str]) -> Dict[str, An
     return result
 
 
-def get_column_detail(session: Any, table_fqn: str, column_name: str) -> Dict[str, Any]:
+def get_column_detail(
+    session: Any,
+    table_fqn: str,
+    column_name: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> Dict[str, Any]:
     """Return profiling, classification, and suggestion metadata for one column."""
 
     normalized = _normalize_table_fqn(table_fqn)
@@ -845,9 +1006,11 @@ def get_column_detail(session: Any, table_fqn: str, column_name: str) -> Dict[st
     if not normalized or not column:
         return {}
 
-    features = get_column_features(session, normalized)
-    classification = get_effective_classification(session, normalized)
-    suggestions = get_suggested_checks(session, normalized)
+    features = get_column_features(session, normalized, metadata_db, metadata_schema)
+    classification = get_effective_classification(
+        session, normalized, metadata_db, metadata_schema
+    )
+    suggestions = get_suggested_checks(session, normalized, metadata_db, metadata_schema)
     feature_record = _first_column_record(features, column)
     classification_record = _first_column_record(classification, column)
     suggestion_records = _suggested_checks_for_column(suggestions, column)
@@ -889,12 +1052,20 @@ def get_column_detail(session: Any, table_fqn: str, column_name: str) -> Dict[st
     return detail
 
 
-def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataFrame:
+def fetch_recent_runs(
+    session: Any,
+    table_fqn: str,
+    limit: int = 10,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return recent profiling runs for the table."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
+
+    tables = _profiling_objects(metadata_db, metadata_schema)
 
     sql = f"""
         SELECT
@@ -913,7 +1084,7 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
             SAMPLE_EST_ROWS,
             CREATED_AT,
             UPDATED_AT
-        FROM {PROFILE_RUN_TABLE}
+        FROM {tables['profile_run_table']}
         WHERE TABLE_FQN = ?
         ORDER BY STARTED_AT DESC
         LIMIT {max(1, limit)}

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import pandas as pd
 from snowflake.snowpark import Session
@@ -15,15 +15,40 @@ DISCOVERY_DB = "ZEUS_ANALYTICS_SIMU"
 DISCOVERY_SCHEMA = "DISCOVERY"
 DISCOVERY_NAMESPACE = f"{DISCOVERY_DB}.{DISCOVERY_SCHEMA}"
 
-PROFILE_PROC = f"{DISCOVERY_NAMESPACE}.DQ_PROFILE_FULL"
-CLASSIFY_PROC = f"{DISCOVERY_NAMESPACE}.DQ_CLASSIFY_COLUMNS_HEURISTIC"
-SUGGESTIONS_PROC = f"{DISCOVERY_NAMESPACE}.DQ_APPLY_RULES"
-SUGGEST_CONFIG_PROC = f"{DISCOVERY_NAMESPACE}.DQ_SUGGEST_CONFIG_FROM_PROFILE"
-TABLE_SUMMARY_VIEW = f"{DISCOVERY_NAMESPACE}.DQ_TABLE_PROFILE_SUMMARY"
-COLUMN_FEATURES_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_FEATURES"
-COLUMN_CLASSIFICATION_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_COLUMN_CLASSIFICATION"
-SUGGESTED_CHECKS_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_SUGGESTED_CHECKS"
-PROFILE_RUN_TABLE = f"{DISCOVERY_NAMESPACE}.DQ_PROFILE_RUN"
+
+def _clean_identifier(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _resolved_metadata(metadata_db: Optional[str], metadata_schema: Optional[str]) -> Tuple[str, str]:
+    db = _clean_identifier(metadata_db)
+    schema = _clean_identifier(metadata_schema)
+    if db and schema:
+        return db, schema
+    return DISCOVERY_DB, DISCOVERY_SCHEMA
+
+
+def _profiling_objects(
+    metadata_db: Optional[str] = None, metadata_schema: Optional[str] = None
+) -> Dict[str, str]:
+    db, schema = _resolved_metadata(metadata_db, metadata_schema)
+    namespace = f"{db}.{schema}"
+    return {
+        "metadata_db": db,
+        "metadata_schema": schema,
+        "namespace": namespace,
+        "profile_proc": f"{namespace}.DQ_PROFILE_FULL",
+        "classify_proc": f"{namespace}.DQ_CLASSIFY_COLUMNS_HEURISTIC",
+        "suggestions_proc": f"{namespace}.DQ_APPLY_RULES",
+        "suggest_config_proc": f"{namespace}.DQ_SUGGEST_CONFIG_FROM_PROFILE",
+        "table_summary_view": f"{namespace}.DQ_TABLE_PROFILE_SUMMARY",
+        "column_features_table": f"{namespace}.DQ_COLUMN_FEATURES",
+        "column_classification_table": f"{namespace}.DQ_COLUMN_CLASSIFICATION",
+        "suggested_checks_table": f"{namespace}.DQ_SUGGESTED_CHECKS",
+        "profile_run_table": f"{namespace}.DQ_PROFILE_RUN",
+    }
 
 
 class ProfilingError(RuntimeError):
@@ -78,14 +103,23 @@ def _friendly_error_message(exc: Exception) -> str:
     return message
 
 
-def _require_feature_rows(session: Any, table_fqn: str) -> None:
+def _require_feature_rows(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Ensure column features were written for *table_fqn*.
 
     Raises :class:`ProfilingError` when no feature rows exist so the UI can
     surface actionable feedback instead of silently succeeding.
     """
 
-    sql = f"SELECT COUNT(*) AS ROW_COUNT FROM {COLUMN_FEATURES_TABLE} WHERE TABLE_FQN = ?"
+    tables = _profiling_objects(metadata_db, metadata_schema)
+    sql = (
+        f"SELECT COUNT(*) AS ROW_COUNT FROM {tables['column_features_table']} "
+        "WHERE TABLE_FQN = ?"
+    )
     counts = _fetch_dataframe(session, sql, params=[table_fqn])
     feature_count = int(counts.iloc[0]["ROW_COUNT"]) if not counts.empty else 0
     if feature_count <= 0:
@@ -100,22 +134,34 @@ def _require_feature_rows(session: Any, table_fqn: str) -> None:
         raise ProfilingError(message)
 
 
-def _delete_existing_classifications(session: Any, table_fqn: str) -> None:
+def _delete_existing_classifications(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Remove prior classifications for *table_fqn* before rewrite."""
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
-        DELETE FROM {COLUMN_CLASSIFICATION_TABLE}
+        DELETE FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
     """
     _execute_sql(session, sql, params=[table_fqn]).collect()
 
 
-def _guard_duplicate_classifications(session: Any, table_fqn: str) -> None:
+def _guard_duplicate_classifications(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Raise if more than one classification exists per column."""
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT COLUMN_NAME, COUNT(*) AS ROW_COUNT
-        FROM {COLUMN_CLASSIFICATION_TABLE}
+        FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
         GROUP BY 1
         HAVING COUNT(*) > 1
@@ -135,19 +181,29 @@ def _guard_duplicate_classifications(session: Any, table_fqn: str) -> None:
     )
 
 
-def run_profiling_v2(session: Any, table_fqn: str) -> None:
+def run_profiling_v2(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Execute the Profiling v2 stored procedure for *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         raise ProfilingError("Fully-qualified table name is required")
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     LOGGER.info("profiling_v2:call proc target=%s", normalized)
     try:
-        _delete_existing_classifications(session, normalized)
-        _execute_sql(session, f"CALL {PROFILE_PROC}(?)", params=[normalized]).collect()
-        _require_feature_rows(session, normalized)
-        _guard_duplicate_classifications(session, normalized)
+        _delete_existing_classifications(session, normalized, metadata_db, metadata_schema)
+        _execute_sql(
+            session,
+            f"CALL {tables['profile_proc']}(?)",
+            params=[normalized],
+        ).collect()
+        _require_feature_rows(session, normalized, metadata_db, metadata_schema)
+        _guard_duplicate_classifications(session, normalized, metadata_db, metadata_schema)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
         message = _friendly_error_message(exc)
         LOGGER.exception("profiling_v2:proc_failed target=%s", normalized)
@@ -156,7 +212,12 @@ def run_profiling_v2(session: Any, table_fqn: str) -> None:
     # Ensure suggested checks are refreshed immediately after profiling so the
     # overview grid can surface rule metadata without requiring a separate
     # button click.
-    run_suggestions_only(session, normalized)
+    run_suggestions_only(
+        session,
+        normalized,
+        metadata_db=metadata_db,
+        metadata_schema=metadata_schema,
+    )
 
 
 # Backwards compatibility for earlier callers/tests.
@@ -168,6 +229,8 @@ def _run_single_stage(
     table_fqn: str,
     proc_name: str,
     failure_message: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
 ) -> None:
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
@@ -185,33 +248,48 @@ def _run_single_stage(
         raise ProfilingError(f"{failure_message}: {message}") from exc
 
 
-def run_classification_only(session: Any, table_fqn: str) -> None:
+def run_classification_only(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Re-run only the column classification stage for *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         raise ProfilingError("Fully-qualified table name is required")
 
-    _delete_existing_classifications(session, normalized)
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
+    _delete_existing_classifications(session, normalized, metadata_db, metadata_schema)
     _run_single_stage(
         session,
         normalized,
-        CLASSIFY_PROC,
+        tables["classify_proc"],
         "Classification run failed",
+        metadata_db=metadata_db,
+        metadata_schema=metadata_schema,
     )
-    _guard_duplicate_classifications(session, normalized)
+    _guard_duplicate_classifications(session, normalized, metadata_db, metadata_schema)
 
 
-def run_suggestions_only(session: Any, table_fqn: str) -> None:
+def run_suggestions_only(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> None:
     """Execute only the DQ_APPLY_RULES stage for *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         raise ProfilingError("Fully-qualified table name is required")
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     LOGGER.info("profiling_v2:call apply_rules target=%s", normalized)
     try:
-        sql = f"CALL {SUGGESTIONS_PROC}(?)"
+        sql = f"CALL {tables['suggestions_proc']}(?)"
         _execute_sql(session, sql, params=[normalized]).collect()
         LOGGER.info("profiling_v2:apply_rules_complete target=%s", normalized)
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
@@ -226,6 +304,8 @@ def suggest_config_from_profile(
     profile_run_id: Any,
     included_columns: Iterable[str],
     config_name: Optional[str] = None,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Call ``DQ_SUGGEST_CONFIG_FROM_PROFILE`` using current profiling context."""
 
@@ -241,6 +321,8 @@ def suggest_config_from_profile(
         raise ProfilingError("At least one included column is required")
 
     params = [profile_run_id, normalized, json.dumps(columns), config_name]
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
     LOGGER.info(
         "profiling_v2:suggest_config target=%s profile_run_id=%s columns=%s",
         normalized,
@@ -250,7 +332,7 @@ def suggest_config_from_profile(
     try:
         rows = _execute_sql(
             session,
-            f"CALL {SUGGEST_CONFIG_PROC}(?, ?, PARSE_JSON(?), ?)",
+            f"CALL {tables['suggest_config_proc']}(?, ?, PARSE_JSON(?), ?)",
             params=params,
         ).collect()
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
@@ -412,14 +494,20 @@ def _sort_summary_frame(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def get_table_profile_summary(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_table_profile_summary(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return all profiling summary rows for the table."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
-    sql = f"SELECT * FROM {TABLE_SUMMARY_VIEW} WHERE TABLE_FQN = ?"
+    tables = _profiling_objects(metadata_db, metadata_schema)
+    sql = f"SELECT * FROM {tables['table_summary_view']} WHERE TABLE_FQN = ?"
     try:
         return _fetch_dataframe(session, sql, params=[normalized])
     except Exception as exc:  # pragma: no cover - Snowflake specific failures
@@ -427,30 +515,41 @@ def get_table_profile_summary(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def fetch_table_summary(session: Any, table_fqn: str) -> Dict[str, Any]:
+def fetch_table_summary(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> Dict[str, Any]:
     """Return the most recent table-level profiling summary."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return {}
 
-    df = get_table_profile_summary(session, normalized)
+    df = get_table_profile_summary(session, normalized, metadata_db, metadata_schema)
     if df.empty:
         return {}
     latest = _sort_summary_frame(df).iloc[0]
     return latest.to_dict()
 
 
-def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_column_features(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return profiling features for each column on *table_fqn*."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT *
-        FROM {COLUMN_FEATURES_TABLE}
+        FROM {tables['column_features_table']}
         WHERE TABLE_FQN = ?
         ORDER BY ORDINAL_POSITION
     """
@@ -468,22 +567,33 @@ def get_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def fetch_column_features(session: Any, table_fqn: str) -> pd.DataFrame:
+def fetch_column_features(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Backwards-compatible wrapper for :func:`get_column_features`."""
 
-    return get_column_features(session, table_fqn)
+    return get_column_features(session, table_fqn, metadata_db, metadata_schema)
 
 
-def get_column_classification(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_column_classification(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return semantic classification rows ordered for UI rendering."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT *
-        FROM {COLUMN_CLASSIFICATION_TABLE}
+        FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, SOURCE DESC, CLASSIFIED_AT DESC
     """
@@ -496,13 +606,23 @@ def get_column_classification(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def fetch_column_classifications(session: Any, table_fqn: str) -> pd.DataFrame:
+def fetch_column_classifications(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Backwards-compatible wrapper for :func:`get_column_classification`."""
 
-    return get_column_classification(session, table_fqn)
+    return get_column_classification(session, table_fqn, metadata_db, metadata_schema)
 
 
-def get_effective_classification(session: Session, table_fqn: str) -> pd.DataFrame:
+def get_effective_classification(
+    session: Session,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """
     Return one row per column for the latest classification (manual or heuristic).
     Used by the column editors in the Profiling v2 UI.
@@ -512,6 +632,7 @@ def get_effective_classification(session: Session, table_fqn: str) -> pd.DataFra
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         WITH ranked AS (
             SELECT
@@ -526,7 +647,7 @@ def get_effective_classification(session: Session, table_fqn: str) -> pd.DataFra
                     PARTITION BY TABLE_FQN, COLUMN_NAME
                     ORDER BY CLASSIFIED_AT DESC
                 ) AS RN
-            FROM {COLUMN_CLASSIFICATION_TABLE}
+            FROM {tables['column_classification_table']}
             WHERE TABLE_FQN = :1
         )
         SELECT
@@ -557,6 +678,8 @@ def save_manual_classification(
     content_type: Optional[str],
     semantic_role: Optional[str],
     actor: Optional[str] = None,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
 ) -> None:
     """Persist a manual classification override for *column_name*."""
 
@@ -576,8 +699,10 @@ def save_manual_classification(
             column,
         )
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
     sql = f"""
-        INSERT INTO {COLUMN_CLASSIFICATION_TABLE} (
+        INSERT INTO {tables['column_classification_table']} (
             TABLE_FQN,
             COLUMN_NAME,
             CONTENT_TYPE,
@@ -612,16 +737,22 @@ def save_manual_classification(
         raise ProfilingError("Failed to save manual classification") from exc
 
 
-def get_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
+def get_suggested_checks(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return suggested DQ checks for each column."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
     sql = f"""
         SELECT *
-        FROM {SUGGESTED_CHECKS_TABLE}
+        FROM {tables['suggested_checks_table']}
         WHERE TABLE_FQN = ?
         ORDER BY COLUMN_NAME, RULE_ID
     """
@@ -632,7 +763,12 @@ def get_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
+def get_overview_grid(
+    session: Session,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """
     Unified overview grid for Profiling v2:
     - One row per column
@@ -675,9 +811,11 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         except Exception:
             return str(value)
 
+    tables = _profiling_objects(metadata_db, metadata_schema)
+
     classification_cte = f"""
         SELECT *
-        FROM {COLUMN_CLASSIFICATION_TABLE}
+        FROM {tables['column_classification_table']}
         WHERE TABLE_FQN = ?
         QUALIFY ROW_NUMBER() OVER (
             PARTITION BY TABLE_FQN, COLUMN_NAME
@@ -690,7 +828,7 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
             {classification_cte}
         )
         SELECT f.*, c.CONTENT_TYPE, c.SEMANTIC_ROLE, c.SOURCE, c.CONFIDENCE, c.CLASSIFIED_AT
-        FROM {COLUMN_FEATURES_TABLE} f
+        FROM {tables['column_features_table']} f
         LEFT JOIN class_dedup c
           ON f.TABLE_FQN = c.TABLE_FQN
          AND f.COLUMN_NAME = c.COLUMN_NAME
@@ -706,17 +844,32 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
     )
     feature_row_count = len(features)
     classification_row_count = len(classification)
+    feature_sample = (
+        features["COLUMN_NAME"].dropna().astype(str).head(3).tolist()
+        if "COLUMN_NAME" in features.columns
+        else []
+    )
+
+    debug_counts = {
+        "feature_row_count": feature_row_count,
+        "classification_row_count": classification_row_count,
+        "columns_rendered": 0,
+        "metadata_db": tables["metadata_db"],
+        "metadata_schema": tables["metadata_schema"],
+        "features_table_fqn": tables["column_features_table"],
+        "class_table_fqn": tables["column_classification_table"],
+        "table_fqn_filter": normalized,
+        "feature_sample_columns": feature_sample,
+    }
 
     if features.empty:
         empty_df = pd.DataFrame(columns=overview_columns)
-        empty_df.attrs["dq_debug_counts"] = {
-            "feature_row_count": feature_row_count,
-            "classification_row_count": classification_row_count,
-            "columns_rendered": 0,
-        }
+        empty_df.attrs["dq_debug_counts"] = debug_counts
         return empty_df
 
-    suggestions = _normalize_dataframe_columns(get_suggested_checks(session, normalized))
+    suggestions = _normalize_dataframe_columns(
+        get_suggested_checks(session, normalized, metadata_db, metadata_schema)
+    )
 
     suggestion_lookup: Dict[str, Dict[str, Any]] = {}
     if not suggestions.empty and "COLUMN_NAME" in suggestions.columns:
@@ -783,18 +936,20 @@ def get_overview_grid(session: Session, table_fqn: str) -> pd.DataFrame:
         )
 
     overview = pd.DataFrame.from_records(overview_rows, columns=overview_columns)
-    overview.attrs["dq_debug_counts"] = {
-        "feature_row_count": feature_row_count,
-        "classification_row_count": classification_row_count,
-        "columns_rendered": len(overview_rows),
-    }
+    debug_counts["columns_rendered"] = len(overview_rows)
+    overview.attrs["dq_debug_counts"] = debug_counts
     return overview
 
 
-def fetch_suggested_checks(session: Any, table_fqn: str) -> pd.DataFrame:
+def fetch_suggested_checks(
+    session: Any,
+    table_fqn: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Backwards-compatible wrapper for :func:`get_suggested_checks`."""
 
-    return get_suggested_checks(session, table_fqn)
+    return get_suggested_checks(session, table_fqn, metadata_db, metadata_schema)
 
 
 def _filter_column_records(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
@@ -837,7 +992,13 @@ def _pluck_fields(record: Dict[str, Any], fields: Iterable[str]) -> Dict[str, An
     return result
 
 
-def get_column_detail(session: Any, table_fqn: str, column_name: str) -> Dict[str, Any]:
+def get_column_detail(
+    session: Any,
+    table_fqn: str,
+    column_name: str,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> Dict[str, Any]:
     """Return profiling, classification, and suggestion metadata for one column."""
 
     normalized = _normalize_table_fqn(table_fqn)
@@ -845,9 +1006,11 @@ def get_column_detail(session: Any, table_fqn: str, column_name: str) -> Dict[st
     if not normalized or not column:
         return {}
 
-    features = get_column_features(session, normalized)
-    classification = get_effective_classification(session, normalized)
-    suggestions = get_suggested_checks(session, normalized)
+    features = get_column_features(session, normalized, metadata_db, metadata_schema)
+    classification = get_effective_classification(
+        session, normalized, metadata_db, metadata_schema
+    )
+    suggestions = get_suggested_checks(session, normalized, metadata_db, metadata_schema)
     feature_record = _first_column_record(features, column)
     classification_record = _first_column_record(classification, column)
     suggestion_records = _suggested_checks_for_column(suggestions, column)
@@ -889,12 +1052,20 @@ def get_column_detail(session: Any, table_fqn: str, column_name: str) -> Dict[st
     return detail
 
 
-def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataFrame:
+def fetch_recent_runs(
+    session: Any,
+    table_fqn: str,
+    limit: int = 10,
+    metadata_db: Optional[str] = None,
+    metadata_schema: Optional[str] = None,
+) -> pd.DataFrame:
     """Return recent profiling runs for the table."""
 
     normalized = _normalize_table_fqn(table_fqn)
     if not normalized:
         return pd.DataFrame()
+
+    tables = _profiling_objects(metadata_db, metadata_schema)
 
     sql = f"""
         SELECT
@@ -913,7 +1084,7 @@ def fetch_recent_runs(session: Any, table_fqn: str, limit: int = 10) -> pd.DataF
             SAMPLE_EST_ROWS,
             CREATED_AT,
             UPDATED_AT
-        FROM {PROFILE_RUN_TABLE}
+        FROM {tables['profile_run_table']}
         WHERE TABLE_FQN = ?
         ORDER BY STARTED_AT DESC
         LIMIT {max(1, limit)}

--- a/snapshots/tests/test_sql_golden.p
+++ b/snapshots/tests/test_sql_golden.p
@@ -34,8 +34,9 @@ def test_run_profiling_v2_invokes_procedure():
     profiling_v2.run_profiling_v2(session, 'DB.SCHEMA.TABLE')
 
     assert session.calls, "Stored procedure call was not recorded"
-    sql, params = session.calls[0]
-    assert "DQ_PROFILE_FULL" in sql
+    proc_calls = [call for call in session.calls if "DQ_PROFILE_FULL" in call[0]]
+    assert proc_calls, "Profiling stored procedure call was not recorded"
+    sql, params = proc_calls[0]
     assert params == ["DB.SCHEMA.TABLE"]
     assert session.responses == []  # responses consumed
 

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -568,6 +568,8 @@ def _render_suggest_config_action(
     helpers: Any,
     session: Any,
     profile_run_id: Optional[str],
+    metadata_db: str,
+    metadata_schema: str,
 ):
     suggest_fn = getattr(helpers, "suggest_config_from_profile", None)
     if not callable(suggest_fn):
@@ -611,12 +613,15 @@ def _render_suggest_config_action(
         ui_strings.PROFILE_V2_SUGGEST_CONFIG_SPINNER.format(table=table_fqn)
     ):
         try:
-            summary = suggest_fn(
+            summary = _call_helper_with_metadata(
+                suggest_fn,
                 session,
                 table_fqn,
                 profile_run_id,
                 included_columns,
                 config_name,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
             )
         except Exception as exc:  # pragma: no cover - UI feedback only
             st.error(
@@ -645,6 +650,12 @@ def _render_overview_debug(overview: pd.DataFrame) -> None:
     feature_count = debug_counts.get("feature_row_count")
     classification_count = debug_counts.get("classification_row_count")
     rendered_count = debug_counts.get("columns_rendered")
+    metadata_db = debug_counts.get("metadata_db")
+    metadata_schema = debug_counts.get("metadata_schema")
+    features_table_fqn = debug_counts.get("features_table_fqn")
+    class_table_fqn = debug_counts.get("class_table_fqn")
+    table_fqn_filter = debug_counts.get("table_fqn_filter")
+    feature_sample_columns = debug_counts.get("feature_sample_columns") or []
 
     with st.expander("Profiling debug", expanded=False):
         st.caption("Profiling grid source counts")
@@ -657,6 +668,14 @@ def _render_overview_debug(overview: pd.DataFrame) -> None:
         st.text(
             f"columns_rendered: {rendered_count if rendered_count is not None else fallback_rendered}"
         )
+        st.caption("Resolved metadata sources")
+        st.text(f"metadata_db: {metadata_db or '-'}")
+        st.text(f"metadata_schema: {metadata_schema or '-'}")
+        st.text(f"features_table_fqn: {features_table_fqn or '-'}")
+        st.text(f"class_table_fqn: {class_table_fqn or '-'}")
+        st.text(f"table_fqn_filter: {table_fqn_filter or '-'}")
+        sample_text = ", ".join(feature_sample_columns) if feature_sample_columns else "-"
+        st.text(f"feature_sample_columns: {sample_text}")
 
 
 def _suggestion_selection_key(
@@ -768,6 +787,8 @@ def _render_classification_grid(
     table_fqn: str,
     helpers: Any,
     session: Any,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     if not isinstance(classification, pd.DataFrame) or classification.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_EMPTY)
@@ -858,12 +879,15 @@ def _render_classification_grid(
     for change in changes:
         column_name = change["column"]
         try:
-            save_fn(
+            _call_helper_with_metadata(
+                save_fn,
                 session,
                 table_fqn,
                 column_name,
                 change["content"] or None,
                 change["semantic"] or None,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
             )
         except Exception as exc:  # pragma: no cover - UI feedback only
             st.error(
@@ -897,6 +921,8 @@ def _render_column_editors(
     table_fqn: str,
     helpers: Any,
     session: Any,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     if not isinstance(classification, pd.DataFrame) or classification.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_EMPTY)
@@ -914,7 +940,9 @@ def _render_column_editors(
     st.markdown(f"**{ui_strings.PROFILE_V2_COLUMNS_EDIT_HEADER}**")
     st.caption(ui_strings.PROFILE_V2_COLUMNS_EDIT_HELP)
     for record in working.to_dict("records"):
-        _render_column_editor_form(record, table_fqn, session, save_fn)
+        _render_column_editor_form(
+            record, table_fqn, session, save_fn, metadata_db, metadata_schema
+        )
 
 
 def _render_column_editor_form(
@@ -922,6 +950,8 @@ def _render_column_editor_form(
     table_fqn: str,
     session: Any,
     save_fn: Any,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     column_name = str(record.get("COLUMN_NAME") or "").strip()
     if not column_name:
@@ -965,6 +995,8 @@ def _render_column_editor_form(
                 column_name,
                 content_value,
                 semantic_value,
+                metadata_db,
+                metadata_schema,
             )
 
 
@@ -987,18 +1019,23 @@ def _handle_manual_classification_save(
     column_name: str,
     content_value: Optional[str],
     semantic_value: Optional[str],
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     content_clean = (content_value or "").strip() or None
     semantic_clean = (semantic_value or "").strip() or None
     spinner = ui_strings.PROFILE_V2_COLUMN_EDIT_SPINNER.format(column=column_name)
     with st.spinner(spinner):
         try:
-            save_fn(
+            _call_helper_with_metadata(
+                save_fn,
                 session,
                 table_fqn,
                 column_name,
                 content_clean,
                 semantic_clean,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
             )
         except Exception as exc:  # pragma: no cover - UI feedback only
             st.error(
@@ -1020,7 +1057,34 @@ def _resolve_helpers(profiling_helpers: Optional[Any]):
     return profiling_helpers or profiling_service
 
 
-def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, Any]:
+def _call_helper_with_metadata(
+    fn: Any,
+    *args,
+    metadata_db: str,
+    metadata_schema: str,
+    **kwargs,
+):
+    try:
+        return fn(
+            *args,
+            metadata_db=metadata_db,
+            metadata_schema=metadata_schema,
+            **kwargs,
+        )
+    except TypeError as exc:
+        message = str(exc)
+        if "metadata_db" in message or "metadata_schema" in message:
+            return fn(*args, **kwargs)
+        raise
+
+
+def _run_table_profile(
+    helpers: Any,
+    session: Any,
+    table_fqn: str,
+    metadata_db: str,
+    metadata_schema: str,
+) -> Dict[str, Any]:
     run_fn = getattr(helpers, "run_profiling_v2", None)
     summary_fn = getattr(helpers, "fetch_table_summary", None)
     overview_fn = getattr(helpers, "get_overview_grid", None)
@@ -1034,7 +1098,13 @@ def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, 
 
     with st.spinner(ui_strings.PROFILE_V2_RUN_SPINNER.format(table=table_fqn)):
         try:
-            run_fn(session, table_fqn)
+            _call_helper_with_metadata(
+                run_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception as exc:  # pragma: no cover - UI feedback only
             logging.exception("profiling:run_failed")
             return {
@@ -1044,8 +1114,24 @@ def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, 
                 "err": ui_strings.PROFILE_V2_RUN_ERROR.format(error=str(exc)),
             }
 
-    summary = summary_fn(session, table_fqn) if callable(summary_fn) else None
-    overview = overview_fn(session, table_fqn) if callable(overview_fn) else pd.DataFrame()
+    summary = None
+    if callable(summary_fn):
+        summary = _call_helper_with_metadata(
+            summary_fn,
+            session,
+            table_fqn,
+            metadata_db=metadata_db,
+            metadata_schema=metadata_schema,
+        )
+    overview = pd.DataFrame()
+    if callable(overview_fn):
+        overview = _call_helper_with_metadata(
+            overview_fn,
+            session,
+            table_fqn,
+            metadata_db=metadata_db,
+            metadata_schema=metadata_schema,
+        )
     column_rows = (
         overview.to_dict("records") if isinstance(overview, pd.DataFrame) else []
     )
@@ -1086,6 +1172,8 @@ def _load_metadata(
     helpers: Any,
     session: Any,
     table_fqn: str,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> _ProfilingData:
     overview_grid: pd.DataFrame = pd.DataFrame()
     suggested_checks: pd.DataFrame = pd.DataFrame()
@@ -1095,7 +1183,13 @@ def _load_metadata(
     overview_fn = getattr(helpers, "get_overview_grid", None)
     if callable(overview_fn):
         try:
-            overview_grid = overview_fn(session, table_fqn)
+            overview_grid = _call_helper_with_metadata(
+                overview_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception("profiling:overview_metadata_failed table=%s", table_fqn)
             overview_grid = pd.DataFrame()
@@ -1105,7 +1199,13 @@ def _load_metadata(
     classification_fn = effective_class_fn if callable(effective_class_fn) else column_class_fn
     if callable(classification_fn):
         try:
-            column_classification = classification_fn(session, table_fqn)
+            column_classification = _call_helper_with_metadata(
+                classification_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception(
                 "profiling:classification_metadata_failed table=%s", table_fqn
@@ -1115,7 +1215,13 @@ def _load_metadata(
     suggestions_fn = getattr(helpers, "get_suggested_checks", None)
     if callable(suggestions_fn):
         try:
-            suggested_checks = suggestions_fn(session, table_fqn)
+            suggested_checks = _call_helper_with_metadata(
+                suggestions_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception(
                 "profiling:suggestions_metadata_failed table=%s", table_fqn
@@ -1125,7 +1231,13 @@ def _load_metadata(
     run_history_fn = getattr(helpers, "fetch_recent_runs", None)
     if callable(run_history_fn):
         try:
-            recent_runs = run_history_fn(session, table_fqn)
+            recent_runs = _call_helper_with_metadata(
+                run_history_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception("profiling:recent_runs_failed table=%s", table_fqn)
             recent_runs = pd.DataFrame()
@@ -1218,7 +1330,13 @@ def render_profile(
             st.session_state["busy_profiling"] = True
             st.session_state["freeze_view"] = True
             try:
-                res = _run_table_profile(helpers, session, fqn)
+                res = _run_table_profile(
+                    helpers,
+                    session,
+                    fqn,
+                    metadata_db,
+                    metadata_schema,
+                )
                 if res.get("ok"):
                     st.session_state["last_profile_summary"] = res.get("summary")
                     st.session_state["last_profile_rows"] = (
@@ -1254,7 +1372,13 @@ def render_profile(
                 ui_strings.PROFILE_V2_CLASSIFY_SPINNER.format(table=target_fqn)
             ):
                 try:
-                    classify_fn(session, target_fqn)
+                    _call_helper_with_metadata(
+                        classify_fn,
+                        session,
+                        target_fqn,
+                        metadata_db=metadata_db,
+                        metadata_schema=metadata_schema,
+                    )
                 except Exception as exc:
                     status_placeholder.error(
                         ui_strings.PROFILE_V2_CLASSIFY_ERROR.format(error=str(exc))
@@ -1275,8 +1399,17 @@ def render_profile(
             with st.spinner(
                 ui_strings.PROFILE_V2_SUGGESTIONS_SPINNER.format(table=target_fqn)
             ):
+                def _suggestions_runner(sess, fqn):
+                    return _call_helper_with_metadata(
+                        suggestions_fn,
+                        sess,
+                        fqn,
+                        metadata_db=metadata_db,
+                        metadata_schema=metadata_schema,
+                    )
+
                 _, error = _call_with_timeout(
-                    suggestions_fn,
+                    _suggestions_runner,
                     SUGGESTIONS_TIMEOUT_SECONDS,
                     session,
                     target_fqn,
@@ -1321,7 +1454,13 @@ def render_profile(
 
     with st.spinner(ui_strings.PROFILE_V2_LOAD_SPINNER):
         try:
-            data = _load_metadata(helpers, session, target_fqn)
+            data = _load_metadata(
+                helpers,
+                session,
+                target_fqn,
+                metadata_db,
+                metadata_schema,
+            )
         except Exception as exc:
             logging.exception(
                 "profiling:metadata_load_failed table=%s", target_fqn
@@ -1370,6 +1509,8 @@ def render_profile(
             helpers,
             session,
             st.session_state.get("profile_last_run_id"),
+            metadata_db,
+            metadata_schema,
         )
         _render_suggestion_sections(
             overview_grid,
@@ -1384,4 +1525,6 @@ def render_profile(
             target_fqn,
             helpers,
             session,
+            metadata_db,
+            metadata_schema,
         )

--- a/tests/test_sql_golden.py
+++ b/tests/test_sql_golden.py
@@ -34,8 +34,9 @@ def test_run_profiling_v2_invokes_procedure():
     profiling_v2.run_profiling_v2(session, 'DB.SCHEMA.TABLE')
 
     assert session.calls, "Stored procedure call was not recorded"
-    sql, params = session.calls[0]
-    assert "DQ_PROFILE_FULL" in sql
+    proc_calls = [call for call in session.calls if "DQ_PROFILE_FULL" in call[0]]
+    assert proc_calls, "Profiling stored procedure call was not recorded"
+    sql, params = proc_calls[0]
     assert params == ["DB.SCHEMA.TABLE"]
     assert session.responses == []  # responses consumed
 

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -568,6 +568,8 @@ def _render_suggest_config_action(
     helpers: Any,
     session: Any,
     profile_run_id: Optional[str],
+    metadata_db: str,
+    metadata_schema: str,
 ):
     suggest_fn = getattr(helpers, "suggest_config_from_profile", None)
     if not callable(suggest_fn):
@@ -611,12 +613,15 @@ def _render_suggest_config_action(
         ui_strings.PROFILE_V2_SUGGEST_CONFIG_SPINNER.format(table=table_fqn)
     ):
         try:
-            summary = suggest_fn(
+            summary = _call_helper_with_metadata(
+                suggest_fn,
                 session,
                 table_fqn,
                 profile_run_id,
                 included_columns,
                 config_name,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
             )
         except Exception as exc:  # pragma: no cover - UI feedback only
             st.error(
@@ -645,6 +650,12 @@ def _render_overview_debug(overview: pd.DataFrame) -> None:
     feature_count = debug_counts.get("feature_row_count")
     classification_count = debug_counts.get("classification_row_count")
     rendered_count = debug_counts.get("columns_rendered")
+    metadata_db = debug_counts.get("metadata_db")
+    metadata_schema = debug_counts.get("metadata_schema")
+    features_table_fqn = debug_counts.get("features_table_fqn")
+    class_table_fqn = debug_counts.get("class_table_fqn")
+    table_fqn_filter = debug_counts.get("table_fqn_filter")
+    feature_sample_columns = debug_counts.get("feature_sample_columns") or []
 
     with st.expander("Profiling debug", expanded=False):
         st.caption("Profiling grid source counts")
@@ -657,6 +668,14 @@ def _render_overview_debug(overview: pd.DataFrame) -> None:
         st.text(
             f"columns_rendered: {rendered_count if rendered_count is not None else fallback_rendered}"
         )
+        st.caption("Resolved metadata sources")
+        st.text(f"metadata_db: {metadata_db or '-'}")
+        st.text(f"metadata_schema: {metadata_schema or '-'}")
+        st.text(f"features_table_fqn: {features_table_fqn or '-'}")
+        st.text(f"class_table_fqn: {class_table_fqn or '-'}")
+        st.text(f"table_fqn_filter: {table_fqn_filter or '-'}")
+        sample_text = ", ".join(feature_sample_columns) if feature_sample_columns else "-"
+        st.text(f"feature_sample_columns: {sample_text}")
 
 
 def _suggestion_selection_key(
@@ -768,6 +787,8 @@ def _render_classification_grid(
     table_fqn: str,
     helpers: Any,
     session: Any,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     if not isinstance(classification, pd.DataFrame) or classification.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_EMPTY)
@@ -858,12 +879,15 @@ def _render_classification_grid(
     for change in changes:
         column_name = change["column"]
         try:
-            save_fn(
+            _call_helper_with_metadata(
+                save_fn,
                 session,
                 table_fqn,
                 column_name,
                 change["content"] or None,
                 change["semantic"] or None,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
             )
         except Exception as exc:  # pragma: no cover - UI feedback only
             st.error(
@@ -897,6 +921,8 @@ def _render_column_editors(
     table_fqn: str,
     helpers: Any,
     session: Any,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     if not isinstance(classification, pd.DataFrame) or classification.empty:
         st.info(ui_strings.PROFILE_V2_COLUMNS_EDIT_EMPTY)
@@ -914,7 +940,9 @@ def _render_column_editors(
     st.markdown(f"**{ui_strings.PROFILE_V2_COLUMNS_EDIT_HEADER}**")
     st.caption(ui_strings.PROFILE_V2_COLUMNS_EDIT_HELP)
     for record in working.to_dict("records"):
-        _render_column_editor_form(record, table_fqn, session, save_fn)
+        _render_column_editor_form(
+            record, table_fqn, session, save_fn, metadata_db, metadata_schema
+        )
 
 
 def _render_column_editor_form(
@@ -922,6 +950,8 @@ def _render_column_editor_form(
     table_fqn: str,
     session: Any,
     save_fn: Any,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     column_name = str(record.get("COLUMN_NAME") or "").strip()
     if not column_name:
@@ -965,6 +995,8 @@ def _render_column_editor_form(
                 column_name,
                 content_value,
                 semantic_value,
+                metadata_db,
+                metadata_schema,
             )
 
 
@@ -987,18 +1019,23 @@ def _handle_manual_classification_save(
     column_name: str,
     content_value: Optional[str],
     semantic_value: Optional[str],
+    metadata_db: str,
+    metadata_schema: str,
 ) -> None:
     content_clean = (content_value or "").strip() or None
     semantic_clean = (semantic_value or "").strip() or None
     spinner = ui_strings.PROFILE_V2_COLUMN_EDIT_SPINNER.format(column=column_name)
     with st.spinner(spinner):
         try:
-            save_fn(
+            _call_helper_with_metadata(
+                save_fn,
                 session,
                 table_fqn,
                 column_name,
                 content_clean,
                 semantic_clean,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
             )
         except Exception as exc:  # pragma: no cover - UI feedback only
             st.error(
@@ -1020,7 +1057,34 @@ def _resolve_helpers(profiling_helpers: Optional[Any]):
     return profiling_helpers or profiling_service
 
 
-def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, Any]:
+def _call_helper_with_metadata(
+    fn: Any,
+    *args,
+    metadata_db: str,
+    metadata_schema: str,
+    **kwargs,
+):
+    try:
+        return fn(
+            *args,
+            metadata_db=metadata_db,
+            metadata_schema=metadata_schema,
+            **kwargs,
+        )
+    except TypeError as exc:
+        message = str(exc)
+        if "metadata_db" in message or "metadata_schema" in message:
+            return fn(*args, **kwargs)
+        raise
+
+
+def _run_table_profile(
+    helpers: Any,
+    session: Any,
+    table_fqn: str,
+    metadata_db: str,
+    metadata_schema: str,
+) -> Dict[str, Any]:
     run_fn = getattr(helpers, "run_profiling_v2", None)
     summary_fn = getattr(helpers, "fetch_table_summary", None)
     overview_fn = getattr(helpers, "get_overview_grid", None)
@@ -1034,7 +1098,13 @@ def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, 
 
     with st.spinner(ui_strings.PROFILE_V2_RUN_SPINNER.format(table=table_fqn)):
         try:
-            run_fn(session, table_fqn)
+            _call_helper_with_metadata(
+                run_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception as exc:  # pragma: no cover - UI feedback only
             logging.exception("profiling:run_failed")
             return {
@@ -1044,8 +1114,24 @@ def _run_table_profile(helpers: Any, session: Any, table_fqn: str) -> Dict[str, 
                 "err": ui_strings.PROFILE_V2_RUN_ERROR.format(error=str(exc)),
             }
 
-    summary = summary_fn(session, table_fqn) if callable(summary_fn) else None
-    overview = overview_fn(session, table_fqn) if callable(overview_fn) else pd.DataFrame()
+    summary = None
+    if callable(summary_fn):
+        summary = _call_helper_with_metadata(
+            summary_fn,
+            session,
+            table_fqn,
+            metadata_db=metadata_db,
+            metadata_schema=metadata_schema,
+        )
+    overview = pd.DataFrame()
+    if callable(overview_fn):
+        overview = _call_helper_with_metadata(
+            overview_fn,
+            session,
+            table_fqn,
+            metadata_db=metadata_db,
+            metadata_schema=metadata_schema,
+        )
     column_rows = (
         overview.to_dict("records") if isinstance(overview, pd.DataFrame) else []
     )
@@ -1086,6 +1172,8 @@ def _load_metadata(
     helpers: Any,
     session: Any,
     table_fqn: str,
+    metadata_db: str,
+    metadata_schema: str,
 ) -> _ProfilingData:
     overview_grid: pd.DataFrame = pd.DataFrame()
     suggested_checks: pd.DataFrame = pd.DataFrame()
@@ -1095,7 +1183,13 @@ def _load_metadata(
     overview_fn = getattr(helpers, "get_overview_grid", None)
     if callable(overview_fn):
         try:
-            overview_grid = overview_fn(session, table_fqn)
+            overview_grid = _call_helper_with_metadata(
+                overview_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception("profiling:overview_metadata_failed table=%s", table_fqn)
             overview_grid = pd.DataFrame()
@@ -1105,7 +1199,13 @@ def _load_metadata(
     classification_fn = effective_class_fn if callable(effective_class_fn) else column_class_fn
     if callable(classification_fn):
         try:
-            column_classification = classification_fn(session, table_fqn)
+            column_classification = _call_helper_with_metadata(
+                classification_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception(
                 "profiling:classification_metadata_failed table=%s", table_fqn
@@ -1115,7 +1215,13 @@ def _load_metadata(
     suggestions_fn = getattr(helpers, "get_suggested_checks", None)
     if callable(suggestions_fn):
         try:
-            suggested_checks = suggestions_fn(session, table_fqn)
+            suggested_checks = _call_helper_with_metadata(
+                suggestions_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception(
                 "profiling:suggestions_metadata_failed table=%s", table_fqn
@@ -1125,7 +1231,13 @@ def _load_metadata(
     run_history_fn = getattr(helpers, "fetch_recent_runs", None)
     if callable(run_history_fn):
         try:
-            recent_runs = run_history_fn(session, table_fqn)
+            recent_runs = _call_helper_with_metadata(
+                run_history_fn,
+                session,
+                table_fqn,
+                metadata_db=metadata_db,
+                metadata_schema=metadata_schema,
+            )
         except Exception:  # pragma: no cover - Snowflake/IO failures
             logging.exception("profiling:recent_runs_failed table=%s", table_fqn)
             recent_runs = pd.DataFrame()
@@ -1218,7 +1330,13 @@ def render_profile(
             st.session_state["busy_profiling"] = True
             st.session_state["freeze_view"] = True
             try:
-                res = _run_table_profile(helpers, session, fqn)
+                res = _run_table_profile(
+                    helpers,
+                    session,
+                    fqn,
+                    metadata_db,
+                    metadata_schema,
+                )
                 if res.get("ok"):
                     st.session_state["last_profile_summary"] = res.get("summary")
                     st.session_state["last_profile_rows"] = (
@@ -1254,7 +1372,13 @@ def render_profile(
                 ui_strings.PROFILE_V2_CLASSIFY_SPINNER.format(table=target_fqn)
             ):
                 try:
-                    classify_fn(session, target_fqn)
+                    _call_helper_with_metadata(
+                        classify_fn,
+                        session,
+                        target_fqn,
+                        metadata_db=metadata_db,
+                        metadata_schema=metadata_schema,
+                    )
                 except Exception as exc:
                     status_placeholder.error(
                         ui_strings.PROFILE_V2_CLASSIFY_ERROR.format(error=str(exc))
@@ -1275,8 +1399,17 @@ def render_profile(
             with st.spinner(
                 ui_strings.PROFILE_V2_SUGGESTIONS_SPINNER.format(table=target_fqn)
             ):
+                def _suggestions_runner(sess, fqn):
+                    return _call_helper_with_metadata(
+                        suggestions_fn,
+                        sess,
+                        fqn,
+                        metadata_db=metadata_db,
+                        metadata_schema=metadata_schema,
+                    )
+
                 _, error = _call_with_timeout(
-                    suggestions_fn,
+                    _suggestions_runner,
                     SUGGESTIONS_TIMEOUT_SECONDS,
                     session,
                     target_fqn,
@@ -1321,7 +1454,13 @@ def render_profile(
 
     with st.spinner(ui_strings.PROFILE_V2_LOAD_SPINNER):
         try:
-            data = _load_metadata(helpers, session, target_fqn)
+            data = _load_metadata(
+                helpers,
+                session,
+                target_fqn,
+                metadata_db,
+                metadata_schema,
+            )
         except Exception as exc:
             logging.exception(
                 "profiling:metadata_load_failed table=%s", target_fqn
@@ -1370,6 +1509,8 @@ def render_profile(
             helpers,
             session,
             st.session_state.get("profile_last_run_id"),
+            metadata_db,
+            metadata_schema,
         )
         _render_suggestion_sections(
             overview_grid,
@@ -1384,4 +1525,6 @@ def render_profile(
             target_fqn,
             helpers,
             session,
+            metadata_db,
+            metadata_schema,
         )


### PR DESCRIPTION
- qualify profiling metadata tables and procedures using the provided metadata namespace and expose the resolved names for debugging
- propagate metadata namespace through profiling UI helper calls with fallbacks and show resolved table info plus sample columns in the debug expander
- refresh tests and mirrored snapshots for the updated profiling behaviors

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942b5050a6c832493c72a4e3d23d5dc)