### PR TITLE
PROF-REMOVE-LEGACY-GRID

### DIFF
--- a/snapshots/streamlit_app.p
+++ b/snapshots/streamlit_app.p
@@ -30,6 +30,7 @@ logging.getLogger("snowflake").setLevel(logging.WARNING)
 from typing import Dict, List, Optional
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "monitor_v3", "docs", "rules"}
+LEGACY_PROFILING_PAGES = {"profiling", "profiling_legacy", "profile_legacy", "profiling_grid"}
 
 
 if st.session_state["_rerun_count"] == 1:
@@ -173,6 +174,10 @@ def _normalize_bool(value) -> bool:
     return text in {"TRUE", "T", "YES", "Y", "1"}
 
 
+def _is_legacy_profiling_page(value: Optional[str]) -> bool:
+    return isinstance(value, str) and value.lower() in LEGACY_PROFILING_PAGES
+
+
 def _get_page_from_query_params() -> Optional[str]:
     candidate: Optional[str] = None
     try:
@@ -186,6 +191,8 @@ def _get_page_from_query_params() -> Optional[str]:
         candidate = value
     if candidate:
         candidate_lower = candidate.lower()
+        if _is_legacy_profiling_page(candidate_lower):
+            return candidate_lower
         if candidate_lower in ALLOWED_PAGES:
             return candidate_lower
     return None
@@ -492,6 +499,26 @@ state = get_state()
 st.session_state.setdefault("editor_target_fqn", None)
 query_page = _get_page_from_query_params()
 last_query_page = st.session_state.get("_last_query_page")
+legacy_page_candidate = next(
+    (
+        value
+        for value in (
+            query_page,
+            st.session_state.get("active_view"),
+            st.session_state.get("page"),
+            last_query_page,
+        )
+        if _is_legacy_profiling_page(value)
+    ),
+    None,
+)
+if legacy_page_candidate:
+    st.warning("Legacy profiling path is removed; update stale session state.")
+    set_view("profile")
+    query_page = "profile"
+    last_query_page = "profile"
+    st.session_state["page"] = "profile"
+    st.session_state["_last_query_page"] = "profile"
 if query_page and query_page != last_query_page:
     st.session_state["_last_query_page"] = query_page
     if query_page != st.session_state.get("active_view"):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -30,6 +30,7 @@ logging.getLogger("snowflake").setLevel(logging.WARNING)
 from typing import Dict, List, Optional
 
 ALLOWED_PAGES = {"home", "cfg", "profile", "monitor", "monitor_v3", "docs", "rules"}
+LEGACY_PROFILING_PAGES = {"profiling", "profiling_legacy", "profile_legacy", "profiling_grid"}
 
 
 if st.session_state["_rerun_count"] == 1:
@@ -173,6 +174,10 @@ def _normalize_bool(value) -> bool:
     return text in {"TRUE", "T", "YES", "Y", "1"}
 
 
+def _is_legacy_profiling_page(value: Optional[str]) -> bool:
+    return isinstance(value, str) and value.lower() in LEGACY_PROFILING_PAGES
+
+
 def _get_page_from_query_params() -> Optional[str]:
     candidate: Optional[str] = None
     try:
@@ -186,6 +191,8 @@ def _get_page_from_query_params() -> Optional[str]:
         candidate = value
     if candidate:
         candidate_lower = candidate.lower()
+        if _is_legacy_profiling_page(candidate_lower):
+            return candidate_lower
         if candidate_lower in ALLOWED_PAGES:
             return candidate_lower
     return None
@@ -492,6 +499,26 @@ state = get_state()
 st.session_state.setdefault("editor_target_fqn", None)
 query_page = _get_page_from_query_params()
 last_query_page = st.session_state.get("_last_query_page")
+legacy_page_candidate = next(
+    (
+        value
+        for value in (
+            query_page,
+            st.session_state.get("active_view"),
+            st.session_state.get("page"),
+            last_query_page,
+        )
+        if _is_legacy_profiling_page(value)
+    ),
+    None,
+)
+if legacy_page_candidate:
+    st.warning("Legacy profiling path is removed; update stale session state.")
+    set_view("profile")
+    query_page = "profile"
+    last_query_page = "profile"
+    st.session_state["page"] = "profile"
+    st.session_state["_last_query_page"] = "profile"
 if query_page and query_page != last_query_page:
     st.session_state["_last_query_page"] = query_page
     if query_page != st.session_state.get("active_view"):


### PR DESCRIPTION
- guard legacy profiling page keys and redirect sessions to the v2 listing route with a warning
- update snapshot mirror after routing changes

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b84df9f88324aab8787ecbdaae26)