### PR TITLE
PROF-SUG-NO-GATE-1 — Always render columns; allow generic rules; suggestions optional

### DIFF
--- a/services/profiling_v2.py
+++ b/services/profiling_v2.py
@@ -792,6 +792,8 @@ def get_overview_grid(
         "rationale",
         "confidence",
         "has_suggestion",
+        "suggested_rule_count",
+        "suggested_rules",
     ]
 
     normalized = _normalize_table_fqn(table_fqn)
@@ -842,20 +844,23 @@ def get_overview_grid(
     classification = _normalize_dataframe_columns(
         _fetch_dataframe(session, classification_cte, params=[normalized])
     )
+    suggestions = _normalize_dataframe_columns(
+        get_suggested_checks(session, normalized, metadata_db, metadata_schema)
+    )
     feature_row_count = len(features)
     classification_row_count = len(classification)
+    suggestion_row_count = len(suggestions)
     feature_sample = (
         features["COLUMN_NAME"].dropna().astype(str).head(3).tolist()
         if "COLUMN_NAME" in features.columns
         else []
     )
-    suggestions = _normalize_dataframe_columns(
-        get_suggested_checks(session, normalized, metadata_db, metadata_schema)
-    )
 
     debug_counts = {
         "feature_row_count": feature_row_count,
-        "suggestion_row_count": len(suggestions),
+        "features_df_rows": feature_row_count,
+        "suggestion_row_count": suggestion_row_count,
+        "suggestions_df_rows": suggestion_row_count,
         "classification_row_count": classification_row_count,
         "columns_rendered": 0,
         "metadata_db": tables["metadata_db"],
@@ -896,6 +901,8 @@ def get_overview_grid(
                 "severity": _stringify(latest_row.get("SEVERITY")) or "-",
                 "rationale": _stringify(latest_row.get("RATIONALE")) or "-",
                 "has_suggestion": bool(len(group)),
+                "suggested_rule_count": len(group),
+                "suggested_rules": group.to_dict("records"),
             }
 
     latest_classifications = _latest_classifications(classification)
@@ -908,7 +915,9 @@ def get_overview_grid(
 
         overview_rows.append(
             {
-                "include_in_dq_config": bool(column_suggestions.get("has_suggestion", False)),
+                "include_in_dq_config": bool(
+                    column_suggestions.get("has_suggestion", False)
+                ),
                 "column_name": column_name,
                 "data_type": _stringify(row.get("DATA_TYPE")),
                 "null_info": _format_count_ratio(
@@ -932,6 +941,10 @@ def get_overview_grid(
                 ),
                 "confidence": norm_conf(classification_row.get("CONFIDENCE")),
                 "has_suggestion": bool(column_suggestions.get("has_suggestion", False)),
+                "suggested_rule_count": int(
+                    column_suggestions.get("suggested_rule_count", 0) or 0
+                ),
+                "suggested_rules": column_suggestions.get("suggested_rules", []),
             }
         )
 
@@ -939,6 +952,7 @@ def get_overview_grid(
     rendered_rows = len(overview_rows)
     debug_counts["columns_rendered"] = rendered_rows
     debug_counts["grid_row_count"] = rendered_rows
+    debug_counts["grid_df_rows"] = rendered_rows
     overview.attrs["dq_debug_counts"] = debug_counts
     return overview
 

--- a/snapshots/services/profiling_v2.p
+++ b/snapshots/services/profiling_v2.p
@@ -792,6 +792,8 @@ def get_overview_grid(
         "rationale",
         "confidence",
         "has_suggestion",
+        "suggested_rule_count",
+        "suggested_rules",
     ]
 
     normalized = _normalize_table_fqn(table_fqn)
@@ -842,20 +844,23 @@ def get_overview_grid(
     classification = _normalize_dataframe_columns(
         _fetch_dataframe(session, classification_cte, params=[normalized])
     )
+    suggestions = _normalize_dataframe_columns(
+        get_suggested_checks(session, normalized, metadata_db, metadata_schema)
+    )
     feature_row_count = len(features)
     classification_row_count = len(classification)
+    suggestion_row_count = len(suggestions)
     feature_sample = (
         features["COLUMN_NAME"].dropna().astype(str).head(3).tolist()
         if "COLUMN_NAME" in features.columns
         else []
     )
-    suggestions = _normalize_dataframe_columns(
-        get_suggested_checks(session, normalized, metadata_db, metadata_schema)
-    )
 
     debug_counts = {
         "feature_row_count": feature_row_count,
-        "suggestion_row_count": len(suggestions),
+        "features_df_rows": feature_row_count,
+        "suggestion_row_count": suggestion_row_count,
+        "suggestions_df_rows": suggestion_row_count,
         "classification_row_count": classification_row_count,
         "columns_rendered": 0,
         "metadata_db": tables["metadata_db"],
@@ -896,6 +901,8 @@ def get_overview_grid(
                 "severity": _stringify(latest_row.get("SEVERITY")) or "-",
                 "rationale": _stringify(latest_row.get("RATIONALE")) or "-",
                 "has_suggestion": bool(len(group)),
+                "suggested_rule_count": len(group),
+                "suggested_rules": group.to_dict("records"),
             }
 
     latest_classifications = _latest_classifications(classification)
@@ -908,7 +915,9 @@ def get_overview_grid(
 
         overview_rows.append(
             {
-                "include_in_dq_config": bool(column_suggestions.get("has_suggestion", False)),
+                "include_in_dq_config": bool(
+                    column_suggestions.get("has_suggestion", False)
+                ),
                 "column_name": column_name,
                 "data_type": _stringify(row.get("DATA_TYPE")),
                 "null_info": _format_count_ratio(
@@ -932,6 +941,10 @@ def get_overview_grid(
                 ),
                 "confidence": norm_conf(classification_row.get("CONFIDENCE")),
                 "has_suggestion": bool(column_suggestions.get("has_suggestion", False)),
+                "suggested_rule_count": int(
+                    column_suggestions.get("suggested_rule_count", 0) or 0
+                ),
+                "suggested_rules": column_suggestions.get("suggested_rules", []),
             }
         )
 
@@ -939,6 +952,7 @@ def get_overview_grid(
     rendered_rows = len(overview_rows)
     debug_counts["columns_rendered"] = rendered_rows
     debug_counts["grid_row_count"] = rendered_rows
+    debug_counts["grid_df_rows"] = rendered_rows
     overview.attrs["dq_debug_counts"] = debug_counts
     return overview
 

--- a/snapshots/tests/test_profile_view.p
+++ b/snapshots/tests/test_profile_view.p
@@ -34,6 +34,25 @@ def test_prepare_overview_frame_preserves_rule_columns():
     assert prepared.loc["orders_total", "has_suggestion"] is True
 
 
+def test_prepare_overview_frame_allows_manual_includes_without_suggestions():
+    overview = pd.DataFrame(
+        [
+            {
+                "column_name": "email",
+                "data_type": "STRING",
+                "has_suggestion": False,
+                "include_in_dq_config": True,
+            }
+        ]
+    )
+
+    prepared = profile_view._prepare_overview_frame(overview)
+
+    assert prepared.loc["email", "include_in_dq_config"] is True
+    assert prepared.loc["email", "suggested_rule_count"] == 0
+    assert prepared.loc["email", "suggested_rules"] == []
+
+
 def test_overview_grid_widget_key_changes_with_nonce():
     key_first = profile_view._overview_grid_widget_key(
         "DB.SCHEMA.TABLE",
@@ -63,5 +82,4 @@ def test_call_with_timeout_handles_timeout():
 
     assert result is None
     assert isinstance(error, TimeoutError)
-
 

--- a/snapshots/views/profile_view.p
+++ b/snapshots/views/profile_view.p
@@ -38,6 +38,8 @@ _OVERVIEW_INTERNAL_COLUMNS = [
     "rationale",
     "confidence",
     "has_suggestion",
+    "suggested_rule_count",
+    "suggested_rules",
 ]
 
 
@@ -560,15 +562,26 @@ def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
 
     working["column_name"] = working["column_name"].astype(str)
     working["has_suggestion"] = working["has_suggestion"].fillna(False).apply(bool)
+    working["suggested_rule_count"] = (
+        pd.to_numeric(working["suggested_rule_count"], errors="coerce")
+        .fillna(0)
+        .astype(int)
+    )
+    working["suggested_rules"] = working["suggested_rules"].apply(lambda value: value or [])
     working["include_in_dq_config"] = working["include_in_dq_config"].apply(
         _normalize_checkbox_value
     )
-    working.loc[~working["has_suggestion"], "include_in_dq_config"] = False
     working = working.set_index("column_name", drop=False)
 
     ordered = working[_OVERVIEW_INTERNAL_COLUMNS]
     ordered.attrs = working.attrs
     return ordered
+
+
+def _overview_grid_widget_key(table_fqn: str, nonce: int = 0) -> str:
+    normalized = (table_fqn or "").replace('"', "").replace(".", "_")
+    normalized = normalized or "table"
+    return f"profile_overview_grid_{normalized}_{nonce}"
 
 
 def _default_config_name(table_fqn: str) -> str:
@@ -724,9 +737,17 @@ def _render_overview_debug(
     classification_count = debug_counts.get("classification_row_count")
     rendered_count = debug_counts.get("columns_rendered")
     suggestion_count = debug_counts.get("suggestion_row_count")
-    grid_count = debug_counts.get("grid_row_count") or rendered_count
+    features_df_rows = debug_counts.get("features_df_rows", feature_count)
+    suggestions_df_rows = debug_counts.get("suggestions_df_rows", suggestion_count)
+    grid_df_rows = (
+        debug_counts.get("grid_df_rows")
+        or debug_counts.get("grid_row_count")
+        or rendered_count
+    )
     if rendered_count is None and isinstance(overview, pd.DataFrame):
         rendered_count = len(overview)
+    if grid_df_rows is None and isinstance(overview, pd.DataFrame):
+        grid_df_rows = len(overview)
 
     features_table_fqn = debug_counts.get("features_table_fqn") or (
         f"{resolved_db}.{resolved_schema}.DQ_COLUMN_FEATURES"
@@ -741,20 +762,24 @@ def _render_overview_debug(
         if "column_name" in overview.columns:
             feature_sample_columns = (
                 overview["column_name"].dropna().astype(str).head(3).tolist()
-    )
+            )
 
     with st.expander("Profiling debug", expanded=False):
         st.caption("Profiling feature source counts")
         st.text(f"feature_row_count: {feature_count if feature_count is not None else 0}")
+        st.text(f"features_df_rows: {features_df_rows if features_df_rows is not None else 0}")
         st.text(
             "classification_row_count: "
             f"{classification_count if classification_count is not None else 0}"
         )
-        st.text(f"columns_rendered: {rendered_count if rendered_count is not None else 0}")
-        st.text(f"feature_df_rows: {grid_count if grid_count is not None else 0}")
         st.text(
-            f"suggestions_df_rows: {suggestion_count if suggestion_count is not None else 0}"
+            f"suggestion_row_count: {suggestion_count if suggestion_count is not None else 0}"
         )
+        st.text(
+            f"suggestions_df_rows: {suggestions_df_rows if suggestions_df_rows is not None else 0}"
+        )
+        st.text(f"columns_rendered: {rendered_count if rendered_count is not None else 0}")
+        st.text(f"grid_df_rows: {grid_df_rows if grid_df_rows is not None else 0}")
         st.caption("Resolved metadata sources")
         st.text(f"metadata_db: {resolved_db}")
         st.text(f"metadata_schema: {resolved_schema}")
@@ -771,6 +796,7 @@ def _normalize_overview_display(overview: pd.DataFrame) -> pd.DataFrame:
         return prepared
 
     display_columns = [
+        "include_in_dq_config",
         "column_name",
         "data_type",
         "null_info",
@@ -783,30 +809,16 @@ def _normalize_overview_display(overview: pd.DataFrame) -> pd.DataFrame:
         "severity",
         "rationale",
         "confidence",
+        "suggested_rule_count",
+        "suggested_rules",
     ]
     for column in display_columns:
         if column not in prepared.columns:
             prepared[column] = None
 
-    display = prepared.reset_index(drop=True)[display_columns]
-    display = display.rename(
-        columns={
-            "column_name": "Column",
-            "data_type": "Type",
-            "null_info": "Nulls",
-            "distinct_info": "Distinct",
-            "min_value": "Min",
-            "max_value": "Max",
-            "length_info": "Length",
-            "rule_id": "Rule ID",
-            "check_type": "Check type",
-            "severity": "Severity",
-            "rationale": "Rationale",
-            "confidence": "Confidence",
-        }
-    )
-    display.attrs = prepared.attrs
-    return display
+    ordered = prepared.reset_index(drop=True)[display_columns]
+    ordered.attrs = prepared.attrs
+    return ordered
 
 
 def _render_overview_page(
@@ -823,9 +835,50 @@ def _render_overview_page(
         _render_overview_debug(normalized, metadata_db, metadata_schema, table_fqn)
         return normalized
 
-    st.dataframe(normalized, use_container_width=True)
-    _render_overview_debug(normalized, metadata_db, metadata_schema, table_fqn)
-    return normalized
+    grid_key = _overview_grid_widget_key(
+        table_fqn,
+        nonce=st.session_state.get("profile_data_nonce", 0),
+    )
+    column_config = {
+        "include_in_dq_config": st.column_config.CheckboxColumn(
+            "Include",
+            help="Include this column when suggesting DQ config",
+        ),
+        "column_name": "Column",
+        "data_type": "Type",
+        "null_info": "Nulls",
+        "distinct_info": "Distinct",
+        "min_value": "Min",
+        "max_value": "Max",
+        "length_info": "Length",
+        "rule_id": "Rule ID",
+        "check_type": "Check type",
+        "severity": "Severity",
+        "rationale": "Rationale",
+        "confidence": "Confidence",
+        "suggested_rule_count": st.column_config.NumberColumn(
+            "Suggested rules",
+            format="%d",
+            help="Number of suggested rules found for this column",
+        ),
+        "suggested_rules": st.column_config.Column(
+            "Suggested rules",
+            help="Raw suggested rules for this column",
+            width="medium",
+        ),
+    }
+    disabled_columns = [col for col in normalized.columns if col != "include_in_dq_config"]
+    edited = st.data_editor(
+        normalized,
+        column_config=column_config,
+        disabled=disabled_columns,
+        hide_index=True,
+        use_container_width=True,
+        key=grid_key,
+    )
+    edited.attrs["dq_debug_counts"] = normalized.attrs.get("dq_debug_counts", {})
+    _render_overview_debug(edited, metadata_db, metadata_schema, table_fqn)
+    return edited
 
 
 def _suggestion_selection_key(

--- a/sql/DQ_APPLY_RULES.sql
+++ b/sql/DQ_APPLY_RULES.sql
@@ -68,16 +68,29 @@ BEGIN
             f.DISTINCT_COUNT,
             f.MIN_VALUE,
             f.MAX_VALUE,
-            COALESCE(c.CONTENT_TYPE, '') AS CONTENT_TYPE
+            COALESCE(c.CONTENT_TYPE, '') AS CONTENT_TYPE,
+            CASE
+                WHEN REGEXP_LIKE(f.DATA_TYPE, 'NUMBER|DECIMAL|INT|FLOAT|DOUBLE|REAL') THEN 'NUMERIC'
+                WHEN REGEXP_LIKE(f.DATA_TYPE, 'DATE|TIME|TIMESTAMP') THEN 'DATE'
+                WHEN REGEXP_LIKE(f.DATA_TYPE, 'CHAR|TEXT|STRING|VARCHAR') THEN 'STRING'
+                ELSE 'ANY'
+            END AS DATA_TYPE_FAMILY,
+            IFF(
+                NULLIF(c.CONTENT_TYPE, '') IS NULL,
+                ARRAY_CONSTRUCT(),
+                ARRAY_CONSTRUCT(UPPER(c.CONTENT_TYPE))
+            ) AS CLASS_LABELS
         FROM features f
         LEFT JOIN classification c
             ON f.TABLE_FQN = c.TABLE_FQN
            AND f.COLUMN_NAME = c.COLUMN_NAME
     ),
     active_rules AS (
-        SELECT RULE_ID, CHECK_TYPE, DEFAULT_SEVERITY
+        SELECT RULE_ID, CHECK_TYPE, DEFAULT_SEVERITY, DATA_TYPE_FAMILY, APPLICABILITY_TAGS
         FROM ZEUS_ANALYTICS_SIMU.DISCOVERY.DQ_RULE_LIBRARY
-        WHERE ACTIVE = True
+        WHERE COALESCE(ENABLED, TRUE) = TRUE
+          AND COALESCE(DEFAULT_SUGGEST, TRUE) = TRUE
+          AND COALESCE(SCOPE, 'COLUMN') = 'COLUMN'
     )
     SELECT
         ctx.TABLE_FQN,
@@ -90,6 +103,15 @@ BEGIN
     FROM column_context ctx
     JOIN active_rules rule_not_null
         ON rule_not_null.RULE_ID = 'NOT_NULL_BASIC'
+       AND (
+            rule_not_null.DATA_TYPE_FAMILY IN ('ANY', ctx.DATA_TYPE_FAMILY)
+            OR rule_not_null.DATA_TYPE_FAMILY IS NULL
+        )
+       AND (
+            rule_not_null.APPLICABILITY_TAGS IS NULL
+            OR ARRAY_SIZE(rule_not_null.APPLICABILITY_TAGS) = 0
+            OR ARRAY_SIZE(ARRAY_INTERSECTION(rule_not_null.APPLICABILITY_TAGS, ctx.CLASS_LABELS)) > 0
+        )
     WHERE ctx.NULL_RATIO < 0.1
 
     UNION ALL
@@ -105,6 +127,15 @@ BEGIN
     FROM column_context ctx
     JOIN active_rules rule_range
         ON rule_range.RULE_ID = 'RANGE_NUMERIC'
+       AND (
+            rule_range.DATA_TYPE_FAMILY IN ('ANY', ctx.DATA_TYPE_FAMILY)
+            OR rule_range.DATA_TYPE_FAMILY IS NULL
+        )
+       AND (
+            rule_range.APPLICABILITY_TAGS IS NULL
+            OR ARRAY_SIZE(rule_range.APPLICABILITY_TAGS) = 0
+            OR ARRAY_SIZE(ARRAY_INTERSECTION(rule_range.APPLICABILITY_TAGS, ctx.CLASS_LABELS)) > 0
+        )
     WHERE REGEXP_LIKE(ctx.DATA_TYPE, '^NUMBER')
 
     UNION ALL
@@ -120,6 +151,15 @@ BEGIN
     FROM column_context ctx
     JOIN active_rules rule_enum
         ON rule_enum.RULE_ID = 'ENUM_SMALL_CARDINALITY'
+       AND (
+            rule_enum.DATA_TYPE_FAMILY IN ('ANY', ctx.DATA_TYPE_FAMILY)
+            OR rule_enum.DATA_TYPE_FAMILY IS NULL
+        )
+       AND (
+            rule_enum.APPLICABILITY_TAGS IS NULL
+            OR ARRAY_SIZE(rule_enum.APPLICABILITY_TAGS) = 0
+            OR ARRAY_SIZE(ARRAY_INTERSECTION(rule_enum.APPLICABILITY_TAGS, ctx.CLASS_LABELS)) > 0
+        )
     WHERE ctx.DISTINCT_COUNT <= 20
 
     UNION ALL
@@ -135,6 +175,15 @@ BEGIN
     FROM column_context ctx
     JOIN active_rules rule_date
         ON rule_date.RULE_ID = 'NOT_FUTURE_DATE'
+       AND (
+            rule_date.DATA_TYPE_FAMILY IN ('ANY', ctx.DATA_TYPE_FAMILY)
+            OR rule_date.DATA_TYPE_FAMILY IS NULL
+        )
+       AND (
+            rule_date.APPLICABILITY_TAGS IS NULL
+            OR ARRAY_SIZE(rule_date.APPLICABILITY_TAGS) = 0
+            OR ARRAY_SIZE(ARRAY_INTERSECTION(rule_date.APPLICABILITY_TAGS, ctx.CLASS_LABELS)) > 0
+        )
     WHERE ctx.CONTENT_TYPE = 'date'
 
     UNION ALL
@@ -150,6 +199,15 @@ BEGIN
     FROM column_context ctx
     JOIN active_rules rule_pattern
         ON rule_pattern.RULE_ID = 'PATTERN_BASIC'
+       AND (
+            rule_pattern.DATA_TYPE_FAMILY IN ('ANY', ctx.DATA_TYPE_FAMILY)
+            OR rule_pattern.DATA_TYPE_FAMILY IS NULL
+        )
+       AND (
+            rule_pattern.APPLICABILITY_TAGS IS NULL
+            OR ARRAY_SIZE(rule_pattern.APPLICABILITY_TAGS) = 0
+            OR ARRAY_SIZE(ARRAY_INTERSECTION(rule_pattern.APPLICABILITY_TAGS, ctx.CLASS_LABELS)) > 0
+        )
     WHERE ctx.CONTENT_TYPE ILIKE '%code%'
        OR ctx.CONTENT_TYPE ILIKE '%identifier%';
     v_inserted := SQLROWCOUNT;

--- a/tests/test_profile_view.py
+++ b/tests/test_profile_view.py
@@ -34,6 +34,25 @@ def test_prepare_overview_frame_preserves_rule_columns():
     assert prepared.loc["orders_total", "has_suggestion"] is True
 
 
+def test_prepare_overview_frame_allows_manual_includes_without_suggestions():
+    overview = pd.DataFrame(
+        [
+            {
+                "column_name": "email",
+                "data_type": "STRING",
+                "has_suggestion": False,
+                "include_in_dq_config": True,
+            }
+        ]
+    )
+
+    prepared = profile_view._prepare_overview_frame(overview)
+
+    assert prepared.loc["email", "include_in_dq_config"] is True
+    assert prepared.loc["email", "suggested_rule_count"] == 0
+    assert prepared.loc["email", "suggested_rules"] == []
+
+
 def test_overview_grid_widget_key_changes_with_nonce():
     key_first = profile_view._overview_grid_widget_key(
         "DB.SCHEMA.TABLE",
@@ -63,5 +82,4 @@ def test_call_with_timeout_handles_timeout():
 
     assert result is None
     assert isinstance(error, TimeoutError)
-
 

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -38,6 +38,8 @@ _OVERVIEW_INTERNAL_COLUMNS = [
     "rationale",
     "confidence",
     "has_suggestion",
+    "suggested_rule_count",
+    "suggested_rules",
 ]
 
 
@@ -560,15 +562,26 @@ def _prepare_overview_frame(overview: pd.DataFrame) -> pd.DataFrame:
 
     working["column_name"] = working["column_name"].astype(str)
     working["has_suggestion"] = working["has_suggestion"].fillna(False).apply(bool)
+    working["suggested_rule_count"] = (
+        pd.to_numeric(working["suggested_rule_count"], errors="coerce")
+        .fillna(0)
+        .astype(int)
+    )
+    working["suggested_rules"] = working["suggested_rules"].apply(lambda value: value or [])
     working["include_in_dq_config"] = working["include_in_dq_config"].apply(
         _normalize_checkbox_value
     )
-    working.loc[~working["has_suggestion"], "include_in_dq_config"] = False
     working = working.set_index("column_name", drop=False)
 
     ordered = working[_OVERVIEW_INTERNAL_COLUMNS]
     ordered.attrs = working.attrs
     return ordered
+
+
+def _overview_grid_widget_key(table_fqn: str, nonce: int = 0) -> str:
+    normalized = (table_fqn or "").replace('"', "").replace(".", "_")
+    normalized = normalized or "table"
+    return f"profile_overview_grid_{normalized}_{nonce}"
 
 
 def _default_config_name(table_fqn: str) -> str:
@@ -724,9 +737,17 @@ def _render_overview_debug(
     classification_count = debug_counts.get("classification_row_count")
     rendered_count = debug_counts.get("columns_rendered")
     suggestion_count = debug_counts.get("suggestion_row_count")
-    grid_count = debug_counts.get("grid_row_count") or rendered_count
+    features_df_rows = debug_counts.get("features_df_rows", feature_count)
+    suggestions_df_rows = debug_counts.get("suggestions_df_rows", suggestion_count)
+    grid_df_rows = (
+        debug_counts.get("grid_df_rows")
+        or debug_counts.get("grid_row_count")
+        or rendered_count
+    )
     if rendered_count is None and isinstance(overview, pd.DataFrame):
         rendered_count = len(overview)
+    if grid_df_rows is None and isinstance(overview, pd.DataFrame):
+        grid_df_rows = len(overview)
 
     features_table_fqn = debug_counts.get("features_table_fqn") or (
         f"{resolved_db}.{resolved_schema}.DQ_COLUMN_FEATURES"
@@ -741,20 +762,24 @@ def _render_overview_debug(
         if "column_name" in overview.columns:
             feature_sample_columns = (
                 overview["column_name"].dropna().astype(str).head(3).tolist()
-    )
+            )
 
     with st.expander("Profiling debug", expanded=False):
         st.caption("Profiling feature source counts")
         st.text(f"feature_row_count: {feature_count if feature_count is not None else 0}")
+        st.text(f"features_df_rows: {features_df_rows if features_df_rows is not None else 0}")
         st.text(
             "classification_row_count: "
             f"{classification_count if classification_count is not None else 0}"
         )
-        st.text(f"columns_rendered: {rendered_count if rendered_count is not None else 0}")
-        st.text(f"feature_df_rows: {grid_count if grid_count is not None else 0}")
         st.text(
-            f"suggestions_df_rows: {suggestion_count if suggestion_count is not None else 0}"
+            f"suggestion_row_count: {suggestion_count if suggestion_count is not None else 0}"
         )
+        st.text(
+            f"suggestions_df_rows: {suggestions_df_rows if suggestions_df_rows is not None else 0}"
+        )
+        st.text(f"columns_rendered: {rendered_count if rendered_count is not None else 0}")
+        st.text(f"grid_df_rows: {grid_df_rows if grid_df_rows is not None else 0}")
         st.caption("Resolved metadata sources")
         st.text(f"metadata_db: {resolved_db}")
         st.text(f"metadata_schema: {resolved_schema}")
@@ -771,6 +796,7 @@ def _normalize_overview_display(overview: pd.DataFrame) -> pd.DataFrame:
         return prepared
 
     display_columns = [
+        "include_in_dq_config",
         "column_name",
         "data_type",
         "null_info",
@@ -783,30 +809,16 @@ def _normalize_overview_display(overview: pd.DataFrame) -> pd.DataFrame:
         "severity",
         "rationale",
         "confidence",
+        "suggested_rule_count",
+        "suggested_rules",
     ]
     for column in display_columns:
         if column not in prepared.columns:
             prepared[column] = None
 
-    display = prepared.reset_index(drop=True)[display_columns]
-    display = display.rename(
-        columns={
-            "column_name": "Column",
-            "data_type": "Type",
-            "null_info": "Nulls",
-            "distinct_info": "Distinct",
-            "min_value": "Min",
-            "max_value": "Max",
-            "length_info": "Length",
-            "rule_id": "Rule ID",
-            "check_type": "Check type",
-            "severity": "Severity",
-            "rationale": "Rationale",
-            "confidence": "Confidence",
-        }
-    )
-    display.attrs = prepared.attrs
-    return display
+    ordered = prepared.reset_index(drop=True)[display_columns]
+    ordered.attrs = prepared.attrs
+    return ordered
 
 
 def _render_overview_page(
@@ -823,9 +835,50 @@ def _render_overview_page(
         _render_overview_debug(normalized, metadata_db, metadata_schema, table_fqn)
         return normalized
 
-    st.dataframe(normalized, use_container_width=True)
-    _render_overview_debug(normalized, metadata_db, metadata_schema, table_fqn)
-    return normalized
+    grid_key = _overview_grid_widget_key(
+        table_fqn,
+        nonce=st.session_state.get("profile_data_nonce", 0),
+    )
+    column_config = {
+        "include_in_dq_config": st.column_config.CheckboxColumn(
+            "Include",
+            help="Include this column when suggesting DQ config",
+        ),
+        "column_name": "Column",
+        "data_type": "Type",
+        "null_info": "Nulls",
+        "distinct_info": "Distinct",
+        "min_value": "Min",
+        "max_value": "Max",
+        "length_info": "Length",
+        "rule_id": "Rule ID",
+        "check_type": "Check type",
+        "severity": "Severity",
+        "rationale": "Rationale",
+        "confidence": "Confidence",
+        "suggested_rule_count": st.column_config.NumberColumn(
+            "Suggested rules",
+            format="%d",
+            help="Number of suggested rules found for this column",
+        ),
+        "suggested_rules": st.column_config.Column(
+            "Suggested rules",
+            help="Raw suggested rules for this column",
+            width="medium",
+        ),
+    }
+    disabled_columns = [col for col in normalized.columns if col != "include_in_dq_config"]
+    edited = st.data_editor(
+        normalized,
+        column_config=column_config,
+        disabled=disabled_columns,
+        hide_index=True,
+        use_container_width=True,
+        key=grid_key,
+    )
+    edited.attrs["dq_debug_counts"] = normalized.attrs.get("dq_debug_counts", {})
+    _render_overview_debug(edited, metadata_db, metadata_schema, table_fqn)
+    return edited
 
 
 def _suggestion_selection_key(


### PR DESCRIPTION
- ensure the profiling overview grid always renders feature rows with editable include checkboxes and suggestion counts
- carry suggestion metadata and debug row totals through overview payloads and refreshed snapshots
- loosen DQ_APPLY_RULES applicability gating so generic rules remain eligible while keeping the existing filters
- add coverage for manual include selections in the profiling overview preparation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943fbcc36a48324a32aaac28f8594b2)